### PR TITLE
Test command line options

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,13 +128,15 @@ build-job:
     - PLATFORMS=linux/amd64
     - THREADS=8
     - DOCKER_TAG=ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}
+    # Before the build, make sure linting passes to fail fast.
+    - make lint
     - make version
     # Connect so we can upload our images
     - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
     # Note that A LOCAL CACHE CAN ONLY HOLD ONE TAG/TARGET AT A TIME!
     # And Quay can't use mode=max registry caching to cache the intermediate targets with the final image, just inline caching.
     # So we have to do the Complicated Cache Shuffle.
-    - echo " Build base image from branch and mainline base caches to local cache"
+    - echo "Build base image from branch and mainline base caches to local cache"
     - docker buildx build --cache-from type=registry,ref=${CI_REPO}:${MAINLINE_CACHE_TAG}-base --cache-from type=registry,ref=${CI_REPO}:${CACHE_TAG}-base --cache-from type=local,src=${HOME}/docker-cache/base --cache-to type=local,dest=${HOME}/docker-cache/base --platform="${PLATFORMS}" --build-arg THREADS=${THREADS} --target base -t ${CI_REPO}:${CACHE_TAG}-base -f Dockerfile .
     - echo "Push base image from local cache to registry cache for branch."
     - docker buildx build --cache-from type=local,src=${HOME}/docker-cache/base --cache-to type=inline --platform="${PLATFORMS}" --build-arg THREADS=${THREADS} --target base -t ${CI_REPO}:${CACHE_TAG}-base -f Dockerfile --push .

--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ DEPS += $(INC_DIR)/BooPHF.h
 DEPS += $(INC_DIR)/mio/mmap.hpp
 DEPS += $(INC_DIR)/atomic_queue.h
 
-.PHONY: clean clean-tests get-deps deps test set-path objs static static-docker docs man .pre-build version
+.PHONY: clean clean-tests get-deps deps lint test set-path objs static static-docker docs man .pre-build version
 
 # Aggregate all libvg deps, and exe deps other than libvg
 LIBVG_DEPS = $(OBJ) $(ALGORITHMS_OBJ) $(IO_OBJ) $(DEP_OBJ) $(DEPS)
@@ -528,7 +528,10 @@ get-deps:
 # And we have submodule deps to build
 deps: $(DEPS)
 
-test: $(BIN_DIR)/$(EXE) $(LIB_DIR)/libvg.a test/build_graph $(BIN_DIR)/shuf $(BIN_DIR)/vcf2tsv $(FASTAHACK_DIR)/fastahack $(BIN_DIR)/rapper
+lint: $(SRC_DIR)/*.cpp $(SRC_DIR)/*.hpp $(ALGORITHMS_SRC_DIR)/*.cpp $(ALGORITHMS_SRC_DIR)/*.hpp $(SUBCOMMAND_SRC_DIR)/*.cpp $(SUBCOMMAND_SRC_DIR)/*.hpp $(UNITTEST_SRC_DIR)/*.cpp $(UNITTEST_SRC_DIR)/*.hpp $(UNITTEST_SUPPORT_SRC_DIR)/*.cpp
+	scripts/check_options.py 1>&2
+
+test: lint $(BIN_DIR)/$(EXE) $(LIB_DIR)/libvg.a test/build_graph $(BIN_DIR)/shuf $(BIN_DIR)/vcf2tsv $(FASTAHACK_DIR)/fastahack $(BIN_DIR)/rapper
 	cd test && prove -v t
 	# Hide the compiler configuration from the doc tests, so that the ones that
 	# build code can't pick up libraries out of the vg build itself.

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -333,6 +333,17 @@ def check_file(filepath: str) -> list:
 
     all_longform = set(help_opts) | set(long_opts)
 
+    # Confirm that the help options are present
+    for help_alias in ['?', 'h']:
+        if help_alias not in getopt_opts:
+            print(f"{filepath}: help alias -{help_alias} is missing from "
+                  "getopt string")
+            return
+        if help_alias in long_opts and long_opts[help_alias].takes_argument:
+            print(f"{filepath}: help alias -{help_alias} should not take an "
+                  "argument")
+            return
+
     # Check longform options between the four sources
     for longform in all_longform:
         cur_help = help_opts.get(longform, OptionInfo())

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -437,8 +437,10 @@ def check_file(filepath: str):
 
 if __name__ == "__main__":
     subcommand_dir = 'src/subcommand'
+    # Some subcommand files have a different format
+    ignore_files = {'test_main.cpp', 'help_main.cpp'}
     for fname in os.listdir(subcommand_dir):
-        if not fname.endswith('_main.cpp'):
+        if not fname.endswith('_main.cpp') or fname in ignore_files:
             continue
         fpath = os.path.join(subcommand_dir, fname)
         problems = check_file(fpath)

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -169,10 +169,26 @@ def extract_long_options(text: str) -> dict:
     return options
 
 def extract_getopt_string(text: str) -> set:
+    """Extract short options from getopt_long() string.
+
+    Looks for the line with `getopt_long()` or `short_options =`.
+    For the former, take the third argument.
+    For the latter, take the string assigned.
+
+    Shortform options followed by : take an argument.
+
+    Parameters
+    ----------
+    text : str
+        The text of the file to search for long_options.
+
+    Returns
+    -------
+    set
+        The string broken up into short options, with : retained
     """
-    Extract short options from the getopt_long() string (e.g. "hx:rt:")
-    Returns a set of short options, with ':' indicating required arguments
-    """
+
+    # Grab third argument of getopt_long()
     match = re.search(r'getopt_long\s*\([^,]+,[^,]+,\s*"([^"]+)"', text)
     if match:
         opts = match.group(1)
@@ -190,9 +206,12 @@ def extract_getopt_string(text: str) -> set:
     result = set()
     i = 0
     while i < len(opts):
+        # Add shortform with its `:`
         if i+1 < len(opts) and opts[i+1] == ':':
             result.add(f'{opts[i]}:')
+            # Skip `:`
             i += 2
+        # This shortform option has no `:`
         else:
             result.add(opts[i])
             i += 1

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -66,7 +66,7 @@ def extract_help_options(text: str) -> dict:
             continue
         # End at end of outermost curly braces
         elif inside_help and stripped == '}' and curly_brace_nesting == 0:
-            inside_help = False
+            break
 
         # Ignore comments and lines outside the helptext
         if not inside_help or stripped.startswith('//'):

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -230,7 +230,7 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
     for line in text.splitlines():
         stripped = line.strip()
         # Are we inside the helptext printing function?
-        if re.search(r'void\shelp_\w+\s*\(', line):
+        if re.search(r'void\shelp_\w+\s*\(char\*\* argv\) \{', stripped):
             inside_help = True
             curly_brace_nesting = -1
             continue

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -128,7 +128,11 @@ CRASHES = {'exit', 'return', 'deprecated', 'abort', 'throw'}
 
 @dataclass
 class OptionInfo:
-    """Information about a command line option."""
+    """Information about a command line option.
+    
+    Doesn't store a longform option because it expects
+    to be a value in a {longform: OptionInfo} dictionary.
+    """
 
     takes_argument: bool = None
     """Whether the option takes an argument."""

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -367,6 +367,13 @@ def check_file(filepath: str):
         elif getopt_opts[help_alias]:
             print(f"{filepath}: help alias -{help_alias} should not take an "
                   "argument")
+        
+        if help_alias not in switch_opts:
+            print(f"{filepath}: help alias -{help_alias} is missing from "
+                  "switch block")
+        elif switch_opts[help_alias]:
+            print(f"{filepath}: help alias -{help_alias} should not use "
+                  "optarg in switch block")
 
     # Check longform options between the four sources
     for longform in all_longform:
@@ -404,6 +411,7 @@ def check_file(filepath: str):
                       f"should be in getopt string")
                 continue
         
+            # Mark that this shortform has been used in getopts
             cur_getopt = getopt_opts.pop(cur_long.shortform)
             
             if cur_getopt is None:
@@ -422,7 +430,10 @@ def check_file(filepath: str):
                     "not used in the switch block")
             continue
 
-        if cur_long.takes_argument != switch_opts[cur_long.shortform]:
+        # Mark that this shortform has been used in the switch block
+        cur_switch = switch_opts.pop(cur_long.shortform)
+
+        if cur_long.takes_argument != cur_switch:
             print(f"{filepath}: --{longform}'s -{cur_long.shortform} "
                     f"{should_str} use optarg")
             continue
@@ -434,6 +445,12 @@ def check_file(filepath: str):
     if getopt_opts:
         print(f"{filepath}: getopt string has options not in long_options[]: "
               f"{', '.join(getopt_opts)}")
+    
+    if '?' in switch_opts:
+        switch_opts.pop('?')
+    if switch_opts:
+        print(f"{filepath}: switch block has options not in long_options[]: "
+              f"{', '.join(switch_opts)}")
 
 if __name__ == "__main__":
     subcommand_dir = 'src/subcommand'

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -287,16 +287,16 @@ def extract_switch_optarg(text: str) -> dict:
     current_cases = []
     has_optarg = False
     inside_switch = False
-    curly_brace_nesting = 0
 
     for line in text.splitlines():
         stripped = line.strip()
 
         # Are we inside the switch statement?
-        if re.search(r'switch\s*\(\s*c\s*\)', text):
+        if re.search(r'switch\s*\(\s*c\s*\)', line):
             inside_switch = True
+            curly_brace_nesting = 0 if '{' in stripped else -1
         elif inside_switch and line.strip() == '}' and curly_brace_nesting == 0:
-            inside_switch = False
+            break
 
         if not inside_switch or line.strip().startswith('//'):
             continue

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -295,7 +295,7 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
         printed_line = re.search(quoted_pattern, stripped)
         if printed_line:
             printed_len = printed_line.end(1) - printed_line.start(1)
-            if printed_len > 81:
+            if printed_len > 80:
                 raise ValueError(f"Helptext line `{stripped}` is {printed_len}"
                                  ">80 characters long")
             if r"\n" in printed_line.group(1):

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -15,6 +15,8 @@ If it still doesn't make sense, ping me.
 
 ## Checks
 
+### File as a whole
+
 Checks performed on the *file as a whole*.
 
 1. The help options (-h, -?) must be present in the getopt string
@@ -24,8 +26,16 @@ Checks performed on the *file as a whole*.
 3. All options in the getopt string must be in long_options[].
 4. All options in the switch block must be in long_options[].
 
-Checks performed on each longform option (pulled from
-the helptext and long_options[]):
+While long_options[], the getopt string, and the switch block
+must have the same option set, the helptext is allowed to be
+missing some options (e.g. deprecated/developer-only options).
+
+Also -? should appear only in the getopt string and the switch block,
+and not in long_options[] or the helptext.
+
+### Each option separately
+
+Longform options are pulled from the helptext and long_options[]
 
 1. All longform options must be in long_options[]
 2. The long_options[] entry must be either `no_argument`

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -517,7 +517,7 @@ def extract_switch_optarg(text: str) -> Dict[str, Optional[bool]]:
     current_cases = []
     has_optarg = False
 
-    def set_optarg_usage(cases: list[str], usage: Optional[bool]):
+    def set_optarg_usage(cases: List[str], usage: Optional[bool]):
         """Set optarg usage for a list of cases."""
         for case in cases:
             if case in shortforms:

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -162,7 +162,7 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
     and ending with the outermost closing curly brace `}`.
     (i.e. nested curly braces are handled correctly)
 
-    Ignores lines with comments.
+    Ignores lines with single-line comments.
 
     Looks for `"  -<short>, --<long> <arg>  <desc>"`
     The shortform option is optional, as is the argument.
@@ -281,6 +281,8 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
             break
 
         # Ignore comments and lines outside the helptext
+        # Multiline comments are not handled correctly,
+        # but they shouldn't be here anyway.
         if not inside_help or stripped.startswith('//'):
             continue
 
@@ -490,7 +492,7 @@ def extract_switch_optarg(text: str) -> Dict[str, Optional[bool]]:
     and ending with the outermost closing curly brace `}`.
     (i.e. nested curly braces are handled correctly)
 
-    Ignores lines with comments. Handles fallthroughs,
+    Ignores lines with single-line comments. Handles fallthroughs,
     breaking cases on either a crash or a `break;`.
 
     Looks for whether each case uses `optarg` or not.
@@ -546,6 +548,9 @@ def extract_switch_optarg(text: str) -> Dict[str, Optional[bool]]:
         elif inside_switch and line.strip() == '}' and curly_brace_nesting == 0:
             break
 
+        # Ignore comments and lines outside the switch
+        # Multiline comments are not handled correctly,
+        # but they shouldn't be here anyway.
         if not inside_switch or line.strip().startswith('//'):
             continue
         if '{' in stripped:
@@ -561,7 +566,7 @@ def extract_switch_optarg(text: str) -> Dict[str, Optional[bool]]:
             if has_optarg:
                 set_optarg_usage(current_cases, True)
             
-            # Remove comments
+            # Remove end-of-line comments
             stripped = stripped.split('//')[0].strip() 
             case_value = case_match.group(1) if case_match else 'default'
 

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -138,7 +138,7 @@ class OptionInfo:
     shortform: Optional[str] = None
     """Short option name, or None if not present."""
     errors: List[str] = None
-    """Some special errors to print about this option."""
+    """Extra things to complain about at the end."""
 
     def is_unset(self) -> bool:
         """Check if this option is unset."""

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -12,6 +12,9 @@ import re
 from typing import Dict, Optional
 from dataclasses import dataclass
 
+SKIP_FILES = {'test_main.cpp', 'help_main.cpp'}
+GIRAFFE_EXCEPTIONS = {'max-multimaps', 'batch-size'}
+
 @dataclass
 class OptionInfo:
     """Information about a command line option."""
@@ -438,6 +441,9 @@ def check_file(filepath: str):
 
         # Check 4: long_options[] vs switch
         if cur_long.shortform not in switch_opts:
+            if 'giraffe_main' in filepath and longform in GIRAFFE_EXCEPTIONS:
+                # Giraffe exceptions are allowed to not have a switch
+                continue
             print(f"{filepath}: --{longform}'s -{cur_long.shortform} is "
                     "not used in the switch block")
             continue
@@ -467,7 +473,7 @@ def check_file(filepath: str):
 if __name__ == "__main__":
     subcommand_dir = 'src/subcommand'
     # Some subcommand files have a different format
-    ignore_files = {'test_main.cpp', 'help_main.cpp'}
+    ignore_files = SKIP_FILES
     for fname in os.listdir(subcommand_dir):
         if not fname.endswith('_main.cpp') or fname in ignore_files:
             continue

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -187,6 +187,24 @@ class OptionInfo:
             return (self.takes_argument == other.takes_argument
                     and self.shortform == other.shortform)
 
+    def __str__(self) -> str:
+        """String representation of this OptionInfo."""
+        if self.is_unset():
+            return "no info"
+        if self.shortform is None:
+            shortform_str = "no shortform"
+        else:
+            # If shortform is a single character, print it
+            # Otherwise, print it as a string
+            if len(self.shortform) == 1:
+                shortform_str = f"shortform -{self.shortform}"
+            else:
+                shortform_str = f'shortform "{self.shortform}"'
+
+        return (shortform_str + ", "
+                + ("does not take" if not self.takes_argument else "takes")
+                + " an argument")
+
 def extract_help_options(text: str) -> Dict[str, OptionInfo]:
     """Extract options from help_<command>()
     
@@ -788,7 +806,7 @@ def check_file(filepath: str) -> bool:
         # Check 4: help vs long_options[]
         if not cur_help.is_unset() and not cur_help.is_compatible(cur_long):
             problem(f"--{longform} has mismatch between helptext "
-                    f"{cur_help} and long_options[] {cur_long}")
+                    f"({cur_help}) and long_options[] ({cur_long})")
             continue
 
         # Check 5: long_options[] vs getopt string

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -12,7 +12,8 @@ options should appear, though I've been flexible about valid
 variations. If something looks off, a detailed message will be
 printed to stdout. If that message doesn't make sense, something
 might've been ignored due to a wrong format, so check "Format".
-If it still doesn't make sense, ping me.
+If it still doesn't make sense, ping @faithokamoto
+(if I'm still here) and/or open an issue on GitHub.
 
 ## Checks
 

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -301,6 +301,9 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
             if printed_len > 81:
                 raise ValueError(f"Helptext line `{stripped}` is {printed_len}"
                                  ">80 characters long")
+            if r"\n" in printed_line.group(1):
+                raise ValueError(f"Helptext line `{stripped}` has a newline "
+                                 "character, which is not allowed; use endl")
 
         # Parse out sections of full pattern
         match = help_pattern.search(stripped)

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -109,7 +109,7 @@ Some GitHub Copilot autocompletions were used.
 import os
 import re
 import sys
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from dataclasses import dataclass
 
 SUBCOMMAND_DIR = 'src/subcommand'
@@ -135,7 +135,7 @@ class OptionInfo:
 
     takes_argument: bool = None
     """Whether the option takes an argument."""
-    shortform: Optional[str | int] = None
+    shortform: Optional[Union[str, int]] = None
     """Short option name, or None if not present."""
     errors: List[str] = None
     """Some special errors to print about this option."""

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -94,11 +94,6 @@ you may have to do multiple runs/fixes to see all the problems.
 For all checks, commented-out lines are ignored.
 (Though multiline comments aren't handled correctly.)
 
-## TODO
-
-- Check that the order of options in the helptext
-  matches the order in long_options[] and getopt_long() string
-
 ## Attribution
 
 The base of this script was written by ChatGPT.

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -364,11 +364,9 @@ def check_file(filepath: str):
         if help_alias not in getopt_opts:
             print(f"{filepath}: help alias -{help_alias} is missing from "
                   "getopt string")
-            return
-        if getopt_opts[help_alias]:
+        elif getopt_opts[help_alias]:
             print(f"{filepath}: help alias -{help_alias} should not take an "
                   "argument")
-            return
 
     # Check longform options between the four sources
     for longform in all_longform:
@@ -431,7 +429,8 @@ def check_file(filepath: str):
     
     # getopt is allowed to have ? as a help alias
     # without that being in long_options[]
-    getopt_opts.pop('?')
+    if '?' in getopt_opts:
+        getopt_opts.pop('?')
     if getopt_opts:
         print(f"{filepath}: getopt string has options not in long_options[]: "
               f"{', '.join(getopt_opts)}")

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -201,7 +201,7 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
     # Match the line's prefix, which should be two spaces
     prefix = r'\s+'
     # Match a shortform option: `-<short`
-    shortform_patten = r'-[\w]'
+    shortform_patten = r'-[^\s]'
     # Match a longform option: `--<long>`
     longform_patten = r'--[a-zA-Z0-9\-]+'
     # Match an optional argument in all-caps, with a preceeding space

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -318,7 +318,7 @@ def extract_switch_optarg(text: str) -> dict:
 
     return optarg_usage
 
-def check_file(filepath: str) -> list:
+def check_file(filepath: str):
     """
     Check consistency of options in a single _main.cpp file.
     Returns list of problematic long options.
@@ -379,13 +379,15 @@ def check_file(filepath: str) -> list:
                 print(f"{filepath}: --{longform}'s -{cur_long.shortform} "
                       f"should be in getopt string")
                 continue
+        
+            cur_getopt = getopt_opts.pop(cur_long.shortform)
             
-            if getopt_opts[cur_long.shortform] is None:
+            if cur_getopt is None:
                 print(f"{filepath}: --{longform}'s -{cur_long.shortform} "
                       "appears multiple times in getopt string")
                 continue
 
-            if cur_long.takes_argument != getopt_opts[cur_long.shortform]:
+            if cur_long.takes_argument != cur_getopt:
                 print(f"{filepath}: --{longform}'s -{cur_long.shortform} "
                       f"{should_str} have a : after it in getopt string")
                 continue
@@ -400,6 +402,13 @@ def check_file(filepath: str) -> list:
             print(f"{filepath}: --{longform}'s -{cur_long.shortform} "
                     f"{should_str} use optarg")
             continue
+    
+    # getopt is allowed to have ? as a help alias
+    # without that being in long_options[]
+    getopt_opts.pop('?')
+    if getopt_opts:
+        print(f"{filepath}: getopt string has options not in long_options[]: "
+              f"{', '.join(getopt_opts)}")
 
 if __name__ == "__main__":
     subcommand_dir = 'src/subcommand'

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -230,14 +230,20 @@ def extract_getopt_string(text: str) -> Dict[str, bool]:
     options = dict()
     i = 0
     while i < len(opts_str):
+        shortform = opts_str[i]
+        if shortform in options:
+            print(f"Duplicate shortform option: {shortform} in {opts_str}")
+            i += 1
+            continue
+        
         # Add shortform with its `:`
         if i+1 < len(opts_str) and opts_str[i+1] == ':':
-            options[opts_str[i]] = True
+            options[shortform] = True
             # Skip `:`
             i += 2
         # This shortform option has no `:`
         else:
-            options[opts_str[i]] = False
+            options[shortform] = False
             i += 1
     return options
 

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -144,7 +144,7 @@ class OptionInfo:
         """Check if this option is unset."""
         return self.takes_argument is None and self.shortform is None
     
-    def __eq__(self, other) -> bool:
+    def is_compatible(self, other) -> bool:
         if not isinstance(other, OptionInfo):
             return False
         # If either shortform is unset, only compare takes_argument
@@ -717,7 +717,7 @@ def check_file(filepath: str) -> bool:
             continue
 
         # Check 4: help vs long_options[]
-        if not cur_help.is_unset() and cur_help != cur_long:
+        if not cur_help.is_unset() and not cur_help.is_compatible(cur_long):
             problem(f"--{longform} has mismatch between helptext "
                     f"{cur_help} and long_options[] {cur_long}")
             continue

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -77,7 +77,11 @@ you may have to do multiple runs/fixes to see all the problems.
   In addition, there must be a "usage:" line somewhere.
   
   Option helptext is not allowed to be over 80 characters long,
-  and all descriptions must line up properly.
+  and all descriptions must line up properly. If there are more
+  than 80 characters between the `"`s, but that's because you
+  have some long default value, just stick that bit on a new line
+  of code without changing the printed text. Check out
+  `filter_main.cpp`'s `--batch-size` for an example.
 
 - long_options[]: within the `long_options[]` array,
   must be an array of `{"longform", arg_type, 0, shortform}`

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -123,10 +123,6 @@ HELP_DESC = 'print this help message to stderr and exit'
 """Expected description for the --help option."""
 ANNOTATE_EXCEPTIONS = {'xg-name', 'bed-name'}
 """annotate_main.cpp lets these appear twice in helptext."""
-# Some giraffe arguments are processed outside of the switch block
-# (at least I think so? I'm not entirely sure)
-GIRAFFE_EXCEPTIONS = {'max-multimaps', 'batch-size'}
-"""Options for giraffe_main.cpp that are not in the switch block."""
 CRASHES = {'exit', 'return', 'deprecated', 'abort', 'throw'}
 """Keywords that indicate a crash/deprecation in the switch block."""
 
@@ -746,9 +742,6 @@ def check_file(filepath: str) -> bool:
 
         # Check 6: long_options[] vs switch
         if cur_long.shortform not in switch_opts:
-            if 'giraffe_main' in filepath and longform in GIRAFFE_EXCEPTIONS:
-                # Giraffe exceptions are allowed to not have a switch
-                continue
             problem(f"--{longform}'s -{cur_long.shortform} is "
                     "not used in the switch block")
             continue

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -339,7 +339,7 @@ def check_file(filepath: str):
             print(f"{filepath}: help alias -{help_alias} is missing from "
                   "getopt string")
             return
-        if help_alias in long_opts and long_opts[help_alias].takes_argument:
+        if getopt_opts[help_alias]:
             print(f"{filepath}: help alias -{help_alias} should not take an "
                   "argument")
             return

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -67,7 +67,7 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
         A dictionary mapping long option names to OptionInfo
     """
 
-    help_opts = {}
+    help_opts = dict()
     # Match the line's prefix, which is `<< "    `
     prefix = r'<< "\s+'
     # Match a shortform option: `-<short`
@@ -152,7 +152,8 @@ def extract_long_options(text: str) -> Dict[str, OptionInfo]:
         A dictionary mapping long option names to OptionInfo
     """
 
-    options = {}
+    options = dict()
+    all_shortforms = set()
     inside_longopts = False
 
     for line in text.splitlines():
@@ -182,6 +183,10 @@ def extract_long_options(text: str) -> Dict[str, OptionInfo]:
                 except ValueError:
                     # Otherwise, it is a character or string
                     shortform = shortform.strip("'")
+                
+                # Skip duplicate shortforms (aliases)
+                if shortform in all_shortforms:
+                    continue
 
                 # Ignore placeholder line with all zeros
                 if long_name == '0':
@@ -189,6 +194,7 @@ def extract_long_options(text: str) -> Dict[str, OptionInfo]:
 
                 takes_arg = (arg_type == 'required_argument')
                 options[long_name] = OptionInfo(takes_arg, shortform)
+                all_shortforms.add(shortform)
     return options
 
 def extract_getopt_string(text: str) -> Dict[str, bool]:

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -229,7 +229,7 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
     curly_brace_nesting = 0
     description_start = None
 
-    def save_option(match: re.Match[str], has_shortform: bool) -> None:
+    def save_option(match: re.Match, has_shortform: bool) -> None:
         """Helper function to save an option."""
         errors = []
         nonlocal description_start

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -96,11 +96,8 @@ For all checks, commented-out lines are ignored.
 
 ## TODO
 
-- Have all "multiple allowed"/"may repeat" be "may repeat"
 - Check that the order of options in the helptext
   matches the order in long_options[] and getopt_long() string
-- Standard description for --threads
-- Disallow "\n" strings in helptext
 
 ## Attribution
 

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -254,9 +254,8 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
                 raise ValueError(f"Help option line '{stripped}' "
                                  "does not start with two spaces")
             if not match.group(5).startswith('  '):
-                raise ValueError(f"Help option line '{stripped}' "
-                                 "has less than two spaces between option "
-                                 "and description")
+                raise ValueError(f"Help option line '{stripped}' has less than "
+                                 "two spaces between option and description")
             save_option(match.group(2)[1], match.group(3)[2:],
                         match.group(4) is not None)
             continue
@@ -264,12 +263,12 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
         # Parse out sections of long-only pattern
         match = long_only_pattern.search(stripped)
         if match:
-            # long-only pattern allowed to have extra spaces at the start
-            # as that might be to line up all the longforms
+            if len(match.group(1)) != 6:
+                raise ValueError(f"Longform option {match.group(2)} "
+                                 "does not line up with the others")
             if not match.group(4).startswith('  '):
-                raise ValueError(f"Help option line '{stripped}' "
-                                 "has less than two spaces between option "
-                                 "and description")
+                raise ValueError(f"Help option line '{stripped}' has less than "
+                                 "two spaces between option and description")
             save_option(None, match.group(2)[2:], match.group(3) is not None)
 
     return help_opts

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -101,6 +101,10 @@ you may have to do multiple runs/fixes to see all the problems.
 For all checks, commented-out lines are ignored.
 (Though multiline comments aren't handled correctly.)
 
+In addition, the logic to figure out when we're inside of a block
+marked by {} assumes that there is only one curly brace of each
+type maximum per line. }} might compile but this script will complain.
+
 ## Attribution
 
 The base of this script was written by ChatGPT.

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -253,8 +253,28 @@ def extract_getopt_string(text: str) -> Dict[str, bool]:
     return options
 
 def extract_switch_optarg(text: str) -> dict:
-    """
-    Returns a dict of shortform -> uses_optarg (True/False), accounting for fallthroughs.
+    """Compile optarg usage within switch(c) block.
+
+    Looks within the switch block handling options,
+    starting with a line with `switch(c)` (plus optional spaces)
+    and ending with the outermost closing curly brace `}`.
+    (i.e. nested curly braces are handled correctly)
+
+    Ignores lines with comments. Handles fallthroughs,
+    breaking cases on either a return or a `break;`.
+
+    Looks for whether each case uses `optarg` or not.
+
+    Parameters
+    ----------
+    text : str
+        The text of the file to search for long_options.
+
+    Returns
+    -------
+    Dict[str, bool]
+        A dictionary mapping shortform names to
+        whether they use optarg (i.e. take an argument).
     """
 
     optarg_usage = {}

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -251,10 +251,14 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
             errors.append(f"Help option -h does not have the expected "
                             f"description '{HELP_DESC}'")
         
+        # Count of blank spaces between option and description
         text_offset = re.match(r'\s+(.+)', description).start(1) - match.start()
+        # Column within printed text which starts thr description
         text_start = match.start(description_num) + text_offset
+        # Use first line's text_start as the description start
         if description_start is None:
             description_start = text_start
+        # All other lines must match
         elif description_start != text_start:
             errors.append(f"Help option line '{stripped}' does not "
                           "line up with the previous option's description")

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -272,8 +272,9 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
             raise ValueError(f"Duplicate longform option '{longform}' found in "
                              "helptext")
 
-    for line in text.splitlines():
-        stripped = line.strip()
+    lines = text.splitlines()
+    for i in range(len(lines)):
+        stripped = lines[i].strip()
         # Are we inside the helptext printing function?
         if re.search(HELPTEXT_FUNCTION, stripped):
             inside_help = True
@@ -305,11 +306,11 @@ def extract_help_options(text: str) -> Dict[str, OptionInfo]:
         if printed_line:
             printed_len = printed_line.end(1) - printed_line.start(1)
             if printed_len > 80:
-                raise ValueError(f"Helptext line `{stripped}` is {printed_len}"
-                                 ">80 characters long")
+                raise ValueError(f"line {i+1} has helptext string `{stripped}` "
+                                 f"which is {printed_len}>80 characters long")
             if r"\n" in printed_line.group(1):
-                raise ValueError(f"Helptext line `{stripped}` has a newline "
-                                 "character, which is not allowed; use endl")
+                raise ValueError(f"line {i+1} has helptext string `{stripped}` "
+                                 "with a newline character; use endl instead")
 
         # Parse out sections of full pattern
         match = help_pattern.search(stripped)

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -64,7 +64,14 @@ def extract_long_options(text: str) -> dict:
             if len(parts) >= 4:
                 long_name = parts[0].strip().strip('"')
                 arg_type = parts[1].strip()
-                shortform = parts[3].strip().strip("'")
+                shortform = parts[3].strip()
+                try:
+                    # Keep shortform as a number if it is one
+                    shortform = int(shortform)
+                except ValueError:
+                    # Otherwise, it is a character or string
+                    shortform = shortform.strip("'")
+
                 if long_name == '0':
                     continue
                 takes_arg = (arg_type == 'required_argument')

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -29,9 +29,9 @@ fix multiple things in the file before the script can run well.
 
 Checks performed on the *file as a whole*.
 
-1. The help options (-h, -?) must be present in the getopt string
-   and the switch block, and must not take an argument. In the
-   switch block, they must crash.
+1. The help options (-h, -?) must be present in the helptext,
+   getopt string, and the switch block, and must not take an
+   argument. In the switch block, they must crash.
 2. The default case in the switch block must crash.
 3. All options in the getopt string must be in long_options[].
 4. All options in the switch block must be in long_options[].
@@ -71,6 +71,10 @@ you may have to do multiple runs/fixes to see all the problems.
   (the description is ignored, and the shortform and argument are optional).
   The longform option must be composed of alphanumeric characters
   and hyphens, and the argument must be in all-caps.
+  In addition, there must be a "usage:" line somewhere.
+  
+  Option helptext is not allowed to be over 80 characters long,
+  and all descriptions must line up properly.
 
 - long_options[]: within the `long_options[]` array,
   must be an array of `{"longform", arg_type, 0, shortform}`

--- a/src/subcommand/add_main.cpp
+++ b/src/subcommand/add_main.cpp
@@ -28,13 +28,15 @@ using namespace vg::subcommand;
 void help_add(char** argv) {
     cerr << "usage: " << argv[0] << " add [options] old.vg >new.vg" << endl
          << "options:" << endl
-         << "    -v, --vcf FILE         add in variants from the given VCF file (may repeat)" << endl
-         << "    -n, --rename V=G       rename contig V in the VCFs to contig G in the graph (may repeat)" << endl
-         << "    -i, --ignore-missing   ignore contigs in the VCF not found in the graph" << endl
-         << "    -r, --variant-range N  range in which to look for nearby variants to make a haplotype" << endl
-         << "    -f, --flank-range N    extra flanking sequence to use outside of found variants" << endl
-         << "    -p, --progress         show progress" << endl
-         << "    -t, --threads N        use N threads (defaults to numCPUs)" << endl;
+         << "  -v, --vcf FILE         add in variants from a VCF (may repeat)" << endl
+         << "  -n, --rename V=G       rename contig V in the VCFs to contig G in the graph" << endl
+         << "                         (may repeat)" << endl
+         << "  -i, --ignore-missing   ignore contigs in the VCF not found in the graph" << endl
+         << "  -r, --variant-range N  range to look for nearby variants to make a haplotype" << endl
+         << "  -f, --flank-range N    extra flanking sequence to use outside of variants" << endl
+         << "  -p, --progress         show progress" << endl
+         << "  -t, --threads N        use N threads [numCPUs]" << endl
+         << "  -h, --help             print this help message to stderr and exit" << endl;
 }
 
 int main_add(int argc, char** argv) {

--- a/src/subcommand/align_main.cpp
+++ b/src/subcommand/align_main.cpp
@@ -31,21 +31,24 @@ using namespace vg::subcommand;
 void help_align(char** argv) {
     cerr << "usage: " << argv[0] << " align [options] <graph.vg> >alignments.gam" << endl
          << "options:" << endl
-         << "    -s, --sequence STR    align a string to the graph in graph.vg using partial order alignment" << endl
-         << "    -Q, --seq-name STR    name the sequence using this value" << endl
-         << "    -j, --json            output alignments in JSON format (default GAM)" << endl
-         << "    -m, --match N         use this match score (default: 1)" << endl
-         << "    -M, --mismatch N      use this mismatch penalty (default: 4)" << endl
-         << "    --score-matrix FILE   read a 5x5 integer substitution scoring matrix from a file" << endl
-         << "    -g, --gap-open N      use this gap open penalty (default: 6)" << endl
-         << "    -e, --gap-extend N    use this gap extension penalty (default: 1)" << endl
-         << "    -T, --full-l-bonus N  provide this bonus for alignments that are full length (default: 5)" << endl
-         << "    -b, --banded-global   use the banded global alignment algorithm" << endl
-         << "    -p, --pinned          pin the (local) alignment traceback to the optimal edge of the graph" << endl
-         << "    -L, --pin-left        pin the first rather than last bases of the graph and sequence" << endl
-         << "    -w, --between POS,POS align the sequence between the two positions, specified as node ID, + or -, offset" << endl
-         << "    -r, --reference STR   don't use an input graph--- run SSW alignment between -s and -r" << endl
-         << "    -D, --debug           print out score matrices and other debugging info" << endl;
+         << "  -s, --sequence STR       align STR to the graph using partial order alignment" << endl
+         << "  -Q, --seq-name STR       name the sequence using this value" << endl
+         << "  -j, --json               output alignments in JSON format (default GAM)" << endl
+         << "  -m, --match N            use this match score [1]" << endl
+         << "  -M, --mismatch N         use this mismatch penalty [4]" << endl
+         << "      --score-matrix FILE  use this 5x5 integer substitution scoring matrix" << endl
+         << "  -g, --gap-open N         use this gap open penalty [6]" << endl
+         << "  -e, --gap-extend N       use this gap extension penalty [1]" << endl
+         << "  -T, --full-l-bonus N     use this bonus for full length alignments [5]" << endl
+         << "  -b, --banded-global      use the banded global alignment algorithm" << endl
+         << "  -p, --pinned             pin the (local) alignment traceback to" << endl
+         << "                           the optimal edge of the graph" << endl
+         << "  -L, --pin-left           pin first instead of last bases of the graph/sequence" << endl
+         << "  -w, --between POS,POS    align the sequence between the two positions," << endl
+         << "                           specified as node ID, + or -, offset" << endl
+         << "  -r, --reference STR      don't use a graph: run SSW alignment between -s / -r" << endl
+         << "  -D, --debug              print out score matrices and other debugging info" << endl
+         << "  -h, --help               print this help message to stderr and exit" << endl;
 }
 
 int main_align(int argc, char** argv) {
@@ -271,7 +274,8 @@ int main_align(int argc, char** argv) {
             // Pick some plausible extraction parameters.
             size_t max_path_length = seq.size() * 2;
             size_t max_gap_length = seq.size() / 2;
-            MinimizerMapper::align_sequence_between_consistently(left_anchor, right_anchor, max_path_length, max_gap_length, graph.get(), &aligner, alignment, seq_name.empty() ? nullptr : &seq_name);
+            MinimizerMapper::align_sequence_between_consistently(left_anchor, right_anchor, max_path_length, 
+                max_gap_length, graph.get(), &aligner, alignment, seq_name.empty() ? nullptr : &seq_name);
 
         } else {
             // Align directly to the full provided graph.

--- a/src/subcommand/align_main.cpp
+++ b/src/subcommand/align_main.cpp
@@ -83,7 +83,7 @@ int main_align(int argc, char** argv) {
             /* These options set a flag. */
             //{"verbose", no_argument,       &verbose_flag, 1},
             {"sequence", required_argument, 0, 's'},
-            {"seq-name", no_argument, 0, 'Q'},
+            {"seq-name", required_argument, 0, 'Q'},
             {"json", no_argument, 0, 'j'},
             {"match", required_argument, 0, 'm'},
             {"mismatch", required_argument, 0, 'M'},
@@ -97,12 +97,13 @@ int main_align(int argc, char** argv) {
             {"pinned", no_argument, 0, 'p'},
             {"pin-left", no_argument, 0, 'L'},
             {"between", required_argument, 0, 'w'},
+            {"help", no_argument, 0, 'h'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "s:jhQ:m:M:g:e:Dr:F:O:bT:pLw:",
-                long_options, &option_index);
+        c = getopt_long (argc, argv, "s:jh?Q:m:M:g:e:Dr:bT:pLw:",
+                         long_options, &option_index);
 
         /* Detect the end of the options. */
         if (c == -1)

--- a/src/subcommand/align_main.cpp
+++ b/src/subcommand/align_main.cpp
@@ -61,7 +61,7 @@ int main_align(int argc, char** argv) {
         return 1;
     }
 
-    #define OPT_SCORE_MATRIX 1000
+    constexpr int OPT_SCORE_MATRIX = 1000;
     string matrix_file_name;
     bool print_cigar = false;
     bool output_json = false;

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -23,22 +23,28 @@ using namespace vg::subcommand;
 void help_annotate(char** argv) {
     cerr << "usage: " << argv[0] << " annotate [options] >output.{gam,vg,tsv}" << endl
          << "graph annotation options:" << endl
-         << "    -x, --xg-name FILE     xg index or graph to annotate (required)" << endl
-         << "    -b, --bed-name FILE    a BED file to convert to GAM. May repeat." << endl
-         << "    -f, --gff-name FILE    a GFF3 file to convert to GAM. May repeat." << endl
-         << "    -g, --ggff             output at GGFF subgraph annotation file instead of GAM (requires -s)" << endl
-         << "    -F, --gaf-output       output in GAF format rather than GAM" << endl
-         << "    -s, --snarls FILE      file containing snarls to expand GFF intervals into" << endl
+         << "  -x, --xg-name FILE     xg index or graph to annotate (required)" << endl
+         << "  -b, --bed-name FILE    BED file to convert to GAM (may repeat)" << endl
+         << "  -f, --gff-name FILE    GFF3 file to convert to GAM (may repeat)" << endl
+         << "  -g, --ggff             output GGFF subgraph annotation file" << endl
+         << "                         instead of GAM (requires -s)" << endl
+         << "  -F, --gaf-output       output in GAF format rather than GAM" << endl
+         << "  -s, --snarls FILE      snarls to expand GFF intervals into" << endl
          << "alignment annotation options:" << endl
-         << "    -a, --gam FILE         file of Alignments to annotate (required)" << endl
-         << "    -x, --xg-name FILE     xg index of the graph against which the Alignments are aligned (required)" << endl
-         << "    -p, --positions        annotate alignments with reference positions" << endl
-         << "    -m, --multi-position   annotate alignments with multiple reference positions" << endl
-         << "    -l, --search-limit N   when annotating with positions, search this far for paths, or -1 to not search (default: 0 (auto from read length))" << endl
-         << "    -b, --bed-name FILE    annotate alignments with overlapping region names from this BED. May repeat." << endl
-         << "    -n, --novelty          output TSV table with header describing how much of each Alignment is novel" << endl
-         << "    -P, --progress         show progress" << endl
-         << "    -t, --threads N        use the specified number of threads" << endl;
+         << "  -a, --gam FILE         alignments to annotate (required)" << endl
+         << "  -x, --xg-name FILE     xg index of the graph against which the" << endl
+         << "                         alignments are aligned (required)" << endl
+         << "  -p, --positions        annotate alignments with reference positions" << endl
+         << "  -m, --multi-position   annotate alignments with multiple reference positions" << endl
+         << "  -l, --search-limit N   when annotating with -p, search this far for paths, or" << endl
+         << "                         -1 to not search [0 (auto from read length)]" << endl
+         << "  -b, --bed-name FILE    annotate alignments with overlapping region names" << endl
+         << "                         from this BED (may repeat)" << endl
+         << "  -n, --novelty          output TSV table with header" << endl
+         << "                         describing how much of each Alignment is novel" << endl
+         << "  -P, --progress         show progress" << endl
+         << "  -t, --threads N        use the specified number of threads" << endl
+         << "  -h, --help             print this help message to stderr and exit" << endl;
 }
 
 /// Find the region of the Mapping's node used by the Mapping, in forward strand space, as start to past_end.
@@ -129,7 +135,7 @@ int main_annotate(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "x:a:pml:b:f:gFs:nt:Ph?",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -334,7 +340,8 @@ int main_annotate(int argc, char** argv) {
             }
             
             get_input_file(gam_name, [&](istream& in) {
-                vg::Progressive::with_progress(show_progress, "Read reads", [&](const std::function<void(size_t, size_t)>& progress) {
+                vg::Progressive::with_progress(show_progress, "Read reads", 
+                    [&](const std::function<void(size_t, size_t)>& progress) {
                     vg::io::for_each_parallel<Alignment>(in, [&](Alignment& aln) {
                         // For each read
                         
@@ -360,10 +367,12 @@ int main_annotate(int argc, char** argv) {
                                 auto node_id = mapping.position().node_id();
                                 auto features = features_on_node.find(node_id);
                                 if (features != features_on_node.end()) {
-                                    // Some things occur on this node. Find the overlaps with the part of the node touched by this read.
+                                    // Some things occur on this node.
+                                    // Find the overlaps with the part of the node touched by this read.
                                     auto overlapping = find_overlapping(features->second, mapping_to_range(xg_index, mapping));
                                     // Save them all to the set (to remove duplicates)
-                                    copy(overlapping.begin(), overlapping.end(), inserter(touched_features, touched_features.begin()));
+                                    copy(overlapping.begin(), overlapping.end(), 
+                                         inserter(touched_features, touched_features.begin()));
                                 }
                             }
                             

--- a/src/subcommand/annotate_main.cpp
+++ b/src/subcommand/annotate_main.cpp
@@ -38,7 +38,7 @@ void help_annotate(char** argv) {
          << "    -b, --bed-name FILE    annotate alignments with overlapping region names from this BED. May repeat." << endl
          << "    -n, --novelty          output TSV table with header describing how much of each Alignment is novel" << endl
          << "    -P, --progress         show progress" << endl
-         << "    -t, --threads          use the specified number of threads" << endl;
+         << "    -t, --threads N        use the specified number of threads" << endl;
 }
 
 /// Find the region of the Mapping's node used by the Mapping, in forward strand space, as start to past_end.
@@ -112,7 +112,7 @@ int main_annotate(int argc, char** argv) {
         {
             {"gam", required_argument, 0, 'a'},
             {"positions", no_argument, 0, 'p'},
-            {"multi-positions", no_argument, 0, 'm'},
+            {"multi-position", no_argument, 0, 'm'},
             {"search-limit", required_argument, 0, 'l'},
             {"xg-name", required_argument, 0, 'x'},
             {"bed-name", required_argument, 0, 'b'},
@@ -123,12 +123,12 @@ int main_annotate(int argc, char** argv) {
             {"novelty", no_argument, 0, 'n'},
             {"progress", no_argument, 0, 'P'},
             {"threads", required_argument, 0, 't'},
-            {"help", required_argument, 0, 'h'},
+            {"help", no_argument, 0, 'h'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:a:pml:b:f:gFs:nt:Ph",
+        c = getopt_long (argc, argv, "x:a:pml:b:f:gFs:nt:Ph?",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -148,7 +148,7 @@ int main_augment(int argc, char** argv) {
         {"edges-only", no_argument, 0, 'E'},
         {"gaf", no_argument, 0, 'F'},
         {"help", no_argument, 0, 'h'},
-        {"progress", required_argument, 0, 'p'},
+        {"progress", no_argument, 0, 'p'},
         {"verbose", no_argument, 0, 'v'},
         {"threads", required_argument, 0, 't'},
         // Loci Options
@@ -156,7 +156,7 @@ int main_augment(int argc, char** argv) {
         {"include-gt", required_argument, 0, 'L'},
         {0, 0, 0, 0}
     };
-    static const char* short_options = "a:Z:A:iCSBhpvt:l:L:sm:c:q:Q:N:EF";
+    static const char* short_options = "a:Z:A:iCSBh?pvt:l:L:sm:c:q:Q:N:EF";
     optind = 2; // force optind past command positional arguments
 
     // This is our command-line parser

--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -44,26 +44,29 @@ void help_augment(char** argv, ConfigurableParser& parser) {
          << "Embed GAM alignments into a graph to facilitate variant calling" << endl
          << endl
          << "general options:" << endl
-         << "    -i, --include-paths         merge the paths implied by alignments into the graph" << endl
-         << "    -S, --keep-softclips        include softclips from input alignments (they are cut by default)" << endl
-         << "    -B, --label-paths           don't augment with alignments, just use them for labeling the graph" << endl
-         << "    -Z, --translation FILE      save translations from augmented back to base graph to FILE" << endl
-         << "    -A, --alignment-out FILE    save augmented GAM reads to FILE" << endl
-         << "    -F, --gaf                   expect (and write) GAF instead of GAM" << endl
-         << "    -s, --subgraph              graph is a subgraph of the one used to create GAM. ignore alignments with missing nodes" << endl
-         << "    -m, --min-coverage N        minimum coverage of a breakpoint required for it to be added to the graph" << endl
-         << "    -c, --expected-cov N        expected coverage.  used only for memory tuning [default : 128]" << endl
-         << "    -q, --min-baseq N           ignore edits whose sequence have average base quality < N" << endl
-         << "    -Q, --min-mapq N            ignore alignments with mapping quality < N" << endl
-         << "    -N, --max-n F               maximum fraction of N bases in an edit for it to be included [default : 0.25]" << endl
-         << "    -E, --edges-only            only edges implied by reads, ignoring edits" << endl
-         << "    -h, --help                  print this help message" << endl
-         << "    -p, --progress              show progress" << endl
-         << "    -v, --verbose               print information and warnings about vcf generation" << endl
-         << "    -t, --threads N             number of threads (only 1st pass with -m or -q option is multithreaded)" << endl
+         << "  -i, --include-paths        merge paths implied by alignments into the graph" << endl
+         << "  -S, --keep-softclips       include softclips from alignments (cut by default)" << endl
+         << "  -B, --label-paths          use alignments only to label graph, not augment" << endl
+         << "  -Z, --translation FILE     save translations from augmented back to base graph" << endl
+         << "  -A, --alignment-out FILE   save augmented GAM reads" << endl
+         << "  -F, --gaf                  expect (and write) GAF instead of GAM" << endl
+         << "  -s, --subgraph             graph is a subgraph of the one used to create GAM." << endl
+         << "                             ignore alignments with missing nodes" << endl
+         << "  -m, --min-coverage N       minimum coverage of a breakpoint required for it" << endl
+         << "                             to be added to the graph" << endl
+         << "  -c, --expected-cov N       expected coverage, used for memory tuning [128]" << endl
+         << "  -q, --min-baseq N          ignore edits with mean base quality < N" << endl
+         << "  -Q, --min-mapq N           ignore alignments with mapping quality < N" << endl
+         << "  -N, --max-n FLOAT          maximum fraction of N bases in an edit" << endl
+         << "                             for it to be included [0.25]" << endl
+         << "  -E, --edges-only           only edges implied by reads, ignoring edits" << endl
+         << "  -h, --help                 print this help message to stderr and exit" << endl
+         << "  -p, --progress             show progress" << endl
+         << "  -v, --verbose              print info and warnings about VCF generation" << endl
+         << "  -t, --threads N            number of threads (for 1st pass with -m or -q)" << endl
          << "loci file options:" << endl
-         << "    -l, --include-loci FILE     merge all alleles in loci into the graph" << endl       
-         << "    -L, --include-gt FILE       merge only the alleles in called genotypes into the graph" << endl;
+         << "  -l, --include-loci FILE    merge all alleles in loci into the graph" << endl       
+         << "  -L, --include-gt FILE      merge only alleles in called genotypes into graph" << endl;
     
      // Then report more options
      parser.print_help(cerr);
@@ -271,7 +274,8 @@ int main_augment(int argc, char** argv) {
         return 1;
     }
     if (label_paths && (!gam_out_file_name.empty() || !translation_file_name.empty() || edges_only)) {
-        cerr << "[vg augment] error: Translation (-Z), GAM (-A) output and edges-only (-E) do not work with \"label-only\" (-B) mode" << endl;
+        cerr << "[vg augment] error: Translation (-Z), GAM (-A) output and edges-only (-E) "
+             << "do not work with \"label-only\" (-B) mode" << endl;
         return 1;
     }
     if (include_paths && edges_only) {
@@ -282,7 +286,8 @@ int main_augment(int argc, char** argv) {
         cerr << "[vg augment] warning: reading the entire GAM from stdin into memory.  it is recommended to pass in"
              << " a filename rather than - so it can be streamed over two passes" << endl;
         if (!gam_out_file_name.empty()) {
-            cerr << "             warning: when streaming in a GAM with -A, the output GAM will lose all non-Path related fields from the input" << endl;
+            cerr << "             warning: when streaming in a GAM with -A, the output GAM will lose all non-Path"
+                 << "related fields from the input" << endl;
         }
     }
 

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -187,7 +187,7 @@ int main_autoindex(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "p:w:r:v:i:g:G:x:H:a:P:R:f:M:T:t:dV:h",
+        c = getopt_long (argc, argv, "p:w:r:v:i:g:G:x:H:a:P:R:f:M:T:t:dV:h?",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -313,6 +313,7 @@ int main_autoindex(int argc, char** argv) {
             case OPT_GCSA_SIZE_LIMIT:
                 IndexingParameters::gcsa_size_limit = parse<int64_t>(optarg);
                 break;
+            case '?':
             case 'h':
                 help_autoindex(argv);
                 return 0;

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -97,36 +97,39 @@ pair<string, vector<string>> parse_provide_string(const string& str) {
 }
 
 void help_autoindex(char** argv) {
-    cerr
-    << "usage: " << argv[0] << " autoindex [options]" << endl
-    << "options:" << endl
-    << "  output:" << endl
-    << "    -p, --prefix PREFIX    prefix to use for all output (default: index)" << endl
-    << "    -w, --workflow NAME    workflow to produce indexes for, can be provided multiple" << endl
-    << "                           times. options: map, mpmap, rpvg, giraffe, sr-giraffe, lr-giraffe (default: map)" << endl
-    << "  input data:" << endl
-    << "    -r, --ref-fasta FILE   FASTA file containing the reference sequence (may repeat)" << endl
-    << "    -v, --vcf FILE         VCF file with sequence names matching -r (may repeat)" << endl
-    << "    -i, --ins-fasta FILE   FASTA file with sequences of INS variants from -v" << endl
-    << "    -g, --gfa FILE         GFA file to make a graph from" << endl
-    << "    -G, --gbz FILE         GBZ file to make indexes from" << endl
-    << "    -x, --tx-gff FILE      GTF/GFF file with transcript annotations (may repeat)" << endl
-    << "    -H, --hap-tx-gff FILE  GTF/GFF file with transcript annotations of a named haplotype (may repeat)" << endl
-    << "  configuration:" << endl
-    << "    -f, --gff-feature STR  GTF/GFF feature type (col. 3) to add to graph (default: " << IndexingParameters::gff_feature_name << ")" << endl
-    << "    -a, --gff-tx-tag STR   GTF/GFF tag (in col. 9) for transcript ID (default: " << IndexingParameters::gff_transcript_tag << ")" << endl
-    << "  logging and computation:" << endl
-    << "    -T, --tmp-dir DIR      temporary directory to use for intermediate files" << endl
-    << "    -M, --target-mem MEM   target max memory usage (not exact, formatted INT[kMG])" << endl
-    << "                           (default: 1/2 of available)" << endl
+    cerr << "usage: " << argv[0] << " autoindex [options]" << endl
+         << "output:" << endl
+         << "  -p, --prefix PREFIX    prefix to use for all output [index]" << endl
+         << "  -w, --workflow NAME    workflow to produce indexes for (may repeat) [map]" << endl
+         << "                         {map, mpmap, rpvg, giraffe, sr-giraffe, lr-giraffe}" << endl
+         << "input data:" << endl
+         << "  -r, --ref-fasta FILE   FASTA file with the reference sequence (may repeat)" << endl
+         << "  -v, --vcf FILE         VCF file with sequence names matching -r (may repeat)" << endl
+         << "  -i, --ins-fasta FILE   FASTA file with sequences of INS variants from -v" << endl
+         << "  -g, --gfa FILE         GFA file to make a graph from" << endl
+         << "  -G, --gbz FILE         GBZ file to make indexes from" << endl
+         << "  -x, --tx-gff FILE      GTF/GFF file with transcript annotations (may repeat)" << endl
+         << "  -H, --hap-tx-gff FILE  GTF/GFF file with transcript annotations " << endl
+         << "                         of a named haplotype (may repeat)" << endl
+         << "configuration:" << endl
+         << "  -f, --gff-feature STR  GTF/GFF feature type (col. 3) to add to graph "
+                                      << "[" << IndexingParameters::gff_feature_name << "]" << endl
+         << "  -a, --gff-tx-tag STR   GTF/GFF tag (in col. 9) for ID "
+                                      << "[" << IndexingParameters::gff_transcript_tag << "]" << endl
+         << "logging and computation:" << endl
+         << "  -T, --tmp-dir DIR      temporary directory to use for intermediate files" << endl
+         << "  -M, --target-mem MEM   target max memory usage (not exact, formatted INT[kMG])" << endl
+         << "                         [1/2 of available]" << endl
 // TODO: hiding this now that we have rewinding options, since detailed args aren't really in the spirit of this subcommand
-//    << "    --gbwt-buffer-size NUM GBWT construction buffer size in millions of nodes; may need to be" << endl
-//    << "                           increased for graphs with long haplotypes (default: " << IndexingParameters::gbwt_insert_batch_size / gbwt::MILLION << ")" << endl
-//    << "    --gcsa-size-limit NUM  limit on size of GCSA2 temporary files on disk in bytes" << endl
-    << "    -t, --threads NUM      number of threads (default: all available)" << endl
-    << "    -V, --verbosity NUM    log to stderr (0 = none, 1 = basic, 2 = debug; default " << (int) IndexingParameters::verbosity << ")" << endl
-    //<< "    -d, --dot              print the dot-formatted graph of index recipes and exit" << endl
-    << "    -h, --help             print this help message to stderr and exit" << endl;
+//    << "  --gbwt-buffer-size NUM GBWT construction buffer size in millions of nodes; may need to be" << endl
+//    << "                              increased for graphs with long haplotypes "
+//                                   << "[" << IndexingParameters::gbwt_insert_batch_size / gbwt::MILLION << "]" << endl
+//    << "  --gcsa-size-limit NUM limit on size of GCSA2 temporary files on disk in bytes" << endl
+         << "  -t, --threads NUM      number of threads [all available]" << endl
+         << "  -V, --verbosity NUM    log to stderr {0 = none, 1 = basic, 2 = debug}"
+         <<                           "[" << (int) IndexingParameters::verbosity << "]" << endl
+       //<< "  -d, --dot              print the dot-formatted graph of index recipes and exit" << endl
+         << "  -h, --help             print this help message to stderr and exit" << endl;
 }
 
 int main_autoindex(int argc, char** argv) {
@@ -315,9 +318,8 @@ int main_autoindex(int argc, char** argv) {
                 break;
             case '?':
             case 'h':
-                help_autoindex(argv);
-                return 0;
             default:
+                help_autoindex(argv);
                 return 1;
         }
     }
@@ -414,5 +416,6 @@ int main_autoindex(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_autoindex("autoindex", "mapping tool-oriented index construction from interchange formats", PIPELINE, 1, main_autoindex);
+static Subcommand vg_autoindex("autoindex", "mapping tool-oriented index construction from interchange formats", 
+                               PIPELINE, 1, main_autoindex);
 

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -139,11 +139,11 @@ int main_autoindex(int argc, char** argv) {
         return 1;
     }
     
-#define OPT_KEEP_INTERMEDIATE 1000
-#define OPT_FORCE_UNPHASED 1001
-#define OPT_FORCE_PHASED 1002
-#define OPT_GBWT_BUFFER_SIZE 1003
-#define OPT_GCSA_SIZE_LIMIT 1004
+    constexpr int OPT_KEEP_INTERMEDIATE =  1000;
+    constexpr int OPT_FORCE_UNPHASED = 1001;
+    constexpr int OPT_FORCE_PHASED = 1002;
+    constexpr int OPT_GBWT_BUFFER_SIZE = 1003;
+    constexpr int OPT_GCSA_SIZE_LIMIT = 1004;
     
     // load the registry
     IndexRegistry registry = VGIndexes::get_vg_index_registry();

--- a/src/subcommand/benchmark_main.cpp
+++ b/src/subcommand/benchmark_main.cpp
@@ -26,7 +26,8 @@ using namespace vg::subcommand;
 void help_benchmark(char** argv) {
     cerr << "usage: " << argv[0] << " benchmark [options] >report.tsv" << endl
          << "options:" << endl
-         << "    -p, --progress         show progress" << endl;
+         << "  -p, --progress         show progress" << endl
+         << "  -h, --help             print this help message to stderr and exit" << endl;
 }
 
 int main_benchmark(int argc, char** argv) {

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -153,7 +153,7 @@ int main_call(int argc, char** argv) {
             {"ploidy-regex", required_argument, 0, 'R'},
             {"gaf", no_argument, 0, 'G'},
             {"traversals", no_argument, 0, 'T'},
-            {"min-trav-len", required_argument, 0, 'M'},
+            {"trav-padding", required_argument, 0, 'M'},
             {"legacy", no_argument, 0, 'L'},
             {"nested", no_argument, 0, 'n'},
             {"chains", no_argument, 0, 'I'},            
@@ -165,7 +165,7 @@ int main_call(int argc, char** argv) {
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "k:Be:b:m:v:aAc:C:f:i:s:r:g:zN:Op:S:o:l:d:R:GTLM:nt:h",
+        c = getopt_long (argc, argv, "k:Be:b:m:v:aAc:C:f:i:s:r:g:zN:Op:S:o:l:d:R:GTLM:nIt:h?",
                          long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -140,7 +140,7 @@ int main_call(int argc, char** argv) {
     // used to merge up snarls from chains when generating traversals
     const size_t max_chain_edges = 1000; 
     const size_t max_chain_trivial_travs = 5;
-    const int OPT_PROGRESS = 1000;
+    constexpr int OPT_PROGRESS = 1000;
     int c;
     optind = 2; // force optind past command positional argument
     while (true) {

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -27,48 +27,67 @@ using namespace vg::subcommand;
 
 /// Helper to ensure that a PathHandleGraph has the VectorizableHandleGraph and PathPositionHandleGraph interfaces.
 typedef bdsg::PairOverlayHelper<PathPositionHandleGraph, bdsg::PackedReferencePathOverlay, PathHandleGraph,
-                                VectorizableHandleGraph, bdsg::PathPositionVectorizableOverlay, PathPositionHandleGraph> ReferencePathVectorizableOverlayHelper;
+                                VectorizableHandleGraph, bdsg::PathPositionVectorizableOverlay, PathPositionHandleGraph> 
+                                ReferencePathVectorizableOverlayHelper;
 
 void help_call(char** argv) {
-  cerr << "usage: " << argv[0] << " call [options] <graph> > output.vcf" << endl
-       << "Call variants or genotype known variants" << endl
-       << endl
-       << "support calling options:" << endl
-       << "    -k, --pack FILE          supports created from vg pack for given input graph" << endl
-       << "    -m, --min-support M,N    minimum allele support (M) and minimum site support (N) for call [default = 2,4]" << endl
-       << "    -e, --baseline-error X,Y baseline error rates for Poisson model for small (X) and large (Y) variants [default= 0.005,0.01]" << endl
-       << "    -B, --bias-mode          use old ratio-based genotyping algorithm as opposed to probablistic model" << endl
-       << "    -b, --het-bias M,N       homozygous alt/ref allele must have >= M/N times more support than the next best allele [default = 6,6]" << endl
-       << "GAF options:" << endl
-       << "    -G, --gaf               output GAF genotypes instead of VCF" << endl
-       << "    -T, --traversals        output all candidate traversals in GAF without doing any genotyping" << endl
-       << "    -M, --trav-padding N    extend each flank of traversals (from -T) with reference path by N bases if possible" << endl
-       << "general options:" << endl
-       << "    -v, --vcf FILE          VCF file to genotype (must have been used to construct input graph with -a)" << endl
-       << "    -a, --genotype-snarls   genotype every snarl, including reference calls (use to compare multiple samples)" << endl
-       << "    -A, --all-snarls        genotype all snarls, including nested child snarls (like deconstruct -a)" << endl
-       << "    -c, --min-length N      genotype only snarls with at least one traversal of length >= N" << endl
-       << "    -C, --max-length N      genotype only snarls where all traversals have length <= N" << endl
-       << "    -f, --ref-fasta FILE    reference fasta (required if VCF contains symbolic deletions or inversions)" << endl
-       << "    -i, --ins-fasta FILE    insertions fasta (required if VCF contains symbolic insertions)" << endl
-       << "    -s, --sample NAME       sample name [default=SAMPLE]" << endl
-       << "    -r, --snarls FILE       snarls (from vg snarls) to avoid recomputing." << endl
-       << "    -g, --gbwt FILE         only call genotypes that are present in given GBWT index." << endl
-       << "    -z, --gbz               only call genotypes that are present in GBZ index (applies only if input graph is GBZ)." << endl
-       << "    -N, --translation FILE  node ID translation (as created by vg gbwt --translation) to apply to snarl names in output" << endl
-       << "    -O, --gbz-translation   use the ID translation from the input gbz to apply snarl names to snarl names and AT fields in output" << endl
-       << "    -p, --ref-path NAME     reference path to call on (multipile allowed. defaults to all paths)" << endl
-       << "    -S, --ref-sample NAME   call on all paths with given sample name (cannot be used with -p)" << endl
-       << "    -o, --ref-offset N      offset in reference path (multiple allowed, 1 per path)" << endl
-       << "    -l, --ref-length N      override length of reference in the contig field of output VCF" << endl
-       << "    -d, --ploidy N          ploidy of sample.  Only 1 and 2 supported. (default: 2)" << endl
-       << "    -R, --ploidy-regex RULES    use the given comma-separated list of colon-delimited REGEX:PLOIDY rules to assign" << endl
-       << "                                ploidies to contigs not visited by the selected samples, or to all contigs simulated" << endl
-       << "                                from if no samples are used. Unmatched contigs get ploidy 2 (or that from -d)." << endl
-       << "    -n, --nested            activate nested calling mode (experimental)" << endl
-       << "    -I, --chains            call chains instead of snarls (experimental)" << endl
-       << "        --progress          show progress" << endl
-       << "    -t, --threads N         number of threads to use" << endl;
+    cerr << "usage: " << argv[0] << " call [options] <graph> > output.vcf" << endl
+         << "Call variants or genotype known variants" << endl
+         << endl
+         << "support calling options:" << endl
+         << "  -k, --pack FILE           supports created from vg pack for given input graph" << endl
+         << "  -m, --min-support M,N     min allele (M) and site (N) support to call [2,4]" << endl
+         << "  -e, --baseline-error X,Y  baseline error rates for Poisson model for small (X)" << endl
+         << "                            and large (Y) variants [0.005,0.01]" << endl
+         << "  -B, --bias-mode           use old ratio-based genotyping algorithm" << endl
+         << "                            as opposed to probablistic model" << endl
+         << "  -b, --het-bias M,N        homozygous alt/ref allele must have >= M/N times" << endl
+         << "                            more support than the next best allele [6,6]" << endl
+         << "GAF options:" << endl
+         << "  -G, --gaf                 output GAF genotypes instead of VCF" << endl
+         << "  -T, --traversals          output all candidate traversals in GAF" << endl
+         << "                            without doing any genotyping" << endl
+         << "  -M, --trav-padding N      extend each flank of traversals (from -T) with" << endl
+         << "                            reference path by N bases if possible" << endl
+         << "general options:" << endl
+         << "  -v, --vcf FILE            VCF file to genotype (must have been used" << endl
+         << "                            to construct input graph with -a)" << endl
+         << "  -a, --genotype-snarls     genotype every snarl, including reference calls" << endl
+         << "                            (use to compare multiple samples)" << endl
+         << "  -A, --all-snarls          genotype all snarls, including nested child snarls" << endl
+         << "                            (like deconstruct -a)" << endl
+         << "  -c, --min-length N        genotype only snarls with" << endl
+         << "                            at least one traversal of length >= N" << endl
+         << "  -C, --max-length N        genotype only snarls where" << endl 
+         << "                            all traversals have length <= N" << endl
+         << "  -f, --ref-fasta FILE      reference FASTA" << endl
+         << "                            (required if VCF has symbolic deletions/inversions)" << endl
+         << "  -i, --ins-fasta FILE      insertions (required if VCF has symbolic insertions)" << endl
+         << "  -s, --sample NAME         sample name [SAMPLE]" << endl
+         << "  -r, --snarls FILE         snarls (from vg snarls) to avoid recomputing." << endl
+         << "  -g, --gbwt FILE           only call genotypes present in given GBWT index" << endl
+         << "  -z, --gbz                 only call genotypes present in GBZ index" << endl
+         << "                            (applies only if input graph is GBZ)" << endl
+         << "  -N, --translation FILE    node ID translation (from vg gbwt --translation)" << endl
+         << "                            to apply to snarl names in output" << endl
+         << "  -O, --gbz-translation     use the ID translation from the input GBZ to" << endl
+         << "                            apply snarl names to snarl names/AT fields in output" << endl
+         << "  -p, --ref-path NAME       reference path to call on (may repeat; default all)" << endl
+         << "  -S, --ref-sample NAME     call on all paths with this sample" << endl
+         << "                            (cannot use with -p)" << endl
+         << "  -o, --ref-offset N        offset in reference path (may repeat; 1 per path)" << endl
+         << "  -l, --ref-length N        override reference length for output VCF contig" << endl
+         << "  -d, --ploidy N            ploidy of sample. {1, 2} [2]" << endl
+         << "  -R, --ploidy-regex RULES  use this comma-separated list of colon-delimited" << endl
+         << "                            REGEX:PLOIDY rules to assign ploidies to contigs" << endl
+         << "                            not visited by the selected samples, or to all" << endl
+         << "                            contigs simulated from if no samples are used." << endl
+         << "                            Unmatched contigs get ploidy 2 (or that from -d)." << endl
+         << "  -n, --nested              activate nested calling mode (experimental)" << endl
+         << "  -I, --chains              call chains instead of snarls (experimental)" << endl
+         << "      --progress            show progress" << endl
+         << "  -t, --threads N           number of threads to use" << endl
+         << "  -h, --help                print this help message to stderr and exit" << endl;
 }    
 
 int main_call(int argc, char** argv) {
@@ -290,7 +309,8 @@ int main_call(int argc, char** argv) {
         {
             int num_threads = parse<int>(optarg);
             if (num_threads <= 0) {
-                cerr << "error:[vg call] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                cerr << "error:[vg call] Thread count (-t) set to " << num_threads 
+                     << ", must set to a positive integer." << endl;
                 exit(1);
             }
             omp_set_num_threads(num_threads);
@@ -348,7 +368,8 @@ int main_call(int argc, char** argv) {
         baseline_error_small = parse<double>(error_toks[0]);
         baseline_error_large = parse<double>(error_toks[1]);
         if (baseline_error_small > baseline_error_large) {
-            cerr << "warning [vg call]: with baseline error -e X,Y option, small variant error (X) normally less than large (Y)" << endl;
+            cerr << "warning [vg call]: with baseline error -e X,Y option, "
+                 << "small variant error (X) normally less than large (Y)" << endl;
         }
     } else if (error_toks.size() != 0) {
         cerr << "error [vg call]: -e option expects exactly two comma-separated numbers X,Y" << endl;
@@ -365,7 +386,8 @@ int main_call(int argc, char** argv) {
         return 1;
     }
 
-    if ((min_allele_len > 0 || max_allele_len < numeric_limits<size_t>::max()) && (legacy || !vcf_filename.empty() || nested)) {
+    if ((min_allele_len > 0 || max_allele_len < numeric_limits<size_t>::max())
+        && (legacy || !vcf_filename.empty() || nested)) {
         cerr << "error [vg call]: -c/-C no supported with -v, -l or -n" << endl;
         return 1;        
     }
@@ -391,7 +413,8 @@ int main_call(int argc, char** argv) {
             if (show_progress) cerr << "[vg call]: Restricting search to GBZ haplotypes" << endl;
             gbwt_index = &gbz_graph->gbz.index;
         } else {
-            cerr << "[vg call]: You can restrict the search to GBZ haplotypes, often to the benefict of speed and accuracy, with the -z option" << endl;
+            cerr << "[vg call]: You can restrict the search to GBZ haplotypes, "
+                 << "often to the benefict of speed and accuracy, with the -z option" << endl;
         }
     } else if (get<1>(input)) {
         path_handle_graph = std::move(get<1>(input));
@@ -422,7 +445,8 @@ int main_call(int argc, char** argv) {
     }
     if (!translation_file_name.empty()) {
         if (!translation->empty()) {
-            cerr << "Warning [vg call]: Using translation from -N overrides that in input GBZ (you probably don't want to use -N)" << endl;
+            cerr << "Warning [vg call]: Using translation from -N overrides that in input GBZ"
+                 << "(you probably don't want to use -N)" << endl;
         }        
         ifstream translation_file(translation_file_name.c_str());
         if (!translation_file) {
@@ -581,7 +605,8 @@ int main_call(int argc, char** argv) {
                 }
             });
 
-        // if we have reference lengths, great!  this will be the only way to get a correct header in the presence of supbpaths
+        // if we have reference lengths, great!
+        // this will be the only way to get a correct header in the presence of supbpaths
         if (!ref_path_lengths.empty()) {
             assert(ref_path_lengths.size() == ref_paths.size());
             for (size_t i = 0; i < ref_paths.size(); ++i) {

--- a/src/subcommand/chain_main.cpp
+++ b/src/subcommand/chain_main.cpp
@@ -29,7 +29,8 @@ using namespace vg::subcommand;
 void help_chain(char** argv) {
     cerr << "usage: " << argv[0] << " chain [options] input.json" << endl
          << "options:" << endl
-         << "    -p, --progress                                 show progress" << endl;
+         << "  -p, --progress       show progress" << endl
+         << "  -h, --help           print this help message to stderr and exit" << endl;
 }
 
 int main_chain(int argc, char** argv) {
@@ -123,7 +124,8 @@ int main_chain(int argc, char** argv) {
                         assert(sequence != nullptr);
                         graph.create_handle(sequence, vg::parse<nid_t>(node_id));
                     } else {
-                        std::cerr << "warning:[vg chain] Unreadable node object at index " << i << ": " << json_error.text << std::endl;
+                        std::cerr << "warning:[vg chain] Unreadable node object at index " << i << ": "
+                                  << json_error.text << std::endl;
                     }
                 } else {
                     std::cerr << "warning:[vg chain] No node object at index " << i << std::endl;
@@ -145,7 +147,8 @@ int main_chain(int argc, char** argv) {
                     const char* to_id = nullptr;
                     int to_end = 0;
                     
-                    if (json_unpack_ex(edge_json, &json_error, 0, "{s:s, s?b, s:s, s?b}", "from", &from_id, "from_start", &from_start, "to", &to_id, "to_end", &to_end) == 0) {
+                    if (json_unpack_ex(edge_json, &json_error, 0, "{s:s, s?b, s:s, s?b}", "from", &from_id,
+                                       "from_start", &from_start, "to", &to_id, "to_end", &to_end) == 0) {
                         // This record is well-formed, so make the edge
                         assert(from_id != nullptr);
                         assert(to_id != nullptr);
@@ -153,7 +156,8 @@ int main_chain(int argc, char** argv) {
                         handle_t to_handle = graph.get_handle(vg::parse<nid_t>(to_id), to_end);
                         graph.create_edge(from_handle, to_handle);
                     } else {
-                        std::cerr << "warning:[vg chain] Unreadable edge object at index " << i << ": " << json_error.text << std::endl;
+                        std::cerr << "warning:[vg chain] Unreadable edge object at index " << i << ": "
+                                  << json_error.text << std::endl;
                     }
                 } else {
                     std::cerr << "warning:[vg chain] No edge object at index " << i << std::endl;
@@ -217,9 +221,11 @@ int main_chain(int argc, char** argv) {
                                    "read_exclusion_start", &read_exclusion_start, 
                                    "read_exclusion_end", &read_exclusion_end) == 0 &&
                     json_unpack_ex(graph_start, &json_error, 0, "{s:s, s?s, s?b}",
-                                   "node_id", &graph_start_id, "offset", &graph_start_offset, "is_reverse", &graph_start_is_reverse) == 0 &&
+                                   "node_id", &graph_start_id, "offset", &graph_start_offset, 
+                                   "is_reverse", &graph_start_is_reverse) == 0 &&
                     json_unpack_ex(graph_end, &json_error, 0, "{s:s, s?s, s?b}",
-                                   "node_id", &graph_end_id, "offset", &graph_end_offset, "is_reverse", &graph_end_is_reverse) == 0) {
+                                   "node_id", &graph_end_id, "offset", &graph_end_offset, 
+                                   "is_reverse", &graph_end_is_reverse) == 0) {
                     
                     // We have an item record.
                     assert(read_start != nullptr);
@@ -241,9 +247,11 @@ int main_chain(int argc, char** argv) {
                     size_t margin_right = vg::parse<size_t>(read_exclusion_start) - (start + length);
                     
                     // Pack up into an item
-                    items.emplace_back(start, make_pos_t(vg::parse<nid_t>(graph_start_id), graph_start_is_reverse, vg::parse<size_t>(graph_start_offset)), length, margin_left, margin_right, score);
+                    items.emplace_back(start, make_pos_t(vg::parse<nid_t>(graph_start_id), graph_start_is_reverse, 
+                                       vg::parse<size_t>(graph_start_offset)), length, margin_left, margin_right, score);
                 } else {
-                    std::cerr << "warning:[vg chain] Unreadable item object at index " << i << ": " << json_error.text << std::endl;
+                    std::cerr << "warning:[vg chain] Unreadable item object at index " 
+                              << i << ": " << json_error.text << std::endl;
                 }
             } else {
                 std::cerr << "warning:[vg chain] No item object at index " << i << std::endl;
@@ -266,7 +274,8 @@ int main_chain(int argc, char** argv) {
 #endif
 
     // Do the chaining. We assume items is already sorted right.
-    std::pair<int, std::vector<size_t>> score_and_chain = vg::algorithms::find_best_chain(items, distance_index, graph, scorer.gap_open, scorer.gap_extension);
+    std::pair<int, std::vector<size_t>> score_and_chain = vg::algorithms::find_best_chain(
+        items, distance_index, graph, scorer.gap_open, scorer.gap_extension);
     
     std::cout << "Best chain gets score " << score_and_chain.first << std::endl;
     

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -143,7 +143,7 @@ int main_chunk(int argc, char** argv) {
     bool path_components = false;
     string snarl_filename;
     
-    #define OPT_NO_EMBEDDED_HAPLOTYPES 1000
+    constexpr int OPT_NO_EMBEDDED_HAPLOTYPES = 1000;
     
     int c;
     optind = 2; // force optind past command positional argument

--- a/src/subcommand/chunk_main.cpp
+++ b/src/subcommand/chunk_main.cpp
@@ -83,7 +83,7 @@ void help_chunk(char** argv) {
          << "    --no-embedded-haplotypes don't load haplotypes from the graph. It is possible to -T without any haplotypes available." << endl
          << "    -f, --fully-contained    only return GAM alignments that are fully contained within chunk" << endl
          << "    -u, --cut-alignments     cut alignments to be fully contained within the chunk" << endl
-         << "    -O, --output-fmt         specify output format (vg, pg, hg, gfa).  [pg (vg with -T)]" << endl
+         << "    -O, --output-fmt STR     specify output format (vg, pg, hg, gfa).  [pg (vg with -T)]" << endl
          << "    -t, --threads N          for tasks that can be done in parallel, use this many threads [1]" << endl
          << "    -h, --help" << endl;
 }
@@ -166,7 +166,7 @@ int main_chunk(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:G:a:gFp:P:s:o:e:S:E:b:c:r:R:Tfut:n:l:m:CMO:",
+        c = getopt_long (argc, argv, "h?x:G:a:gFp:P:s:o:e:S:E:b:c:r:R:Tfut:n:l:m:CMO:",
                 long_options, &option_index);
 
 

--- a/src/subcommand/circularize_main.cpp
+++ b/src/subcommand/circularize_main.cpp
@@ -27,11 +27,11 @@ void help_circularize(char** argv){
         << "Makes specific paths or nodes in a graph circular." << endl
         << endl
         << "options:" << endl
-        << "    -p  --path  <PATHNAME>  circularize the path by connecting its head/tail node." << endl
-        << "    -P, --pathfile <PATHSFILE> circularize all paths in the provided file." << endl
-        << "    -a, --head  <node_id>   circularize a head and tail node (must provide a tail)." << endl
-        << "    -z, --tail  <tail_id>   circularize a head and tail node (must provide a head)." << endl
-        << "    -d  --describe          list all the paths in the graph."   << endl
+        << "    -p, --path NAME         circularize the path by connecting its head/tail node." << endl
+        << "    -P, --pathfile FILE     circularize all paths in the provided file." << endl
+        << "    -a, --head ID           circularize a head and tail node (must provide a tail)." << endl
+        << "    -z, --tail ID           circularize a head and tail node (must provide a head)." << endl
+        << "    -d, --describe          list all the paths in the graph."   << endl
         << endl;
     exit(1);
 }
@@ -54,17 +54,18 @@ int main_circularize(int argc, char** argv){
     while (true){
         static struct option long_options[] =
         {
+            {"help", no_argument, 0, 'h'},
             {"path", required_argument, 0, 'p'},
             {"pathfile", required_argument, 0, 'P'},
             {"head", required_argument, 0, 'a'},
             {"tail", required_argument, 0, 'z'},
-            {"describe", required_argument, 0, 'd'},
+            {"describe", no_argument, 0, 'd'},
             {0,0,0,0}
         };
 
 
     int option_index = 0;
-    c = getopt_long (argc, argv, "hdp:P:a:z:",
+    c = getopt_long (argc, argv, "h?dp:P:a:z:",
             long_options, &option_index);
     if (c == -1){
         break;

--- a/src/subcommand/circularize_main.cpp
+++ b/src/subcommand/circularize_main.cpp
@@ -22,17 +22,17 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
-void help_circularize(char** argv){
+void help_circularize(char** argv) {
     cerr << "usage: " << argv[0] << " circularize [options] <graph.vg> > [circularized.vg]" << endl
-        << "Makes specific paths or nodes in a graph circular." << endl
-        << endl
-        << "options:" << endl
-        << "    -p, --path NAME         circularize the path by connecting its head/tail node." << endl
-        << "    -P, --pathfile FILE     circularize all paths in the provided file." << endl
-        << "    -a, --head ID           circularize a head and tail node (must provide a tail)." << endl
-        << "    -z, --tail ID           circularize a head and tail node (must provide a head)." << endl
-        << "    -d, --describe          list all the paths in the graph."   << endl
-        << endl;
+         << "Makes specific paths or nodes in a graph circular." << endl
+         << endl
+         << "options:" << endl
+         << "  -p, --path NAME         circularize the path by connecting its head/tail node" << endl
+         << "  -P, --pathfile FILE     circularize all paths in the provided file" << endl
+         << "  -a, --head ID           circularize a head and tail node (must provide a tail)" << endl
+         << "  -z, --tail ID           circularize a head and tail node (must provide a head)" << endl
+         << "  -d, --describe          list all the paths in the graph"   << endl
+         << "  -h, --help              print this help message to stderr and exit" << endl;
     exit(1);
 }
 
@@ -66,7 +66,7 @@ int main_circularize(int argc, char** argv){
 
     int option_index = 0;
     c = getopt_long (argc, argv, "h?dp:P:a:z:",
-            long_options, &option_index);
+                     long_options, &option_index);
     if (c == -1){
         break;
     }

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -31,15 +31,15 @@ void help_clip(char** argv) {
        << "snarl selection and clipping options:" << endl
        << "    -n, --min-nodes N         clip out snarls with > N nodes" << endl
        << "    -e, --min-edges N         clip out snarls with > N edges" << endl
-       << "    -B, --min-bases N         clip out snarls with > N bases" << endl     
+       << "    -i, --min-bases N         clip out snarls with > N bases" << endl     
        << "    -N, --min-nodes-shallow N clip out snarls with > N nodes not including nested snarls" << endl
        << "    -E, --min-edges-shallow N clip out snarls with > N edges not including nested snarls" << endl
        << "    -a, --min-avg-degree N    clip out snarls with average degree > N" << endl
-       << "    -l, --min-reflen N        ignore snarls whose reference traversal spans less than N bp" << endl     
-       << "    -L, --min-reflen-prop F   ignore snarls whose reference traversal spans less than proportion F (0<=F<=1) of the whole reference path" << endl
-       << "    -A, --max-reflen N        ignore snarls whose reference traversal spans fewer than N bp" << endl
-       << "    -g  --net-edges           only clip net-edges inside snarls" << endl
-       << "    -G  --top-net_edges       only clip net-edges inside top-level snarls" << endl
+       << "    -A, --min-reflen N        ignore snarls whose reference traversal spans less than N bp" << endl     
+       << "    -l, --max-reflen-prop F   ignore snarls whose reference traversal spans more than proportion F (0<=F<=1) of the whole reference path" << endl
+       << "    -L, --max-reflen N        ignore snarls whose reference traversal spans more than N bp" << endl
+       << "    -g, --net-edges           only clip net-edges inside snarls" << endl
+       << "    -G, --top-net-edges       only clip net-edges inside top-level snarls" << endl
        << "big deletion edge clipping options:" << endl
        << "    -D, --max-deletion-edge N clip out all edges whose endpoints have distance > N on a reference path" << endl
        << "    -c, --context N           search up to at most N steps from reference paths for candidate deletion edges [1]" << endl
@@ -108,19 +108,19 @@ int main_clip(int argc, char** argv) {
             {"min-reflen", required_argument, 0, 'A'},
             {"net-edges", no_argument, 0, 'g'},
             {"top-net-edges", no_argument, 0, 'G'},            
-            {"max-deletion", required_argument, 0, 'D'},
+            {"max-deletion-edge", required_argument, 0, 'D'},
             {"context", required_argument, 0, 'c'},
             {"path-prefix", required_argument, 0, 'P'},
             {"snarls", required_argument, 0, 'r'},
             {"min-fragment-len", required_argument, 0, 'm'},
             {"output-bed", no_argument, 0, 'B'},
             {"threads", required_argument, 0, 't'},
-            {"verbose", required_argument, 0, 'v'},
+            {"verbose", no_argument, 0, 'v'},
             {0, 0, 0, 0}
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hb:d:sSn:e:i:N:E:a:l:L:A:gGD:c:P:r:m:Bt:v",
+        c = getopt_long (argc, argv, "h?b:d:sSn:e:i:N:E:a:l:L:A:gGD:c:P:r:m:Bt:v",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -17,40 +17,52 @@ using namespace vg::subcommand;
 using namespace vg::io;
 
 void help_clip(char** argv) {
-  cerr << "usage: " << argv[0] << " [options] <graph>" << endl
-       << "Chop out variation within path intervals of a vg graph" << endl
-       << endl
-       << "input options: " << endl
-       << "    -b, --bed FILE            BED regions corresponding to path intervals of the graph to target" << endl
-       << "    -r, --snarls FILE         snarls from vg snarls (recomputed if unspecified and -n,-e,-N,-E,-a,-l,-L, or -D used)." << endl
-       << "depth clipping options: " << endl
-       << "    -d, --depth N             clip out nodes and edges with path depth below N (note you can use snarl selection and bed options to target subregions)" << endl
-       << "stub clipping options:" << endl
-       << "    -s, --stubs               clip out all stubs (nodes with degree-0 sides that aren't on reference)" << endl
-       << "    -S, --stubbify-paths      clip out all edges necessary to ensure selected reference paths have exactly two stubs" << endl
-       << "snarl selection and clipping options:" << endl
-       << "    -n, --min-nodes N         clip out snarls with > N nodes" << endl
-       << "    -e, --min-edges N         clip out snarls with > N edges" << endl
-       << "    -i, --min-bases N         clip out snarls with > N bases" << endl     
-       << "    -N, --min-nodes-shallow N clip out snarls with > N nodes not including nested snarls" << endl
-       << "    -E, --min-edges-shallow N clip out snarls with > N edges not including nested snarls" << endl
-       << "    -a, --min-avg-degree N    clip out snarls with average degree > N" << endl
-       << "    -A, --min-reflen N        ignore snarls whose reference traversal spans less than N bp" << endl     
-       << "    -l, --max-reflen-prop F   ignore snarls whose reference traversal spans more than proportion F (0<=F<=1) of the whole reference path" << endl
-       << "    -L, --max-reflen N        ignore snarls whose reference traversal spans more than N bp" << endl
-       << "    -g, --net-edges           only clip net-edges inside snarls" << endl
-       << "    -G, --top-net-edges       only clip net-edges inside top-level snarls" << endl
-       << "big deletion edge clipping options:" << endl
-       << "    -D, --max-deletion-edge N clip out all edges whose endpoints have distance > N on a reference path" << endl
-       << "    -c, --context N           search up to at most N steps from reference paths for candidate deletion edges [1]" << endl
-       << "general options: " << endl
-       << "    -P, --path-prefix STRING  do not clip out alleles on paths beginning with given prefix (such references must be specified either with -P or -b). Multiple allowed" << endl
-       << "    -m, --min-fragment-len N  don't write novel path fragment if it is less than N bp long" << endl
-       << "    -B, --output-bed          write BED-style file of affected intervals instead of clipped graph. " << endl
-       << "                              columns 4-9 are: snarl node-count edge-count shallow-node-count shallow-edge-count avg-degree" << endl
-       << "    -t, --threads N           number of threads to use [default: all available]" << endl
-       << "    -v, --verbose             print some logging messages" << endl
-       << endl;
+    cerr << "usage: " << argv[0] << " [options] <graph>" << endl
+         << "Chop out variation within path intervals of a vg graph" << endl
+         << endl
+         << "input options: " << endl
+         << "  -b, --bed FILE             BED regions for path intervals of graph to target" << endl
+         << "  -r, --snarls FILE          snarls from vg snarls (recomputed if unspecified" << endl
+         << "                             and -n, -e, -N, -E, -a, -l, -L, or -D used)" << endl
+         << "depth clipping options: " << endl
+         << "  -d, --depth N              clip out nodes and edges with path depth below N" << endl
+         << "                             use snarl selection/BED options to target regions" << endl
+         << "stub clipping options:" << endl
+         << "  -s, --stubs                clip out all stubs, i.e. nodes with degree-0 sides" << endl
+         << "                             that aren't on reference" << endl
+         << "  -S, --stubbify-paths       clip out all edges neccessary so that selected" << endl
+         << "                             reference paths have exactly two stubs" << endl
+         << "snarl selection and clipping options:" << endl
+         << "  -n, --min-nodes N          clip out snarls with >N nodes" << endl
+         << "  -e, --min-edges N          clip out snarls with >N edges" << endl
+         << "  -i, --min-bases N          clip out snarls with >N bases" << endl     
+         << "  -N, --min-nodes-shallow N  clip out snarls with >N nodes," << endl
+         << "                             ignoring nested snarls" << endl
+         << "  -E, --min-edges-shallow N  clip out snarls with >N edges," << endl
+         << "                             ignoring nested snarls" << endl
+         << "  -a, --min-avg-degree N     clip out snarls with average degree > N" << endl
+         << "  -A, --min-reflen N         ignore snarls with reference traversal span < N bp" << endl     
+         << "  -l, --max-reflen-prop F    ignore snarls with reference traversal span > F" << endl
+         << "                             (0<=F<=1) of the whole reference path" << endl
+         << "  -L, --max-reflen N         ignore snarls with reference traversal span > N bp" << endl
+         << "  -g, --net-edges            only clip net-edges inside snarls" << endl
+         << "  -G, --top-net-edges        only clip net-edges inside top-level snarls" << endl
+         << "big deletion edge clipping options:" << endl
+         << "  -D, --max-deletion-edge N  clip out all edges whose endpoints have" << endl
+         << "                             distance > N on a reference path" << endl
+         << "  -c, --context N            search up to at most N steps from reference paths" << endl
+         << "                             for candidate deletion edges [1]" << endl
+         << "general options: " << endl
+         << "  -P, --path-prefix STR      do not clip out alleles on paths beginning with STR" << endl
+         << "                             (specify such references with -P or -b; may repeat)" << endl
+         << "  -m, --min-fragment-len N   don't write novel path fragment if < N bp long" << endl
+         << "  -B, --output-bed           write BED-style file of intervals," << endl
+         << "                             instead of clipped grap. columns 4-9 are:" << endl
+         << "                             snarl node-count edge-count shallow-node-count" << endl
+         << "                             shallow-edge-count avg-degree" << endl
+         << "  -t, --threads N            number of threads to use [all available]" << endl
+         << "  -v, --verbose              print some logging messages" << endl
+         << "  -h, --help                 print this help message to stderr and exit" << endl;
 }    
 
 int main_clip(int argc, char** argv) {
@@ -121,7 +133,7 @@ int main_clip(int argc, char** argv) {
         };
         int option_index = 0;
         c = getopt_long (argc, argv, "h?b:d:sSn:e:i:N:E:a:l:L:A:gGD:c:P:r:m:Bt:v",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -133,7 +145,7 @@ int main_clip(int argc, char** argv) {
         case '?':
         case 'h':
             help_clip(argv);
-            return 0;
+            return 1;
         case 'b':
             bed_path = optarg;
             break;
@@ -230,7 +242,8 @@ int main_clip(int argc, char** argv) {
     }
 
     if ((max_deletion >= 0 || stub_clipping || stubbify_reference) && (snarl_option || out_bed)) {
-        cerr << "error:[vg-clip] bed output (-B) and snarl complexity options (-n, -e, -N, -E, -a, -l, -L, -A) cannot be used with -D, -s or -S" << endl;
+        cerr << "error:[vg-clip] bed output (-B) and snarl complexity options (-n, -e, -N, -E, -a, -l, -L, -A) "
+             << "cannot be used with -D, -s or -S" << endl;
         return 1;
     }
 
@@ -333,10 +346,12 @@ int main_clip(int argc, char** argv) {
             }
             if (bed_regions_in_graph.size() != bed_regions.size()) {
                 if (verbose) {
-                    cerr << "[vg clip]: Dropped " << (bed_regions.size() - bed_regions_in_graph.size()) << " BED regions whose sequence names do not correspond to paths in the graph" << endl;
+                    cerr << "[vg clip]: Dropped " << (bed_regions.size() - bed_regions_in_graph.size()) 
+                         << " BED regions whose sequence names do not correspond to paths in the graph" << endl;
                 }
                 if (bed_regions_in_graph.empty()) {
-                    cerr << "warning:[vg-clip] No BED region found that lies on path in graph (use vg paths -Lv to list paths that are in the graph)" << endl;
+                    cerr << "warning:[vg-clip] No BED region found that lies on path in graph "
+                         << "(use vg paths -Lv to list paths that are in the graph)" << endl;
                 }
             }
             swap(bed_regions, bed_regions_in_graph);
@@ -370,10 +385,11 @@ int main_clip(int argc, char** argv) {
             clip_low_depth_nodes_and_edges(graph.get(), min_depth, ref_prefixes, min_fragment_len, verbose);
         } else {
             // do the contained snarls
-            clip_contained_low_depth_nodes_and_edges(graph.get(), pp_graph, bed_regions, *snarl_manager, false, min_depth, min_fragment_len,
-                                                     min_nodes, min_edges, min_bases, min_nodes_shallow, min_edges_shallow, min_avg_degree, min_reflen, max_reflen_prop, max_reflen,
-                                                     only_net_edges || only_top_net_edges, only_top_net_edges,
-                                                     out_bed, verbose);
+            clip_contained_low_depth_nodes_and_edges(graph.get(), pp_graph, bed_regions, *snarl_manager, false, 
+                                                     min_depth, min_fragment_len, min_nodes, min_edges, min_bases,
+                                                     min_nodes_shallow, min_edges_shallow, min_avg_degree, min_reflen,
+                                                     max_reflen_prop, max_reflen, only_net_edges || only_top_net_edges,
+                                                     only_top_net_edges, out_bed, verbose);
         }
         
     } else if (max_deletion >= 0) {
@@ -398,8 +414,9 @@ int main_clip(int argc, char** argv) {
     }else {
         // run the alt-allele clipping
         clip_contained_snarls(graph.get(), pp_graph, bed_regions, *snarl_manager, false, min_fragment_len,
-                              min_nodes, min_edges, min_bases, min_nodes_shallow, min_edges_shallow, min_avg_degree, min_reflen,
-                              max_reflen_prop, max_reflen, only_net_edges || only_top_net_edges, only_top_net_edges, out_bed, verbose);
+                              min_nodes, min_edges, min_bases, min_nodes_shallow, min_edges_shallow,
+                              min_avg_degree, min_reflen, max_reflen_prop, max_reflen,
+                              only_net_edges || only_top_net_edges, only_top_net_edges, out_bed, verbose);
     }
 
     // write the graph

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -40,32 +40,36 @@ using namespace vg;
 using namespace vg::subcommand;
 
 void help_cluster(char** argv) {
-    cerr
-    << "usage: " << argv[0] << " cluster [options] input.gam > output.gam" << endl
-    << "Find and cluster mapping seeds." << endl
-    << endl
-    << "basic options:" << endl
-    << "  -x, --xg-name FILE            use this xg index or graph (required)" << endl
-    << "  -f, --gbz-format              input graph is in GBZ format (contains both a graph and haplotypes)" << endl
-    << "  -g, --gcsa-name FILE          use this GCSA2/LCP index pair (both FILE and FILE.lcp)" << endl
-    << "  -G, --gbwt-name FILE          use this gbwt" << endl
-    << "  -B, --gbwtgraph-name FILE     use this gbwtgraph" << endl
-    << "  -m, --minimizer-name FILE     use this minimizer index" << endl
-    << "  -l, --long-reads              minimizer index is for long reads" << endl
-    << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl
-    << "  -p, --prefix PREFIX           prefix to find indexes at" << endl
-    << "  -c, --hit-cap INT             use all minimizers with at most INT hits [10]" << endl
-    << "  -C, --hard-hit-cap INT        ignore minimizers with more than this many locations [500]" << endl
-    << "  -a, --hits-above INT          output sequences of minimizers with at least INT hits [inf]" << endl
-    << "  -S, --sequences-only          only output -s sequences of minimizers, no clustering/ziptree (overrides -Z)" << endl
-    << "  -F, --score-fraction FLOAT    select minimizers between hit caps until score is FLOAT of total [0.9]" << endl
-    << "  -U, --max-min INT             use at most INT minimizers, 0 for no limit [500]" << endl
-    << "  -b, --num-bp-per-min INT      use maximum of number minimizers calculated by READ_LENGTH / INT and --max-min [1000]" << endl
-    << "  -D, --downsample-min INT      downsample minimizers with windows of length read length/INT, 0 for no downsampling [0]" << endl
-    << "  -z, --zip-codes FILE          file containing extra zip codes not stored in the minimizers" << endl
-    << "  -Z, --zip-tree                create a zipcode tree instead of clustering" << endl
-    << "computational parameters:" << endl 
-    << "  -t, --threads INT             number of compute threads to use" << endl;
+    cerr << "usage: " << argv[0] << " cluster [options] input.gam > output.gam" << endl
+         << "Find and cluster mapping seeds." << endl
+         << endl
+         << "basic options:" << endl
+         << "  -h, --help                    print this help message to stderr and exit" << endl
+         << "  -x, --xg-name FILE            use this xg index or graph (required)" << endl
+         << "  -f, --gbz-format              input graph is GBZ format (has graph & GBWT)" << endl
+         << "  -g, --gcsa-name FILE          use FILE & FILE.lcp GCSA2/LCP index pair" << endl
+         << "  -G, --gbwt-name FILE          use this GBWT" << endl
+         << "  -B, --gbwtgraph-name FILE     use this GBWTGraph" << endl
+         << "  -m, --minimizer-name FILE     use this minimizer index" << endl
+         << "  -l, --long-reads              minimizer index is for long reads" << endl
+         << "  -d, --dist-name FILE          cluster using this distance index (required)" << endl
+         << "  -p, --prefix PREFIX           prefix to find indexes at" << endl
+         << "  -c, --hit-cap INT             use all minimizers with at most INT hits [10]" << endl
+         << "  -C, --hard-hit-cap INT        ignore minimizers with more than INT hits [500]" << endl
+         << "  -a, --hits-above INT          output minimizers with at least INT hits [inf]" << endl
+         << "  -S, --sequences-only          only output -s sequences of minimizers," << endl
+         << "                                no clustering/ziptree (overrides -Z)" << endl
+         << "  -F, --score-fraction FLOAT    select minimizers between -c/-C until" << endl
+         << "                                score is FLOAT of total [0.9]" << endl
+         << "  -U, --max-min INT             use at most INT minimizers, 0 for no limit [500]" << endl
+         << "  -b, --num-bp-per-min INT      use maximum of number minimizers calculated by" << endl
+         << "                                READ_LENGTH / INT and --max-min [1000]" << endl
+         << "  -D, --downsample-min INT      downsample minimizers with windows of length" << endl
+         << "                                read length/INT, 0 for no downsampling [0]" << endl
+         << "  -z, --zip-codes FILE          file containing ip codes not in the minimizers" << endl
+         << "  -Z, --zip-tree                create a zipcode tree instead of clustering" << endl
+         << "computational parameters:" << endl 
+         << "  -t, --threads INT             number of compute threads to use" << endl;
 }
 
 int main_cluster(int argc, char** argv) {
@@ -284,7 +288,8 @@ int main_cluster(int argc, char** argv) {
             {
                 int num_threads = parse<int>(optarg);
                 if (num_threads <= 0) {
-                    cerr << "error:[vg cluster] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                    cerr << "error:[vg cluster] Thread count (-t) set to " << num_threads 
+                         << ", must set to a positive integer." << endl;
                     exit(1);
                 }
                 omp_set_num_threads(num_threads);
@@ -671,7 +676,8 @@ int main_cluster(int argc, char** argv) {
                     }
             
                     // Put the most covering cluster's index first
-                    std::sort(cluster_indexes_in_order.begin(), cluster_indexes_in_order.end(), [&](const size_t& a, const size_t& b) -> bool {
+                    std::sort(cluster_indexes_in_order.begin(), cluster_indexes_in_order.end(), 
+                    [&](const size_t& a, const size_t& b) -> bool {
                         // Return true if a must come before b, and false otherwise
                         return read_coverage_by_cluster.at(a) > read_coverage_by_cluster.at(b);
                     });

--- a/src/subcommand/cluster_main.cpp
+++ b/src/subcommand/cluster_main.cpp
@@ -129,7 +129,7 @@ int main_cluster(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:fg:G:B:m:ld:p:c:C:a:SF:U:b:D:z:Zt:",
+        c = getopt_long (argc, argv, "h?x:fg:G:B:m:ld:p:c:C:a:SF:U:b:D:z:Zt:",
                          long_options, &option_index);
 
 

--- a/src/subcommand/combine_main.cpp
+++ b/src/subcommand/combine_main.cpp
@@ -27,14 +27,18 @@ using namespace vg::subcommand;
 void help_combine(char** argv) {
     cerr << "usage: " << argv[0] << " combine [options] <graph1.vg> [graph2.vg ...] >merged.vg" << endl
          << "Combines one or more graphs into a single file, regardless of input format." << endl
-         << "Node IDs will be modified as needed to resolve conflicts (in same manner as vg ids -j)." << endl
+         << "Node IDs will be modified as needed to resolve conflicts (same as vg ids -j)." << endl
          << endl
          << "Options:" << endl
-         << "    -c, --cat-proto       merge graphs by converting each to Protobuf (if not already) and catting the results."
-         << "                          node IDs not modified [DEPRECATED]" << endl
-         << "    -p, --connect-paths   add edges necessary to connect paths with the same name present in different graphs." << endl
-         << "                          ex: If path x is present in graphs N-1 and N, then an edge connecting the last node of x in N-1 " << endl
-         << "                          and the first node of x in N will be added." << endl;
+         << "  -c, --cat-proto       merge by converting each to Protobuf (if not already)" << endl
+         << "                        and catting the results." << endl
+         << "                        node IDs not modified [DEPRECATED]" << endl
+         << "  -p, --connect-paths   add edges necessary to connect paths with the same name" << endl
+         << "                        which are present in different graphs." << endl
+         << "                        ex: If path x is present in graphs N-1 and N, then" << endl
+         << "                        an edge connecting the last node of x in N-1 " << endl
+         << "                        and the first node of x in N will be added." << endl
+         << "  -h, --help            print this help message to stderr and exit" << endl;
 }
 
 static int cat_proto_graphs(int argc, char** argv);
@@ -62,7 +66,7 @@ int main_combine(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?pc",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -89,7 +93,8 @@ int main_combine(int argc, char** argv) {
 
     if (cat_proto) {
         if (connect_paths) 
-        cerr << "warning [vg combine]: --cat-proto/-c option is deprecated and will be removed in a future version of vg." << endl;
+        cerr << "warning [vg combine]: --cat-proto/-c option is deprecated "
+             << "and will be removed in a future version of vg." << endl;
         return cat_proto_graphs(argc, argv);
     }
     
@@ -117,7 +122,9 @@ int main_combine(int argc, char** argv) {
             graph->for_each_path_handle([&](path_handle_t path_handle) {
                     string path_name = graph->get_path_name(path_handle);
                     if (first_graph->has_path(path_name)) {
-                        cerr << "error [vg combine]: Paths with name \"" << path_name << "\" found in multiple input graphs. If they are consecutive subpath ranges, they can be connected by using the -p option." << endl;
+                        cerr << "error [vg combine]: Paths with name \"" << path_name
+                             << "\" found in multiple input graphs. If they are consecutive subpath ranges, "
+                             << "they can be connected by using the -p option." << endl;
                         exit(1);
                     }
                 });

--- a/src/subcommand/combine_main.cpp
+++ b/src/subcommand/combine_main.cpp
@@ -61,7 +61,7 @@ int main_combine(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hpc",
+        c = getopt_long (argc, argv, "h?pc",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/concat_main.cpp
+++ b/src/subcommand/concat_main.cpp
@@ -54,7 +54,7 @@ int main_concat(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hp",
+        c = getopt_long (argc, argv, "h?p",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/concat_main.cpp
+++ b/src/subcommand/concat_main.cpp
@@ -26,12 +26,13 @@ using namespace vg::subcommand;
 void help_concat(char** argv) {
     cerr << "usage: " << argv[0] << " concat [options] <graph1.vg> [graph2.vg ...] >merged.vg" << endl
          << "Concatenates graphs in order by adding edges from the tail nodes of the" << endl
-         << "predecessor to the head nodes of the following graph.  If node ID spaces overlap "
+         << "predecessor to the head nodes of the following graph.  If node ID spaces overlap" << endl
          << "between graphs, they will be resolved (as in vg ids -j)" << endl
          << endl
          << "Options:" << endl
-         << "    -p, --only-join-paths         only add edges necessary to join up appended paths (as opposed between all heads/tails)" << endl
-         << endl;
+         << "  -p, --only-join-paths  only add edges necessary to join up appended paths" << endl
+         << "                         (as opposed between all heads/tails)" << endl
+         << "  -h, --help             print this help message to stderr and exit" << endl;
 }
 
 int main_concat(int argc, char** argv) {
@@ -55,7 +56,7 @@ int main_concat(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?p",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -22,33 +22,38 @@ void help_construct(char** argv) {
     cerr << "usage: " << argv[0] << " construct [options] >new.vg" << endl
          << "options:" << endl
          << "construct from a reference and variant calls:" << endl
-         << "    -r, --reference FILE   input FASTA reference (may repeat)" << endl
-         << "    -v, --vcf FILE         input VCF (may repeat)" << endl
-         << "    -n, --rename V=F       match contig V in the VCFs to contig F in the FASTAs (may repeat)" << endl
-         << "    -a, --alt-paths        save paths for alts of variants by SHA1 hash" << endl
-         << "    -A, --alt-paths-plain  save paths for alts of variants by variant ID if possible, otherwise SHA1" << endl
-         << "                           (IDs must be unique across all input VCFs)" << endl
-         << "    -R, --region REGION    specify a VCF contig name or 1-based inclusive region (may repeat, if on different contigs)" << endl
-         << "    -C, --region-is-chrom  don't attempt to parse the regions (use when the reference" << endl
-         << "                           sequence name could be inadvertently parsed as a region)" << endl
-         << "    -z, --region-size N    variants per region to parallelize (default: 1024)" << endl
-         << "    -t, --threads N        use N threads to construct graph (defaults to numCPUs)" << endl
-         << "    -S, --handle-sv        include structural variants in construction of graph." << endl
-         << "    -I, --insertions FILE  a FASTA file containing insertion sequences "<< endl
-         << "                           (referred to in VCF) to add to graph." << endl
-         << "    -f, --flat-alts        don't chop up alternate alleles from input VCF" << endl
-         << "    -l, --parse-max N      don't chop up alternate alleles from input VCF longer than N (default: 100)" << endl
-         << "    -i, --no-trim-indels   don't remove the 1bp reference base from alt alleles of indels." << endl
-         << "    -N, --in-memory        construct the entire graph in memory before outputting it." <<endl
+         << "  -r, --reference FILE   input FASTA reference (may repeat)" << endl
+         << "  -v, --vcf FILE         input VCF (may repeat)" << endl
+         << "  -n, --rename V=F       match contig V in the VCFs to contig F in the FASTAs" << endl
+         << "                         (may repeat)" << endl
+         << "  -a, --alt-paths        save paths for alts of variants by SHA1 hash" << endl
+         << "  -A, --alt-paths-plain  save paths for alts of variants by variant ID" << endl
+         << "                         if possible, otherwise SHA1" << endl
+         << "                         (IDs must be unique across all input VCFs)" << endl
+         << "  -R, --region REGION    specify a VCF contig name or 1-based inclusive region" << endl
+         << "                         (may repeat, if on different contigs)" << endl
+         << "  -C, --region-is-chrom  don't attempt to parse the regions (use when reference" << endl
+         << "                         sequence name could be parsed as a region)" << endl
+         << "  -z, --region-size N    variants per region to parallelize [1024]" << endl
+         << "  -t, --threads N        use N threads to construct graph [numCPUs]" << endl
+         << "  -S, --handle-sv        include structural variants in construction of graph." << endl
+         << "  -I, --insertions FILE  a FASTA file containing insertion sequences "<< endl
+         << "                         (referred to in VCF) to add to graph." << endl
+         << "  -f, --flat-alts        don't chop up alternate alleles from input VCF" << endl
+         << "  -l, --parse-max N      don't chop up alternate alleles from input VCF" << endl
+         << "                         longer than N [100]" << endl
+         << "  -i, --no-trim-indels   don't remove the 1bp ref base from indel alt alleles" << endl
+         << "  -N, --in-memory        construct entire graph in memory before outputting it" <<endl
          << "construct from a multiple sequence alignment:" << endl
-         << "    -M, --msa FILE         input multiple sequence alignment" << endl
-         << "    -F, --msa-format STR   format of the MSA file (options: fasta, clustal; default fasta)" << endl
-         << "    -d, --drop-msa-paths   don't add paths for the MSA sequences into the graph" << endl
+         << "  -M, --msa FILE         input multiple sequence alignment" << endl
+         << "  -F, --msa-format STR   format of the MSA file {fasta, clustal} [fasta]" << endl
+         << "  -d, --drop-msa-paths   don't add paths for the MSA sequences into the graph" << endl
          << "shared construction options:" << endl
-         << "    -m, --node-max N       limit the maximum allowable node sequence size (default: 32)" << endl
-         << "                           nodes greater than this threshold will be divided" << endl
-         << "                           note: nodes larger than ~1024 bp can't be GCSA2-indexed" << endl
-         << "    -p, --progress         show progress" << endl;
+         << "  -m, --node-max N       limit maximum allowable node sequence size [32]" << endl
+         << "                         nodes greater than this threshold will be divided" << endl
+         << "                         note: nodes larger than ~1024 bp can't be GCSA2-indexed" << endl
+         << "  -p, --progress         show progress" << endl
+         << "  -h, --help             print this help message to stderr and exit" << endl;
 
 }
 
@@ -310,7 +315,8 @@ int main_construct(int argc, char** argv) {
             auto callback = [&](Graph& big_chunk) {
                 // Sort the nodes by ID so that the serialized chunks come out in sorted order
                 // TODO: We still interleave chunks from different threads working on different contigs
-                std::sort(big_chunk.mutable_node()->begin(), big_chunk.mutable_node()->end(), [](const Node& a, const Node& b) -> bool {
+                std::sort(big_chunk.mutable_node()->begin(), big_chunk.mutable_node()->end(), 
+                [](const Node& a, const Node& b) -> bool {
                     // Return true if a comes before b
                     return a.id() < b.id();
                 });

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -36,13 +36,13 @@ void help_construct(char** argv) {
          << "    -S, --handle-sv        include structural variants in construction of graph." << endl
          << "    -I, --insertions FILE  a FASTA file containing insertion sequences "<< endl
          << "                           (referred to in VCF) to add to graph." << endl
-         << "    -f, --flat-alts N      don't chop up alternate alleles from input VCF" << endl
+         << "    -f, --flat-alts        don't chop up alternate alleles from input VCF" << endl
          << "    -l, --parse-max N      don't chop up alternate alleles from input VCF longer than N (default: 100)" << endl
          << "    -i, --no-trim-indels   don't remove the 1bp reference base from alt alleles of indels." << endl
          << "    -N, --in-memory        construct the entire graph in memory before outputting it." <<endl
          << "construct from a multiple sequence alignment:" << endl
          << "    -M, --msa FILE         input multiple sequence alignment" << endl
-         << "    -F, --msa-format       format of the MSA file (options: fasta, clustal; default fasta)" << endl
+         << "    -F, --msa-format STR   format of the MSA file (options: fasta, clustal; default fasta)" << endl
          << "    -d, --drop-msa-paths   don't add paths for the MSA sequences into the graph" << endl
          << "shared construction options:" << endl
          << "    -m, --node-max N       limit the maximum allowable node sequence size (default: 32)" << endl
@@ -102,6 +102,7 @@ int main_construct(int argc, char** argv) {
                 {"parse-max", required_argument, 0, 'l'},
                 {"no-trim-indels", no_argument, 0, 'i'},
                 {"in-memory", no_argument, 0, 'N'},
+                {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}
             };
 

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -118,7 +118,7 @@ int main_convert(int argc, char** argv) {
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hgr:b:HvxapxfP:Q:BT:WG:F:t:",
+        c = getopt_long (argc, argv, "h?gr:b:HvxapfP:Q:BT:WG:F:t:",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -41,12 +41,16 @@ void no_multiple_inputs(input_type input);
 // Promote haplotype-sense paths for the samples in ref_samples to reference sense.
 // Promote generic-sense path with the locus hap_locus to haplotype sense.
 // Copy across other haplotype-sense paths if unless drop_haplotypes is true.
-void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, const std::unordered_set<std::string>& ref_samples, const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes);
+void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output,
+                                 const std::unordered_set<std::string>& ref_samples,
+                                 const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes);
 // Copy paths from input to output.
 // Promote haplotype-sense paths for the samples in ref_samples to reference sense.
 // Promote generic-sense paths with the locus hap_locus to haplotype sense.
 // Copy across other haplotype-sense paths if unless drop_haplotypes is true.
-void add_and_adjust_paths(const PathHandleGraph* input, MutablePathHandleGraph* output, const std::unordered_set<std::string>& ref_samples, const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes);
+void add_and_adjust_paths(const PathHandleGraph* input, MutablePathHandleGraph* output, 
+                          const std::unordered_set<std::string>& ref_samples, 
+                          const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes);
 
 
 //------------------------------------------------------------------------------
@@ -119,7 +123,7 @@ int main_convert(int argc, char** argv) {
         };
         int option_index = 0;
         c = getopt_long (argc, argv, "h?gr:b:HvxapfP:Q:BT:WG:F:t:",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -131,7 +135,7 @@ int main_convert(int argc, char** argv) {
         case '?':
         case 'h':
             help_convert(argv);
-            return 0;
+            return 1;
         case 'g':
             no_multiple_inputs(input);
             input = input_gfa;
@@ -209,7 +213,8 @@ int main_convert(int argc, char** argv) {
             {
                 num_threads = parse<int>(optarg);
                 if (num_threads <= 0) {
-                    cerr << "error:[vg convert] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                    cerr << "error:[vg convert] Thread count (-t) set to " << num_threads
+                         << ", must set to a positive integer." << endl;
                     exit(1);
                 }
                 omp_set_num_threads(num_threads);
@@ -230,15 +235,18 @@ int main_convert(int argc, char** argv) {
     }
     if (gfa_output_algorithm == algorithm_gbwtgraph) {
         if (output_format != "gfa") {
-             cerr << "error [vg convert]: Only GFA output format can be used with the GBWTGraph library GFA conversion algorithm" << endl;
+             cerr << "error [vg convert]: Only GFA output format can be used "
+                  << "with the GBWTGraph library GFA conversion algorithm" << endl;
              return 1;
         }
         if (input == input_gfa) {
-             cerr << "error [vg convert]: GFA input cannot be used with the GBWTGraph library GFA conversion algorithm" << endl;
+             cerr << "error [vg convert]: GFA input cannot be used "
+                  << "with the GBWTGraph library GFA conversion algorithm" << endl;
              return 1;
         }
         if (!(rgfa_paths.empty() && rgfa_prefixes.empty() && wline)) {
-            cerr << "error [vg convert]: GFA output options (-P, -Q, -W) cannot be used with the GBWTGraph library GFA conversion algorithm" << endl;
+            cerr << "error [vg convert]: GFA output options (-P, -Q, -W) cannot be used "
+                 << "with the GBWTGraph library GFA conversion algorithm" << endl;
             return 1;
         }
     }
@@ -255,11 +263,13 @@ int main_convert(int argc, char** argv) {
         return 1;
     }
     if (new_sample.empty() != hap_locus.empty()) {
-        cerr << "error [vg convert]: to convert a generic-sense path to a haplotype, both --hap-locus and --new-sample are required" << endl;
+        cerr << "error [vg convert]: to convert a generic-sense path to a haplotype, "
+             << "both --hap-locus and --new-sample are required" << endl;
         return 1;
     }
     if (output_format == "vg") {
-          cerr << "[vg convert] warning: vg-protobuf output (-v / --vg-out) is deprecated. please use -p instead." << endl;
+          cerr << "[vg convert] warning: vg-protobuf output (-v / --vg-out) is deprecated. "
+               << "please use -p instead." << endl;
     }
 
     
@@ -275,8 +285,8 @@ int main_convert(int argc, char** argv) {
         string input_graph_filename = get_input_file_name(optind, argc, argv);
         input_graph = vg::io::VPKG::load_one<HandleGraph>(input_graph_filename);
 
-        unique_ptr<AlignmentEmitter> emitter = get_non_hts_alignment_emitter("-", (input == input_gam) ? "GAF" : "GAM", {}, get_thread_count(),
-                                                                             input_graph.get());
+        unique_ptr<AlignmentEmitter> emitter = get_non_hts_alignment_emitter(
+            "-", (input == input_gam) ? "GAF" : "GAM", {}, get_thread_count(), input_graph.get());
         std::function<void(Alignment&)> lambda = [&] (Alignment& aln) {
             emitter->emit_singles({aln});
         };                
@@ -327,7 +337,8 @@ int main_convert(int argc, char** argv) {
             
             // Need to go through a handle graph
             bdsg::HashGraph intermediate;
-            cerr << "warning [vg convert]: currently cannot convert GFA directly to XG; converting through another format" << endl;
+            cerr << "warning [vg convert]: currently cannot convert GFA directly to XG; "
+                 << "converting through another format" << endl;
             algorithms::gfa_to_path_handle_graph(input_stream_name, &intermediate,
                                                  input_rgfa_rank, gfa_trans_path);
             graph_to_xg_adjusting_paths(&intermediate, xg_graph, ref_samples, hap_locus, new_sample, drop_haplotypes);
@@ -338,7 +349,8 @@ int main_convert(int argc, char** argv) {
             // "-" input here.
             try {
                 if (output_path_graph != nullptr) {
-                    MutablePathMutableHandleGraph* mutable_output_graph = dynamic_cast<MutablePathMutableHandleGraph*>(output_path_graph);
+                    MutablePathMutableHandleGraph* mutable_output_graph \
+                        = dynamic_cast<MutablePathMutableHandleGraph*>(output_path_graph);
                     assert(mutable_output_graph != nullptr);
                     algorithms::gfa_to_path_handle_graph(input_stream_name, mutable_output_graph,
                                                          input_rgfa_rank, gfa_trans_path);
@@ -389,7 +401,8 @@ int main_convert(int argc, char** argv) {
                 xg::XG* xg_graph = dynamic_cast<xg::XG*>(output_graph.get());
                 if (input_path_graph != nullptr) {
                     // We can convert to XG with paths, which we might adjust
-                    graph_to_xg_adjusting_paths(input_path_graph, xg_graph, ref_samples, hap_locus, new_sample, drop_haplotypes);
+                    graph_to_xg_adjusting_paths(input_path_graph, xg_graph, ref_samples, 
+                                               hap_locus, new_sample, drop_haplotypes);
                 } else {
                     // No paths, just convert to xg without paths
                     xg_graph->from_handle_graph(*input_graph);
@@ -397,19 +410,22 @@ int main_convert(int argc, char** argv) {
             }
             // PathHandleGraph (possibly with haplotypes) to PathHandleGraph.
             else if (input_path_graph != nullptr && output_path_graph != nullptr) {
-                MutablePathMutableHandleGraph* mutable_output_graph = dynamic_cast<MutablePathMutableHandleGraph*>(output_path_graph);
+                MutablePathMutableHandleGraph* mutable_output_graph \
+                    = dynamic_cast<MutablePathMutableHandleGraph*>(output_path_graph);
                 assert(mutable_output_graph != nullptr);
                 // ID hint (TODO: currently not needed since only odgi used it)
                 mutable_output_graph->set_id_increment(input_graph->min_node_id());
                 // Copy the graph as-is
                 handlealgs::copy_handle_graph(input_graph.get(), mutable_output_graph);
                 // Copy the paths across with possibly some rewriting
-                add_and_adjust_paths(input_path_graph, mutable_output_graph, ref_samples, hap_locus, new_sample, drop_haplotypes);
+                add_and_adjust_paths(input_path_graph, mutable_output_graph, ref_samples, 
+                                     hap_locus, new_sample, drop_haplotypes);
             }
             // HandleGraph output.
             else {
                 if (input_path_graph != nullptr) {
-                    cerr << "warning [vg convert]: output format does not support paths, they are being dropped from the input" << endl;
+                    cerr << "warning [vg convert]: output format does not support paths, "
+                         << "they are being dropped from the input" << endl;
                 }
                 MutableHandleGraph* mutable_output_graph = dynamic_cast<MutableHandleGraph*>(output_graph.get());
                 assert(mutable_output_graph != nullptr);
@@ -439,7 +455,8 @@ int main_convert(int argc, char** argv) {
             // We need to find a GBWTGraph to use for this
             const gbwtgraph::GBWTGraph* gbwt_graph = vg::algorithms::find_gbwtgraph(input_graph.get());
             if (gbwt_graph == nullptr) {
-                cerr << "error [vg convert]: input graph does not have a GBWTGraph, so GBWTGraph library GFA conversion algorithm cannot be used." << endl;
+                cerr << "error [vg convert]: input graph does not have a GBWTGraph, "
+                     << "so GBWTGraph library GFA conversion algorithm cannot be used." << endl;
                 return 1;
             }
             
@@ -491,41 +508,50 @@ int main_convert(int argc, char** argv) {
 void help_convert(char** argv) {
     cerr << "usage: " << argv[0] << " convert [options] <input-graph>" << endl
          << "input options:" << endl
-         << "    -g, --gfa-in           input in GFA format" << endl
-         << "    -r, --in-rgfa-rank N   import rgfa tags with rank <= N as paths [default=0]" << endl
-         << "    -b, --gbwt-in FILE     input graph is a GBWTGraph using the GBWT in FILE" << endl
-         << "        --ref-sample STR   change haplotypes for this sample to reference paths (may repeat)" << endl
-         << "        --hap-locus STR    change generic paths with this locus to haplotype paths (must be used with --new-sample)" << endl
-         << "        --new-sample STR   when using --hap-locus, give the new haplotype this sample name (must be used with --hap-locus)" << endl
+         << "  -g, --gfa-in               input in GFA format" << endl
+         << "  -r, --in-rgfa-rank N       import rgfa tags with rank <= N as paths [0]" << endl
+         << "  -b, --gbwt-in FILE         input graph is a GBWTGraph using the GBWT in FILE" << endl
+         << "      --ref-sample STR       change haplotypes for this sample to" << endl
+         << "                             reference paths (may repeat)" << endl
+         << "      --hap-locus STR        change generic paths with this locus" << endl
+         << "                             to haplotype paths (must be used with --new-sample)" << endl
+         << "      --new-sample STR       when using --hap-locus, give the new haplotype" << endl
+         << "                             this sample name (must be used with --hap-locus)" << endl
          << "gfa input options (use with -g):" << endl
-         << "    -T, --gfa-trans FILE   write gfa id conversions to FILE" << endl
+         << "  -T, --gfa-trans FILE       write gfa id conversions to FILE" << endl
          << "output options:" << endl
-         << "    -v, --vg-out           output in VG's original Protobuf format [DEPRECATED: use -p instead]." << endl
-         << "    -a, --hash-out         output in HashGraph format" << endl
-         << "    -p, --packed-out       output in PackedGraph format [default]" << endl
-         << "    -x, --xg-out           output in XG format" << endl
-         << "    -f, --gfa-out          output in GFA format" << endl
-         << "    -H, --drop-haplotypes  do not include haplotype paths in the output" << endl
-         << "                           (useful with GBWTGraph / GBZ inputs)" << endl
+         << "  -v, --vg-out               output in VG's original Protobuf format" << endl
+         << "                             [DEPRECATED: use -p instead]." << endl
+         << "  -a, --hash-out             output in HashGraph format" << endl
+         << "  -p, --packed-out           output in PackedGraph format (default)" << endl
+         << "  -x, --xg-out               output in XG format" << endl
+         << "  -f, --gfa-out              output in GFA format" << endl
+         << "  -H, --drop-haplotypes      do not include haplotype paths in the output" << endl
+         << "                             (useful with GBWTGraph / GBZ inputs)" << endl
          << "gfa output options (use with -f):" << endl
-         << "    -P, --rgfa-path STR    write given path as rGFA tags instead of lines" << endl
-         << "                           (multiple allowed, only rank-0 supported)" << endl
-         << "    -Q, --rgfa-prefix STR  write paths with given prefix as rGFA tags instead of lines" << endl
-         << "                           (multiple allowed, only rank-0 supported)" << endl
-         << "    -B, --rgfa-pline       paths written as rGFA tags also written as lines" << endl
-         << "    -W, --no-wline         write all paths as GFA P-lines instead of W-lines." << endl
-         << "                           allows handling multiple phase blocks and subranges used together." << endl
-         << "    --gbwtgraph-algorithm  always use the GBWTGraph library GFA algorithm." << endl
-         << "                           not compatible with other GFA output options or non-GBWT graphs." << endl
-         << "    --vg-algorithm         always use the VG GFA algorithm. Works with all options and graph types," << endl
-         << "                           but can't preserve original GFA coordinates." << endl
-         << "    --no-translation       when using the GBWTGraph algorithm, convert the graph directly to GFA." << endl
-         << "                           do not use the translation to preserve original coordinates." << endl
+         << "  -P, --rgfa-path STR        write given path as rGFA tags instead of lines" << endl
+         << "                             (may repeat, only rank-0 supported)" << endl
+         << "  -Q, --rgfa-prefix STR      write paths with this prefix as rGFA tags instead" << endl
+         << "                             of lines (may repeat, only rank-0 supported)" << endl
+         << "  -B, --rgfa-pline           paths written as rGFA tags also written as lines" << endl
+         << "  -W, --no-wline             write all paths as GFA P-lines instead of W-lines." << endl
+         << "                             allows handling multiple phase blocks " << endl
+         << "                             and subranges used together." << endl
+         << "      --gbwtgraph-algorithm  always use the GBWTGraph library GFA algorithm." << endl
+         << "                             not compatible with other GFA output options" << endl
+         << "                             or non-GBWT graphs." << endl
+         << "      --vg-algorithm         always use the VG GFA algorithm. Works with all" << endl
+         << "                             options and graph types, but can't preserve" << endl
+         << "                             original GFA coordinates" << endl
+         << "      --no-translation       when using the GBWTGraph algorithm, convert graph" << endl
+         << "                             directly to GFA; do not use the translation" << endl
+         << "                             to preserve original coordinates" << endl
          << "alignment options:" << endl
-         << "    -G, --gam-to-gaf FILE  convert GAM FILE to GAF" << endl
-         << "    -F, --gaf-to-gam FILE  convert GAF FILE to GAM" << endl
+         << "  -G, --gam-to-gaf FILE      convert GAM FILE to GAF" << endl
+         << "  -F, --gaf-to-gam FILE      convert GAF FILE to GAM" << endl
          << "general options:" << endl
-         << "    -t, --threads N        use N threads (defaults to numCPUs)" << endl;
+         << "  -t, --threads N            use N threads [numCPUs]" << endl
+         << "  -h, --help                 print this help message to stderr and exit" << endl;
 }
 
 void no_multiple_inputs(input_type input) {
@@ -541,7 +567,8 @@ void no_multiple_inputs(input_type input) {
 /// have no more than one phase block per sample/haplotype/contig combination.
 /// Also return a map from sample name to set of observed haplotype numbers (so
 /// we can include them in reference-sense paths only if needed).
-std::unordered_map<std::string, std::unordered_set<int64_t>> check_duplicate_path_names(const PathHandleGraph* input, const std::unordered_set<std::string>& ref_samples) {
+std::unordered_map<std::string, std::unordered_set<int64_t>> check_duplicate_path_names(
+    const PathHandleGraph* input, const std::unordered_set<std::string>& ref_samples) {
     // Check to make sure no ref samples have fragmented haplotypes. If they
     // do, we can't drop the phase block and can't change the sense to
     // reference. Store set of phase blocks by sample, haplotype, contig.
@@ -562,7 +589,8 @@ std::unordered_map<std::string, std::unordered_set<int64_t>> check_duplicate_pat
             auto phase_block = input->get_phase_block(path);
             
             // Find the place to remember phase blocks for it
-            auto& phase_block_set = phase_block_sets[std::tuple<std::string, int64_t, std::string>(sample, haplotype, contig)];
+            auto& phase_block_set = phase_block_sets[
+                std::tuple<std::string, int64_t, std::string>(sample, haplotype, contig)];
             
             // Insert the phase block
             phase_block_set.insert(phase_block);
@@ -584,7 +612,9 @@ std::unordered_map<std::string, std::unordered_set<int64_t>> check_duplicate_pat
     return sample_to_haplotypes;
 }
 
-void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, const std::unordered_set<std::string>& ref_samples, const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes) {
+void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, 
+                                 const std::unordered_set<std::string>& ref_samples, 
+                                 const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes) {
     // Building an XG uses a slightly different interface, so we duplicate some
     // code from the normal MutablePathMutableHandleGraph build.
     // TODO: Find a way to unify the duplicated code?
@@ -613,7 +643,8 @@ void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, c
     // Enumerate path steps.
     auto for_each_path_element = [&](const std::function<void(const std::string& path_name,
                                                               const nid_t& node_id, const bool& is_rev,
-                                                              const std::string& cigar, const bool& is_empty, const bool& is_circular)>& lambda) {
+                                                              const std::string& cigar, const bool& is_empty, 
+                                                              const bool& is_circular)>& lambda) {
         
         // Define a function to copy over a path.
         // XG constructuon relies on name-encoded path metadata.
@@ -708,7 +739,9 @@ void graph_to_xg_adjusting_paths(const PathHandleGraph* input, xg::XG* output, c
     output->from_enumerators(for_each_sequence, for_each_edge, for_each_path_element, false);
 }
 
-void add_and_adjust_paths(const PathHandleGraph* input, MutablePathHandleGraph* output, const std::unordered_set<std::string>& ref_samples, const std::string& hap_locus, const std::string& new_sample, bool drop_haplotypes) {
+void add_and_adjust_paths(const PathHandleGraph* input, MutablePathHandleGraph* output, 
+                          const std::unordered_set<std::string>& ref_samples, const std::string& hap_locus, 
+                          const std::string& new_sample, bool drop_haplotypes) {
     
     // Make sure we aren't working with fragmented haplotypes that can't convert to reference sense.
     auto sample_to_haplotypes = check_duplicate_path_names(input, ref_samples);

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -34,29 +34,40 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
-void help_deconstruct(char** argv){
+void help_deconstruct(char** argv) {
     cerr << "usage: " << argv[0] << " deconstruct [options] [-p|-P] <PATH> <GRAPH>" << endl
-         << "Outputs VCF records for Snarls present in a graph (relative to a chosen reference path)." << endl
+         << "Output VCF records for Snarls present in a graph (relative to a reference path)." << endl
          << "options: " << endl
-         << "    -p, --path NAME          a reference path to deconstruct against (multiple allowed)." << endl
-         << "    -P, --path-prefix NAME   all paths [excluding GBWT threads / non-reference GBZ paths] beginning with NAME used as reference (multiple allowed)." << endl
-         << "                             other non-ref paths not considered as samples. " << endl
-         << "    -r, --snarls FILE        snarls file (from vg snarls) to avoid recomputing." << endl
-         << "    -g, --gbwt FILE          consider alt traversals that correspond to GBWT haplotypes in FILE (not needed for GBZ graph input)." << endl
-         << "    -T, --translation FILE   node ID translation (as created by vg gbwt --translation) to apply to snarl names and AT fields in output" << endl
-         << "    -O, --gbz-translation    use the ID translation from the input gbz to apply snarl names to snarl names and AT fields in output" << endl
-         << "    -a, --all-snarls         process all snarls, including nested snarls (by default only top-level snarls reported)." << endl
-         << "    -c, --context-jaccard N  set context mapping size used to disambiguate alleles at sites with multiple reference traversals (default: 10000)." << endl
-         << "    -u, --untangle-travs     use context mapping to determine the reference-relative positions of each step in allele traversals (AP INFO field)." << endl
-         << "    -K, --keep-conflicted    retain conflicted genotypes in output." << endl
-         << "    -S, --strict-conflicts   drop genotypes when we have more than one haplotype for any given phase (set by default when using GBWT input)." << endl
-         << "    -C, --contig-only-ref    only use the CONTIG name (and not SAMPLE#CONTIG#HAPLOTYPE etc) for the reference if possible (ie there is only one reference sample)." << endl
-         << "    -L, --cluster F          cluster traversals whose (handle) Jaccard coefficient is >= F together (default: 1.0) [experimental]" << endl
-         << "    -n, --nested             write a nested VCF, including special tags. [experimental]" << endl
-         << "    -R, --star-allele        use *-alleles to denote alleles that span but do not cross the site. Only works with -n" << endl
-         << "    -t, --threads N          use N threads" << endl
-         << "    -v, --verbose            print some status messages" << endl
-         << endl;
+         << "  -p, --path NAME          a reference path to deconstruct against (may repeat)." << endl
+         << "  -P, --path-prefix NAME   all paths [minus GBWT threads / non-ref GBZ paths]" << endl
+         << "                           beginning with NAME used as reference (may repeat)." << endl
+         << "                           other non-ref paths not considered as samples. " << endl
+         << "  -r, --snarls FILE        snarls file (from vg snarls) to avoid recomputing." << endl
+         << "  -g, --gbwt FILE          consider alt traversals for GBWT haplotypes in FILE" << endl
+         << "                           (not needed for GBZ graph input)." << endl
+         << "  -T, --translation FILE   node ID translation (from vg gbwt --translation)" << endl
+         << "                           to apply to snarl names and AT fields in output" << endl
+         << "  -O, --gbz-translation    use the ID translation from the input GBZ to apply" << endl
+         << "                           snarl names to snarl names and AT fields in output" << endl
+         << "  -a, --all-snarls         process all snarls, including nested snarls" << endl
+         << "                           (by default only top-level snarls reported)." << endl
+         << "  -c, --context-jaccard N  set context mapping size used to disambiguate alleles" << endl
+         << "                           at sites with multiple reference traversals [10000]" << endl
+         << "  -u, --untangle-travs     use context mapping fpr reference-relative positions" << endl
+         << "                           of each step in allele traversals (AP INFO field)." << endl
+         << "  -K, --keep-conflicted    retain conflicted genotypes in output." << endl
+         << "  -S, --strict-conflicts   drop genotypes when we have more than one haplotype" << endl
+         << "                           for any given phase (set by default for GBWT input)." << endl
+         << "  -C, --contig-only-ref    only use CONTIG name (not SAMPLE#CONTIG#HAPLOTYPE)" << endl
+         << "                           for reference if possible (i.e. only one ref sample)" << endl
+         << "  -L, --cluster F          cluster traversals whose (handle) Jaccard coefficient" << endl
+         << "                           is >= F together [1.0; experimental]" << endl
+         << "  -n, --nested             write a nested VCF, plus special tags [experimental]" << endl
+         << "  -R, --star-allele        use *-alleles to denote alleles that span" << endl
+         << "                           but do not cross the site. Only works with -n" << endl
+         << "  -t, --threads N          use N threads" << endl
+         << "  -v, --verbose            print some status messages" << endl
+         << "  -h, --help               print this help message to stderr and exit" << endl;
 }
 
 int main_deconstruct(int argc, char** argv){
@@ -311,7 +322,8 @@ int main_deconstruct(int argc, char** argv){
     }
     if (!translation_file_name.empty()) {
         if (!translation->empty()) {
-            cerr << "Warning [vg deconstruct]: Using translation from -T overrides that in input GBZ (you probably don't want to use -T)" << endl;
+            cerr << "Warning [vg deconstruct]: Using translation from -T overrides that in input GBZ "
+                 << "(you probably don't want to use -T)" << endl;
         }
         ifstream translation_file(translation_file_name.c_str());
         if (!translation_file) {

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -98,6 +98,7 @@ int main_deconstruct(int argc, char** argv){
                 {"translation", required_argument, 0, 'T'},
                 {"gbz-translation", no_argument, 0, 'O'},                
                 {"path-traversals", no_argument, 0, 'e'},
+                {"ploidy", required_argument, 0, 'd'},
                 {"context-jaccard", required_argument, 0, 'c'},
                 {"untangle-travs", no_argument, 0, 'u'},
                 {"all-snarls", no_argument, 0, 'a'},
@@ -106,14 +107,14 @@ int main_deconstruct(int argc, char** argv){
                 {"contig-only-ref", no_argument, 0, 'C'},
                 {"cluster", required_argument, 0, 'L'},
                 {"nested", no_argument, 0, 'n'},
-                {"start-allele", no_argument, 0, 'R'},
+                {"star-allele", no_argument, 0, 'R'},
                 {"threads", required_argument, 0, 't'},
                 {"verbose", no_argument, 0, 'v'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hp:P:H:r:g:T:OeKSCd:c:uaL:nRt:v",
+        c = getopt_long (argc, argv, "h?p:P:H:r:g:T:OeKSCd:c:uaL:nRt:v",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -149,7 +150,6 @@ int main_deconstruct(int argc, char** argv){
         case 'd':
             cerr << "Warning [vg deconstruct]: -d is deprecated - ploidy now inferred from haplotypes in path names" << endl;
             break;
-            break;            
         case 'c':
             context_jaccard_window = parse<int>(optarg);
             break;

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -28,24 +28,28 @@ using namespace vg::subcommand;
 void help_depth(char** argv) {
     cerr << "usage: " << argv[0] << " depth [options] <graph>" << endl
          << "options:" << endl
-         << "  packed coverage depth (print 1-based positional depths along path):" << endl
-         << "    -k, --pack FILE        supports created from vg pack for given input graph" << endl
-         << "    -d, --count-dels       count deletion edges within the bin as covering reference positions" << endl
-         << "  GAM/GAF coverage depth (print <mean> <stddev> for depth):" << endl
-         << "    -g, --gam FILE         read alignments from this GAM file (could be '-' for stdin)" << endl
-         << "    -a, --gaf FILE         read alignments from this GAF file (could be '-' for stdin)" << endl
-         << "    -n, --max-nodes N      maximum nodes to consider [1000000]" << endl
-         << "    -s, --random-seed N    random seed for sampling nodes to consider" << endl
-         << "    -Q, --min-mapq N       ignore alignments with mapping quality < N [0]" << endl
-         << "  path coverage depth (print 1-based positional depths along path):" << endl
-         << "     activate by specifiying -p without -k" << endl
-         << "    -c, --count-cycles     count each time a path steps on a position (by default paths are only counted once)" << endl
-         << "  common options:" << endl
-         << "    -p, --ref-path NAME    reference path to call on (multipile allowed.  defaults to all paths)" << endl
-         << "    -P, --paths-by STR     select the paths with the given name prefix" << endl        
-         << "    -b, --bin-size N       bin size (in bases) [1] (2 extra columns printed when N>1: bin-end-pos and stddev)" << endl
-         << "    -m, --min-coverage N   ignore nodes with less than N coverage depth [1]" << endl
-         << "    -t, --threads N        number of threads to use [all available]" << endl;
+         << "packed coverage depth (print 1-based positional depths along path):" << endl
+         << "  -k, --pack FILE        supports created from vg pack for given input graph" << endl
+         << "  -d, --count-dels       count deletion edges within the bin" << endl
+         << "                         as covering reference positions" << endl
+         << "GAM/GAF coverage depth (print <mean> <stddev> for depth):" << endl
+         << "  -g, --gam FILE         read alignments from this GAM file ('-' for stdin)" << endl
+         << "  -a, --gaf FILE         read alignments from this GAF file ('-' for stdin)" << endl
+         << "  -n, --max-nodes N      maximum nodes to consider [1000000]" << endl
+         << "  -s, --random-seed N    random seed for sampling nodes to consider" << endl
+         << "  -Q, --min-mapq N       ignore alignments with mapping quality < N [0]" << endl
+         << "path coverage depth (print 1-based positional depths along path):" << endl
+         << "   activate by specifiying -p without -k" << endl
+         << "  -c, --count-cycles     count each time a path steps on a position" << endl
+         << "                         (by default paths are only counted once)" << endl
+         << "common options:" << endl
+         << "  -p, --ref-path NAME    reference path to call on (may repeat; defaults all)" << endl
+         << "  -P, --paths-by STR     select the paths with the given name prefix" << endl        
+         << "  -b, --bin-size N       bin size (in bases) [1]" << endl
+         << "                         2 extra columns printed when N>1: bin-end-pos & stddev" << endl
+         << "  -m, --min-coverage N   ignore nodes with less than N coverage depth [1]" << endl
+         << "  -t, --threads N        number of threads to use [all available]" << endl
+         << "  -h, --help             print this help message to stderr and exit" << endl;
 }
 
 int main_depth(int argc, char** argv) {
@@ -94,7 +98,7 @@ int main_depth(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?k:p:P:b:dg:a:n:s:Q:m:ct:",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -81,7 +81,7 @@ int main_depth(int argc, char** argv) {
             {"bin-size", required_argument, 0, 'b'},
             {"count-dels", no_argument, 0, 'd'},
             {"gam", required_argument, 0, 'g'},
-            {"gaf", no_argument, 0, 'a'},
+            {"gaf", required_argument, 0, 'a'},
             {"max-nodes", required_argument, 0, 'n'},
             {"random-seed", required_argument, 0, 's'},
             {"min-mapq", required_argument, 0, 'Q'},
@@ -93,7 +93,7 @@ int main_depth(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hk:p:P:b:dg:a:n:s:m:ct:",
+        c = getopt_long (argc, argv, "h?k:p:P:b:dg:a:n:s:Q:m:ct:",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/dotplot_main.cpp
+++ b/src/subcommand/dotplot_main.cpp
@@ -47,11 +47,12 @@ int main_dotplot(int argc, char** argv) {
         static struct option long_options[] =
         {
             {"xg", required_argument, 0, 'x'},
+            {"help", no_argument, 0, 'h'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:",
+        c = getopt_long (argc, argv, "h?x:",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/dotplot_main.cpp
+++ b/src/subcommand/dotplot_main.cpp
@@ -27,8 +27,8 @@ using namespace vg::subcommand;
 void help_dotplot(char** argv) {
     cerr << "usage: " << argv[0] << " dotplot [options]" << endl
          << "options:" << endl
-         << "  input:" << endl
-         << "    -x, --xg FILE         use the graph or the XG index FILE" << endl;
+         << "  -x, --xg FILE         use the graph or the XG index FILE" << endl
+         << "  -h, --help            print this help message to stderr and exit" << endl;
     //<< "  output:" << endl;
 }
 
@@ -53,7 +53,7 @@ int main_dotplot(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?x:",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/explode_main.cpp
+++ b/src/subcommand/explode_main.cpp
@@ -19,12 +19,12 @@ using namespace vg::subcommand;
 
 void help_explode(char** argv) {
     cerr << "usage: " << argv[0] << " explode [options] source.vg part_dir" << endl
-         << "Breaks a graph into connected components in their own files in the given directory" << endl
+         << "Breaks connected components of graph into" << endl
+         << "their own files in the given directory" << endl
          << endl
          << "options:" << endl
-         << "general:" << endl
-         << "    -t, --threads N          for tasks that can be done in parallel, use this many threads [1]" << endl
-         << "    -h, --help" << endl;
+         << "  -t, --threads N      for multithreaded tasks, use this many threads [1]" << endl
+         << "  -h, --help           print this help message to stderr and exit" << endl;
 }
 
 int main_explode(int argc, char** argv) {
@@ -48,7 +48,7 @@ int main_explode(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?t:",
-                long_options, &option_index);
+                         long_options, &option_index);
 
 
         // Detect the end of the options.
@@ -71,7 +71,8 @@ int main_explode(int argc, char** argv) {
         }
     }
 
-    cerr << "vg explode is deprecated.  Please use \"vg chunk -C source.vg -b part_dir/component\" for same* functionality as \"vg explode source.vg part_dir\"" << endl
+    cerr << "vg explode is deprecated.  Please use \"vg chunk -C source.vg -b part_dir/component\" "
+         << "for the same* functionality as \"vg explode source.vg part_dir\"" << endl
          << " * (unlike explode, the output directory must already exist when running chunk, though)" << endl;
     return 1;
 

--- a/src/subcommand/explode_main.cpp
+++ b/src/subcommand/explode_main.cpp
@@ -47,7 +47,7 @@ int main_explode(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "ht:",
+        c = getopt_long (argc, argv, "h?t:",
                 long_options, &option_index);
 
 

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -28,47 +28,66 @@ void help_filter(char** argv) {
          << "Filter alignments by properties." << endl
          << endl
          << "options:" << endl
-         << "    -M, --input-mp-alns        input is multipath alignments (GAMP) rather than GAM" << endl
-         << "    -n, --name-prefix NAME     keep only reads with this prefix in their names [default='']" << endl
-         << "    -N, --name-prefixes FILE   keep reads with names with one of many prefixes, one per nonempty line" << endl
-         << "    -e, --exact-name           match read names exactly instead of by prefix" << endl
-         << "    -a, --subsequence NAME     keep reads that contain this subsequence" << endl
-         << "    -A, --subsequences FILE    keep reads that contain one of these subsequences, one per nonempty line" << endl
-         << "    -p, --proper-pairs         keep reads that are annotated as being properly paired" << endl
-         << "    -P, --only-mapped          keep reads that are mapped" << endl
-         << "    -X, --exclude-contig REGEX drop reads with refpos annotations on contigs matching the given regex (may repeat)" << endl
-         << "    -F, --exclude-feature NAME drop reads with the given feature in the \"features\" annotation (may repeat)" << endl
-         << "    -s, --min-secondary N      minimum score to keep secondary alignment" << endl
-         << "    -r, --min-primary N        minimum score to keep primary alignment" << endl
-         << "    -L, --max-length N         drop reads with length > N" << endl
-         << "    -O, --rescore              re-score reads using default parameters and only alignment information" << endl
-         << "    -f, --frac-score           normalize score based on length" << endl
-         << "    -u, --substitutions        use substitution count instead of score" << endl
-         << "    -o, --max-overhang N       drop reads whose alignments begin or end with an insert > N [default=99999]" << endl
-         << "    -m, --min-end-matches N    drop reads that don't begin with at least N matches on each end" << endl
-         << "    -S, --drop-split           remove split reads taking nonexistent edges" << endl
-         << "    -x, --xg-name FILE         use this xg index or graph (required for -S and -D)" << endl
-         << "    -v, --verbose              print out statistics on numbers of reads dropped by what." << endl
-         << "    -V, --no-output            print out statistics (as above) but do not write out filtered GAM." << endl
-         << "    -T, --tsv-out FIELD[;FIELD] do not write filtered gam but a tsv of the given fields" << endl
-         << "                                See \"Getting alignment statistics with ‐‐tsv‐out\" wiki page" << endl
-         << "    -q, --min-mapq N           drop alignments with mapping quality < N" << endl
-         << "    -E, --repeat-ends N        drop reads with tandem repeat (motif size <= 2N, spanning >= N bases) at either end" << endl
-         << "    -D, --defray-ends N        clip back the ends of reads that are ambiguously aligned, up to N bases" << endl
-         << "    -C, --defray-count N       stop defraying after N nodes visited (used to keep runtime in check) [default=99999]" << endl
-         << "    -d, --downsample S.P       drop all but the given portion 0.P of the reads. S may be an integer seed as in SAMtools" << endl
-         << "    -R, --max-reads N          drop all but N reads. Nondeterministic on multiple threads." << endl
-         << "    -i, --interleaved          assume interleaved input. both ends will be dropped if either fails filter" << endl
-         << "    -I, --interleaved-all      assume interleaved input. both ends will be dropped if *both* fail filters" << endl
-         << "    -b, --min-base-quality Q:F drop reads with where fewer than fraction F bases have base quality >= PHRED score Q." << endl
-         << "    -G, --annotation K[:V]     keep reads if the annotation is present and not false or empty. If a value is given, keep reads if the values are equal" << endl
-         << "                               similar to running jq 'select(.annotation.K==V)' on the json" << endl 
-         << "    -c, --correctly-mapped     keep only reads that are marked as correctly-mapped" << endl
-         << "    -l, --first-alignment      keep only the first alignment for each read. Must be run with 1 thread" << endl
-         << "    -U, --complement           apply the complement of the filter implied by the other arguments." << endl
-         << "    -B, --batch-size N         work in batches of the given number of reads [default=" << vg::io::DEFAULT_PARALLEL_BATCHSIZE << "]" << endl
-         << "    -t, --threads N            number of threads [1]" << endl
-         << "        --progress             show progress" << endl;
+         << "  -M, --input-mp-alns          input is multipath alignments (GAMP), not GAM" << endl
+         << "  -n, --name-prefix NAME       keep only reads with this name prefix ['']" << endl
+         << "  -N, --name-prefixes FILE     keep reads with names with any of these prefixes," << endl
+         << "                               one per nonempty line" << endl
+         << "  -e, --exact-name             match read names exactly instead of by prefix" << endl
+         << "  -a, --subsequence NAME       keep reads that contain this subsequence" << endl
+         << "  -A, --subsequences FILE      keep reads that contain one of these subsequences" << endl
+         << "                               one per nonempty line" << endl
+         << "  -p, --proper-pairs           keep reads annotated as being properly paired" << endl
+         << "  -P, --only-mapped            keep reads that are mapped" << endl
+         << "  -X, --exclude-contig REGEX   drop reads with refpos annotations on contigs" << endl
+         << "                               matching the given regex (may repeat)" << endl
+         << "  -F, --exclude-feature NAME   drop reads with the given feature" << endl
+         << "                               in the \"features\" annotation (may repeat)" << endl
+         << "  -s, --min-secondary N        minimum score to keep secondary alignment" << endl
+         << "  -r, --min-primary N          minimum score to keep primary alignment" << endl
+         << "  -L, --max-length N           drop reads with length > N" << endl
+         << "  -O, --rescore                re-score reads using default parameters" << endl
+         << "                               and only alignment information" << endl
+         << "  -f, --frac-score             normalize score based on length" << endl
+         << "  -u, --substitutions          use substitution count instead of score" << endl
+         << "  -o, --max-overhang N         drop reads whose alignments begin or end" << endl
+         << "                               with an insert > N [99999]" << endl
+         << "  -m, --min-end-matches N      drop reads without >=N matches on each end" << endl
+         << "  -S, --drop-split             remove split reads taking nonexistent edges" << endl
+         << "  -x, --xg-name FILE           use this xg index/graph (required for -S and -D)" << endl
+         << "  -v, --verbose                print out statistics on numbers of reads dropped" << endl
+         << "  -V, --no-output              print out -v statistics and do not write the GAM" << endl
+         << "  -T, --tsv-out FIELD[;FIELD]  write TSV of given fields instead of filtered GAM" << endl
+         << "                               See wiki page:" << endl
+         << "                               \"Getting alignment statistics with ‐‐tsv‐out\"" << endl
+         << "  -q, --min-mapq N             drop alignments with mapping quality < N" << endl
+         << "  -E, --repeat-ends N          drop reads with tandem repeat (motif size <= 2N," << endl
+         << "                               spanning >= N bases) at either end" << endl
+         << "  -D, --defray-ends N          clip back the ends of ambiguously aligned reads" << endl
+         << "                               up to N bases" << endl
+         << "  -C, --defray-count N         stop defraying after N nodes visited" << endl
+         << "                               (used to keep runtime in check) [99999]" << endl
+         << "  -d, --downsample S.P         drop all but the given portion 0.P of the reads." << endl
+         << "                               S may be an integer seed as in SAMtools" << endl
+         << "  -R, --max-reads N            drop all but N reads. Use on a single thread" << endl
+         << "  -i, --interleaved            both ends will be dropped if either fails filter" << endl
+         << "                               assume interleaved input" << endl
+         << "  -I, --interleaved-all        both ends will be dropped if *both* fail filters" << endl
+         << "                               assume interleaved input" << endl
+         << "  -b, --min-base-quality Q:F   drop reads with where fewer than fraction F bases" << endl
+         << "                               have base quality >= PHRED score Q." << endl
+         << "  -G, --annotation K[:V]       keep reads if the annotation is present and " << endl
+         << "                               not false/empty. If a value is given, keep reads" << endl
+         << "                               if the values are equal similar to running" << endl 
+         << "                               jq 'select(.annotation.K==V)' on the json" << endl
+         << "  -c, --correctly-mapped       keep only reads marked as correctly-mapped" << endl
+         << "  -l, --first-alignment        keep only the first alignment for each read" << endl
+         << "                               Must be run with 1 thread" << endl
+         << "  -U, --complement             apply opposite of the filter from other arguments" << endl
+         << "  -B, --batch-size N           work in batches of N reads " 
+                                         << "[" << vg::io::DEFAULT_PARALLEL_BATCHSIZE << "]" << endl
+         << "  -t, --threads N              number of threads [1]" << endl
+         << "      --progress               show progress" << endl
+         << "  -h, --help                   print this help message to stderr and exit" << endl;
 }
 
 int main_filter(int argc, char** argv) {

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -66,7 +66,7 @@ void help_filter(char** argv) {
          << "    -c, --correctly-mapped     keep only reads that are marked as correctly-mapped" << endl
          << "    -l, --first-alignment      keep only the first alignment for each read. Must be run with 1 thread" << endl
          << "    -U, --complement           apply the complement of the filter implied by the other arguments." << endl
-         << "    -B, --batch-size           work in batches of the given number of reads [default=" << vg::io::DEFAULT_PARALLEL_BATCHSIZE << "]" << endl
+         << "    -B, --batch-size N         work in batches of the given number of reads [default=" << vg::io::DEFAULT_PARALLEL_BATCHSIZE << "]" << endl
          << "    -t, --threads N            number of threads [1]" << endl
          << "        --progress             show progress" << endl;
 }
@@ -151,8 +151,8 @@ int main_filter(int argc, char** argv) {
                 {"min-primary", required_argument, 0, 'r'},
                 {"max-length", required_argument, 0, 'L'},
                 {"rescore", no_argument, 0, 'O'},
-                {"frac-score", required_argument, 0, 'f'},
-                {"substitutions", required_argument, 0, 'u'},
+                {"frac-score", no_argument, 0, 'f'},
+                {"substitutions", no_argument, 0, 'u'},
                 {"max-overhang", required_argument, 0, 'o'},
                 {"min-end-matches", required_argument, 0, 'm'},
                 {"drop-split",  no_argument, 0, 'S'},
@@ -176,11 +176,12 @@ int main_filter(int argc, char** argv) {
                 {"batch-size", required_argument, 0, 'B'},
                 {"threads", required_argument, 0, 't'},
                 {"progress", no_argument, 0, OPT_PROGRESS},
+                {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "Mn:N:ea:A:pPX:F:s:r:L:Od:fauo:m:Sx:vVT:q:E:D:C:d:R:iIb:G:clUB:t:",
+        c = getopt_long (argc, argv, "Mn:N:ea:A:pPX:F:s:r:L:Ofuo:m:Sx:vVT:q:E:D:C:d:R:iIb:G:clUB:t:h?",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -269,6 +270,7 @@ int main_filter(int argc, char** argv) {
             break;            
         case 'S':
             drop_split = true;
+            break;
         case 'x':
             xg_name = optarg;
             break;

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -131,10 +131,10 @@ int main_find(int argc, char** argv) {
     int subgraph_k = 0;
     string gbwt_name;
 
-    #define OPT_MAPPING 1000
-    #define OPT_CONNECTING_START 1001
-    #define OPT_CONNECTING_END 1002
-    #define OPT_CONNECTING_RANGE 1003
+    constexpr int OPT_MAPPING = 1000;
+    constexpr int OPT_CONNECTING_START = 1001;
+    constexpr int OPT_CONNECTING_END = 1002;
+    constexpr int OPT_CONNECTING_RANGE = 1003;
 
     int c;
     optind = 2; // force optind past command positional argument

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -28,45 +28,57 @@ using namespace vg::io;
 void help_find(char** argv) {
     cerr << "usage: " << argv[0] << " find [options] >sub.vg" << endl
          << "options:" << endl
+         << "  -h, --help                  print this help message to stderr and exit" << endl
          << "graph features:" << endl
-         << "    -x, --xg-name FILE     use this xg index or graph (instead of rocksdb db)" << endl
-         << "    -n, --node ID          find node(s), return 1-hop context as graph" << endl
-         << "    -N, --node-list FILE   a white space or line delimited list of nodes to collect" << endl
-         << "        --mapping FILE     also include nodes that map to the selected node ids" << endl
-         << "    -e, --edges-end ID     return edges on end of node with ID" << endl
-         << "    -s, --edges-start ID   return edges on start of node with ID" << endl
-         << "    -c, --context STEPS    expand the context of the subgraph this many steps" << endl
-         << "    -L, --use-length       treat STEPS in -c or M in -r as a length in bases" << endl
-         << "    -P, --position-in PATH find the position of the node (specified by -n) in the given path" << endl
-         << "    -I, --list-paths       write out the path names in the index" << endl
-         << "    -r, --node-range N:M   get nodes from N to M" << endl
-         << "    -G, --gam GAM          accumulate the graph touched by the alignments in the GAM" << endl
-         << "    --connecting-start POS find the graph connecting from POS (node ID, + or -, node offset) to --connecting-end" << endl
-         << "    --connecting-end POS   find the graph connecting to POS (node ID, + or -, node offset) from --connecting-start" << endl
-         << "    --connecting-range INT traverse up to INT bases when going from --connecting-start to --connecting-end (default: 100)" << endl
+         << "  -x, --xg-name FILE          use this xg index or graph (instead of rocksdb db)" << endl
+         << "  -n, --node ID               find node(s), return 1-hop context as graph" << endl
+         << "  -N, --node-list FILE        whitespace or line delimited list of nodes to grab" << endl
+         << "      --mapping FILE          include nodes mapping to the selected node IDs" << endl
+         << "  -e, --edges-end ID          return edges on end of node with ID" << endl
+         << "  -s, --edges-start ID        return edges on start of node with ID" << endl
+         << "  -c, --context STEPS         expand the context of the subgraph this many steps" << endl
+         << "  -L, --use-length            treat STEPS in -c or M in -r as a length in bases" << endl
+         << "  -P, --position-in PATH      find the position of -n node in the given path" << endl
+         << "  -I, --list-paths            write out the path names in the index" << endl
+         << "  -r, --node-range N:M        get nodes from N to M" << endl
+         << "  -G, --gam GAM               accumulate the graph touched by GAM's alignments" << endl
+         << "      --connecting-start POS  find graph from POS (node ID, + or -, node offset)" << endl
+         << "                              connecteing to --connecting-end" << endl
+         << "      --connecting-end POS    find graph to POS (node ID, + or -, node offset)" << endl
+         << "                              connecting from --connecting-start" << endl
+         << "      --connecting-range INT  traverse up to INT bases when going " << endl
+         << "                              from --connecting-start to --connecting-end [100]" << endl
          << "subgraphs by path range:" << endl
-         << "    -p, --path TARGET      find the node(s) in the specified path range(s) TARGET=path[:pos1[-pos2]]" << endl
-         << "    -R, --path-bed FILE    read our targets from the given BED FILE" << endl
-         << "    -E, --path-dag         with -p or -R, gets any node in the partial order from pos1 to pos2, assumes id sorted DAG" << endl
-         << "    -W, --save-to PREFIX   instead of writing target subgraphs to stdout," << endl
-         << "                           write one per given target to a separate file named PREFIX[path]:[start]-[end].vg" << endl
-         << "    -K, --subgraph-k K     instead of graphs, write kmers from the subgraphs" << endl
-         << "    -H, --gbwt FILE        when enumerating kmers from subgraphs, determine their frequencies in this GBWT haplotype index" << endl
+         << "  -p, --path TARGET           find the node(s) in the specified path range(s)" << endl
+         << "                              TARGET=path[:pos1[-pos2]]" << endl
+         << "  -R, --path-bed FILE         read our targets from the given BED FILE" << endl
+         << "  -E, --path-dag              with -p or -R, gets any node in the partial order" << endl
+         << "                              from pos1 to pos2, assumes id sorted DAG" << endl
+         << "  -W, --save-to PREFIX        instead of writing target subgraphs to stdout," << endl
+         << "                              write one per given target to a separate file" << endl
+         << "                              named PREFIX[path]:[start]-[end].vg" << endl
+         << "  -K, --subgraph-k K          instead of graphs, write kmers from the subgraphs" << endl
+         << "  -H, --gbwt FILE             when enumerating kmers from subgraphs, determine" << endl
+         << "                              their frequencies in this GBWT haplotype index" << endl
          << "alignments:" << endl
-         << "    -l, --sorted-gam FILE  use this sorted, indexed GAM file" << endl
-         << "    -F, --sorted-gaf FILE  use this sorted, indexed GAF file" << endl
-         << "    -o, --alns-on N:M      write alignments which align to any of the nodes between N and M (inclusive)" << endl
-         << "    -A, --to-graph VG      get alignments to the provided subgraph" << endl
+         << "  -l, --sorted-gam FILE       use this sorted, indexed GAM file" << endl
+         << "  -F, --sorted-gaf FILE       use this sorted, indexed GAF file" << endl
+         << "  -o, --alns-on N:M           write alignments which align to any of the" << endl
+         << "                              nodes between N and M (inclusive)" << endl
+         << "  -A, --to-graph VG           get alignments to the provided subgraph" << endl
          << "sequences:" << endl
-         << "    -g, --gcsa FILE        use this GCSA2 index of the sequence space of the graph (required for sequence queries)" << endl
-         << "    -S, --sequence STR     search for sequence STR using" << endl
-         << "    -M, --mems STR         describe the super-maximal exact matches of the STR (gcsa2) in JSON" << endl
-         << "    -B, --reseed-length N  find non-super-maximal MEMs inside SMEMs of length at least N" << endl
-         << "    -f, --fast-reseed      use fast SMEM reseeding algorithm" << endl
-         << "    -Y, --max-mem N        the maximum length of the MEM (default: GCSA2 order)" << endl
-         << "    -Z, --min-mem N        the minimum length of the MEM (default: 1)" << endl
-         << "    -D, --distance         return distance on path between pair of nodes (-n). if -P not used, best path chosen heurstically" << endl
-         << "    -Q, --paths-named S    return all paths whose names are prefixed with S (multiple allowed)" << endl;
+         << "  -g, --gcsa FILE             use this GCSA2 index of the graph's sequence space" << endl
+         << "                              (required for sequence queries)" << endl
+         << "  -S, --sequence STR          search for sequence STR using" << endl
+         << "  -M, --mems STR              describe the super-maximal exact matches" << endl
+         << "                              of the STR (GCSA2) in JSON" << endl
+         << "  -B, --reseed-length N       find non-super-maximal MEMs inside SMEMs length>=N" << endl
+         << "  -f, --fast-reseed           use fast SMEM reseeding algorithm" << endl
+         << "  -Y, --max-mem N             maximum length of the MEM [GCSA2 order]" << endl
+         << "  -Z, --min-mem N             minimum length of the MEM [1]" << endl
+         << "  -D, --distance              return distance on path between pair of nodes (-n)" << endl
+         << "                              if -P not used, best path chosen heurstically" << endl
+         << "  -Q, --paths-named STR       return all paths with name prefix STR (may repeat)" << endl;
 
 }
 
@@ -603,7 +615,8 @@ int main_find(int argc, char** argv) {
                 cerr << "[vg find] error, exactly 2 nodes (-n) required with -D" << endl;
                 exit(1);
             }
-            cout << vg::algorithms::min_approx_path_distance(dynamic_cast<PathPositionHandleGraph*>(&*xindex), make_pos_t(node_ids[0], false, 0), make_pos_t(node_ids[1], false, 0), 1000) << endl;
+            cout << vg::algorithms::min_approx_path_distance(dynamic_cast<PathPositionHandleGraph*>(&*xindex),
+                make_pos_t(node_ids[0], false, 0), make_pos_t(node_ids[1], false, 0), 1000) << endl;
             return 0;
         }
         if (list_path_names) {
@@ -699,14 +712,17 @@ int main_find(int argc, char** argv) {
                             for (auto& p : vg::algorithms::nearest_offsets_in_paths(xindex, walk.begin, subgraph_k*2)) {
                                 const uint64_t& start_p = p.second.front().first;
                                 const bool& start_rev = p.second.front().second;
-                                if (p.first == path_handle && (!start_rev && start_p >= target.start || start_rev && start_p <= target.end)) {
-                                    start_str = target.seq + ":" + std::to_string(start_p) + (p.second.front().second ? "-" : "+");
+                                if (p.first == path_handle && (!start_rev && start_p >= target.start 
+                                                               || start_rev && start_p <= target.end)) {
+                                    start_str = target.seq + ":" + std::to_string(start_p) 
+                                                + (p.second.front().second ? "-" : "+");
                                 }
                             }
                             for (auto& p : vg::algorithms::nearest_offsets_in_paths(xindex, walk.end, subgraph_k*2)) {
                                 const uint64_t& end_p = p.second.front().first;
                                 const bool& end_rev = p.second.front().second;
-                                if (p.first == path_handle && (!end_rev && end_p <= target.end || end_rev && end_p >= target.start)) {
+                                if (p.first == path_handle && (!end_rev && end_p <= target.end 
+                                                               || end_rev && end_p >= target.start)) {
                                     end_str = target.seq + ":" + std::to_string(end_p) + (p.second.front().second ? "-" : "+");
                                 }
                             }
@@ -761,7 +777,8 @@ int main_find(int argc, char** argv) {
             nid_t id_start=0, id_end=0;
             vector<string> parts = split_delims(range, ":");
             if (parts.size() == 1) {
-                cerr << "[vg find] error, format of range must be \"N:M\" where start id is N and end id is M, got " << range << endl;
+                cerr << "[vg find] error, format of range must be \"N:M\" where start id is N and end id is M, got "
+                     << range << endl;
                 exit(1);
             }
             convert(parts.front(), id_start);
@@ -897,7 +914,8 @@ int main_find(int argc, char** argv) {
             mapper.fast_reseed = use_fast_reseed;
             // get the mems
             double lcp_avg, fraction_filtered;
-            auto mems = mapper.find_mems_deep(sequence.begin(), sequence.end(), lcp_avg, fraction_filtered, max_mem_length, min_mem_length, mem_reseed_length);
+            auto mems = mapper.find_mems_deep(sequence.begin(), sequence.end(), lcp_avg, fraction_filtered,
+                                              max_mem_length, min_mem_length, mem_reseed_length);
             
             // dump them to stdout
             cout << mems_to_json(mems) << endl;

--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -119,10 +119,10 @@ int main_find(int argc, char** argv) {
     int subgraph_k = 0;
     string gbwt_name;
 
-    constexpr int OPT_MAPPING = 1000;
-    constexpr int OPT_CONNECTING_START = 1001;
-    constexpr int OPT_CONNECTING_END = 1002;
-    constexpr int OPT_CONNECTING_RANGE = 1003;
+    #define OPT_MAPPING 1000
+    #define OPT_CONNECTING_START 1001
+    #define OPT_CONNECTING_END 1002
+    #define OPT_CONNECTING_RANGE 1003
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -165,11 +165,12 @@ int main_find(int argc, char** argv) {
                 {"list-paths", no_argument, 0, 'I'},
                 {"subgraph-k", required_argument, 0, 'K'},
                 {"gbwt", required_argument, 0, 'H'},
+                {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "x:n:e:s:o:hc:LS:p:P:r:l:F:mg:M:B:fDG:N:A:Y:Z:IQ:ER:W:K:H:",
+        c = getopt_long (argc, argv, "x:n:e:s:o:h?c:LS:p:P:r:l:F:mg:M:B:fDG:N:A:Y:Z:IQ:ER:W:K:H:",
                          long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/gamcompare_main.cpp
+++ b/src/subcommand/gamcompare_main.cpp
@@ -32,7 +32,7 @@ void help_gamcompare(char** argv) {
          << "    -I, --ignore T             ignore the given truth contig name (may repeat)" << endl
          << "    -o, --output-gam FILE      output GAM annotated with correctness to FILE instead of standard output" << endl
          << "    -T, --tsv                  output TSV (correct, mq, aligner, read) compatible with plot-qq.R to standard output" << endl
-         << "    -a, --aligner              aligner name for TSV output [\"vg\"]" << endl
+         << "    -a, --aligner STR          aligner name for TSV output [\"vg\"]" << endl
          << "    -s, --score-alignment      get a correctness score of the alignment (higher is better)" << endl
          << "    -t, --threads N            number of threads to use" << endl;
 }
@@ -125,7 +125,7 @@ int main_gamcompare(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hd:r:I:n:o:Ta:st:",
+        c = getopt_long (argc, argv, "h?d:r:I:n:o:Ta:st:",
                          long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/gamcompare_main.cpp
+++ b/src/subcommand/gamcompare_main.cpp
@@ -26,15 +26,18 @@ void help_gamcompare(char** argv) {
     cerr << "usage: " << argv[0] << " gamcompare aln.gam truth.gam >output.gam" << endl
          << endl
          << "options:" << endl
-         << "    -d, --distance-index FILE  use distances from this distance index instead of path position annotations" << endl
-         << "    -r, --range N              distance within which to consider reads correct" << endl
-         << "    -n, --rename Q=T           interpret the given query contig name as the given truth contig (may repeat)" << endl
-         << "    -I, --ignore T             ignore the given truth contig name (may repeat)" << endl
-         << "    -o, --output-gam FILE      output GAM annotated with correctness to FILE instead of standard output" << endl
-         << "    -T, --tsv                  output TSV (correct, mq, aligner, read) compatible with plot-qq.R to standard output" << endl
-         << "    -a, --aligner STR          aligner name for TSV output [\"vg\"]" << endl
-         << "    -s, --score-alignment      get a correctness score of the alignment (higher is better)" << endl
-         << "    -t, --threads N            number of threads to use" << endl;
+         << "  -d, --distance-index FILE  use distances from this distance index" << endl
+         << "                             instead of path position annotations" << endl
+         << "  -r, --range N              distance within which to consider reads correct" << endl
+         << "  -n, --rename Q=T           treat query contig Q as truth contig T (may repeat)" << endl
+         << "  -I, --ignore T             ignore the given truth contig name (may repeat)" << endl
+         << "  -o, --output-gam FILE      output GAM to FILE instead of standard output" << endl
+         << "  -T, --tsv                  output TSV (correct, mq, aligner, read)" << endl
+         << "                             compatible with plot-qq.R to standard output" << endl
+         << "  -a, --aligner STR          aligner name for TSV output [\"vg\"]" << endl
+         << "  -s, --score-alignment      get alignment correctness score (higher is better)" << endl
+         << "  -t, --threads N            number of threads to use" << endl
+         << "  -h, --help                 print this help message to stderr and exit" << endl;
 }
 
 // A gapless alignment between a read and a single node.

--- a/src/subcommand/gampcompare_main.cpp
+++ b/src/subcommand/gampcompare_main.cpp
@@ -56,13 +56,13 @@ int main_gampcompare(int argc, char** argv) {
             {"range", required_argument, 0, 'r'},
             {"gam", no_argument, 0, 'G'},
             {"aligner", required_argument, 0, 'a'},
-            {"distance", required_argument, 0, 'd'},
+            {"distance", no_argument, 0, 'd'},
             {"threads", required_argument, 0, 't'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hr:a:t:Gd",
+        c = getopt_long (argc, argv, "h?r:a:t:Gd",
                          long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/gampcompare_main.cpp
+++ b/src/subcommand/gampcompare_main.cpp
@@ -26,11 +26,12 @@ void help_gampcompare(char** argv) {
     cerr << "usage: " << argv[0] << " gampcompare [options] alngraph.xg aln.gamp truth.gam > output.tsv" << endl
          << endl
          << "options:" << endl
-         << "    -G, --gam                alignments are in GAM format rather than GAMP" << endl
-         << "    -r, --range N            distance within which to consider reads correct [100]" << endl
-         << "    -a, --aligner STR        aligner name for TSV output [\"vg\"]" << endl
-         << "    -d, --distance           report minimum distance along a path rather than correctness" << endl
-         << "    -t, --threads N          number of threads to use [1]" << endl;
+         << "  -G, --gam          alignments are in GAM format rather than GAMP" << endl
+         << "  -r, --range N      distance within which to consider reads correct [100]" << endl
+         << "  -a, --aligner STR  aligner name for TSV output [\"vg\"]" << endl
+         << "  -d, --distance     report minimum distance along path rather than correctness" << endl
+         << "  -t, --threads N    number of threads to use [1]" << endl
+         << "  -h, --help         print this help message to stderr and exit" << endl;
 }
 
 int main_gampcompare(int argc, char** argv) {
@@ -183,7 +184,8 @@ int main_gampcompare(int argc, char** argv) {
             else {
                 cout << (get<0>(result) <= range);
             }
-            cout << '\t' << get<1>(result) << '\t' << get<2>(result) << '\t' << get<3>(result) << '\t' << aligner_name << '\t' << get<4>(result) << endl;
+            cout << '\t' << get<1>(result) << '\t' << get<2>(result) << '\t' << get<3>(result) << '\t' 
+                 << aligner_name << '\t' << get<4>(result) << endl;
         }
         buffer.clear();
     };
@@ -238,7 +240,8 @@ int main_gampcompare(int argc, char** argv) {
         
         // put the result on the IO buffer
         auto& buffer = buffers[omp_get_thread_num()];
-        buffer.emplace_back(abs_dist, proto_mp_aln.subpath_size() > 0, proto_mp_aln.mapping_quality(), group_mapq, move(*proto_mp_aln.mutable_name()));
+        buffer.emplace_back(abs_dist, proto_mp_aln.subpath_size() > 0, proto_mp_aln.mapping_quality(), 
+                            group_mapq, move(*proto_mp_aln.mutable_name()));
         if (buffer.size() > buffer_size) {
 #pragma omp critical
             flush_buffer(buffer);

--- a/src/subcommand/gamsort_main.cpp
+++ b/src/subcommand/gamsort_main.cpp
@@ -90,7 +90,7 @@ int main_gamsort(int argc, char **argv)
             { 0, 0, 0, 0 }
         };
         int option_index = 0;
-        c = getopt_long(argc, argv, "pst:i:dGc:m:Sg:bh", long_options, &option_index);
+        c = getopt_long(argc, argv, "pst:i:dGc:m:Sg:bh?", long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/gamsort_main.cpp
+++ b/src/subcommand/gamsort_main.cpp
@@ -28,28 +28,33 @@ constexpr static size_t GAM_MAX_THREADS = 4;
 // Because intermediate merges are independent, we can use more threads.
 // The final single-threaded merge can use 5 bgzip threads.
 
-void help_gamsort(char **argv)
-{
+void help_gamsort(char** argv) {
     std::cerr << "usage: " << argv[0] << " " << argv[1] << " [options] input > output" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Sort a GAM/GAF file, or index a sorted GAM file." << std::endl;
     std::cerr << std::endl;
     std::cerr << "General options:" << std::endl;
-    std::cerr << "    -p, --progress          show progress" << std::endl;
-    std::cerr << "    -s, --shuffle           shuffle reads by hash" << std::endl;
-    std::cerr << "    -t, --threads N         use N worker threads (default: " << GAM_MAX_THREADS << " for GAM, " << GAFSorterParameters::THREADS << " for GAF)" << std::endl;
+    std::cerr << "  -p, --progress          show progress" << std::endl;
+    std::cerr << "  -s, --shuffle           shuffle reads by hash" << std::endl;
+    std::cerr << "  -t, --threads N         use N worker threads "
+                                        << "[" << GAM_MAX_THREADS << " for GAM, " 
+                                        << GAFSorterParameters::THREADS << " for GAF]" << std::endl;
     std::cerr << std::endl;
     std::cerr << "GAM sorting options:" << std::endl;
-    std::cerr << "    -i, --index FILE        produce an index of the sorted GAM file" << std::endl;
-    std::cerr << "    -d, --dumb-sort         use naive sorting algorithm (no tmp files, faster for small GAMs)" << std::endl;
+    std::cerr << "  -i, --index FILE        produce an index of the sorted GAM file" << std::endl;
+    std::cerr << "  -d, --dumb-sort         use naive sorting algorithm" << std::endl;
+    std::cerr << "                          (no tmp files, faster for small GAMs)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "GAF sorting options:" << std::endl;
-    std::cerr << "    -G, --gaf-input         input is a GAF file" << std::endl;
-    std::cerr << "    -c, --chunk-size N      number of reads per chunk (default: " << GAFSorterParameters::RECORDS_PER_FILE << ")" << std::endl;
-    std::cerr << "    -m, --merge-width N     number of files to merge at once (default: " << GAFSorterParameters::FILES_PER_MERGE << ")" << std::endl;
-    std::cerr << "    -S, --stable            use stable sorting" << std::endl;
-    std::cerr << "    -g, --gbwt-output FILE  write a GBWT index of the paths to FILE" << std::endl;
-    std::cerr << "    -b, --bidirectional     make the GBWT index bidirectional" << std::endl;
+    std::cerr << "  -G, --gaf-input         input is a GAF file" << std::endl;
+    std::cerr << "  -c, --chunk-size N      number of reads per chunk "
+                                        << "[" << GAFSorterParameters::RECORDS_PER_FILE << "]" << std::endl;
+    std::cerr << "  -m, --merge-width N     number of files to merge at once "
+                                        << "[" << GAFSorterParameters::FILES_PER_MERGE << "]" << std::endl;
+    std::cerr << "  -S, --stable            use stable sorting" << std::endl;
+    std::cerr << "  -g, --gbwt-output FILE  write a GBWT index of the paths to FILE" << std::endl;
+    std::cerr << "  -b, --bidirectional     make the GBWT index bidirectional" << std::endl;
+    std::cerr << "  -h, --help              print this help message to stderr and exit" << endl;
     std::cerr << std::endl;
 }
 

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -288,7 +288,6 @@ void help_gbwt(char** argv) {
     std::cerr << "        --path-fields X     parse metadata as haplotypes, mapping regex submatches to these fields instead of using vg-parser-compatible rules" << std::endl;
     std::cerr << "        --translation FILE  write the segment to node translation table to FILE" << std::endl;
     std::cerr << "    -Z, --gbz-input         extract GBWT and GBWTGraph from GBZ input (one input arg)" << std::endl;
-    std::cerr << "        --translation FILE  write the segment to node translation table to FILE" << std::endl;
     std::cerr << "    -I, --gg-in FILE        load GBWTGraph from FILE and GBWT from input (one input arg) " << std::endl;
     std::cerr << "    -E, --index-paths       index the embedded non-alt paths in the graph (requires -x, no input args)" << std::endl;
     std::cerr << "    -A, --alignment-input   index the alignments in the GAF files specified in input args (requires -x)" << std::endl;

--- a/src/subcommand/gbwt_main.cpp
+++ b/src/subcommand/gbwt_main.cpp
@@ -246,95 +246,122 @@ int main_gbwt(int argc, char** argv) {
 void help_gbwt(char** argv) {
     std::cerr << "usage: " << argv[0] << " gbwt [options] [args]" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Manipulate GBWTs. Input GBWTs are loaded from input args or built in earlier steps." << std::endl;
+    std::cerr << "Manipulate GBWTs. Input GBWTs are loaded from input args" << std::endl;
+    std::cerr << "or built in earlier steps. See wiki page \"VG GBWT Subcommand\"." << std::endl;
     std::cerr << "The input graph is provided with one of -x, -G, or -Z" << std::endl;
     std::cerr << std::endl;
     std::cerr << "General options:" << std::endl;
-    std::cerr << "    -x, --xg-name FILE      read the graph from FILE" << std::endl;
-    std::cerr << "    -o, --output FILE       write output GBWT to FILE" << std::endl;
-    std::cerr << "    -d, --temp-dir DIR      use directory DIR for temporary files" << std::endl;
-    std::cerr << "    -p, --progress          show progress and statistics" << std::endl;
+    std::cerr << "  -h, --help              print this help message to stderr and exit" << std::endl;
+    std::cerr << "  -x, --xg-name FILE      read the graph from FILE" << std::endl;
+    std::cerr << "  -o, --output FILE       write output GBWT to FILE" << std::endl;
+    std::cerr << "  -d, --temp-dir DIR      use directory DIR for temporary files" << std::endl;
+    std::cerr << "  -p, --progress          show progress and statistics" << std::endl;
     std::cerr << std::endl;
     std::cerr << "GBWT construction parameters (for steps 1 and 4):" << std::endl;
-    std::cerr << "        --buffer-size N     GBWT construction buffer size in millions of nodes (default " << (gbwt::DynamicGBWT::INSERT_BATCH_SIZE / gbwt::MILLION) << ")" << std::endl;
-    std::cerr << "        --id-interval N     store path ids at one out of N positions (default " << gbwt::DynamicGBWT::SAMPLE_INTERVAL << ")" << std::endl;
+    std::cerr << "      --buffer-size N     construction buffer size in millions of nodes"
+                                        <<  "[" << (gbwt::DynamicGBWT::INSERT_BATCH_SIZE / gbwt::MILLION) << "]" << std::endl;
+    std::cerr << "      --id-interval N     store path IDs at 1/N positions "
+                                        << "[" << gbwt::DynamicGBWT::SAMPLE_INTERVAL << "]" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Multithreading:" << std::endl;
-    std::cerr << "        --num-jobs N        use at most N parallel build jobs (for -v, -G, -A, -l, -P; default " << GBWTConfig::default_build_jobs() << ")" << std::endl;
-    std::cerr << "        --num-threads N     use N parallel search threads (for -b and -r; default " << omp_get_max_threads() << ")" << std::endl;
+    std::cerr << "      --num-jobs N        use at most N parallel build jobs" << std::endl;
+    std::cerr << "                          (for -v, -G, -A, -l, -P) " 
+                                        << "[" << GBWTConfig::default_build_jobs() << "]" << std::endl;
+    std::cerr << "      --num-threads N     use N parallel search threads" << std::endl;
+    std::cerr << "                          (for -b and -r) [" << omp_get_max_threads() << "]" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 1: GBWT construction (requires -o and one of { -v, -G, -Z, -E, A }):" << std::endl;
-    std::cerr << "    -v, --vcf-input         index the haplotypes in the VCF files specified in input args in parallel" << std::endl;
-    std::cerr << "                            (inputs must be over different contigs; requires -x, implies -f)" << std::endl;
-    std::cerr << "                            (does not store graph contigs in the GBWT)" << std::endl;
-    std::cerr << "        --preset X          use preset X (available: 1000gp)" << std::endl;
-    std::cerr << "        --inputs-as-jobs    create one build job for each input instead of using first-fit heuristic" << std::endl;
-    std::cerr << "        --parse-only        store the VCF parses without building GBWTs" << std::endl;
-    std::cerr << "                            (use -o for the file name prefix; skips subsequent steps)" << std::endl;
-    std::cerr << "        --ignore-missing    do not warn when variants are missing from the graph" << std::endl;
-    std::cerr << "        --actual-phasing    do not interpret unphased homozygous genotypes as phased" << std::endl;
-    std::cerr << "        --force-phasing     replace unphased genotypes with randomly phased ones" << std::endl;
-    std::cerr << "        --discard-overlaps  skip overlapping alternate alleles if the overlap cannot be resolved" << std::endl;
-    std::cerr << "                            instead of creating a phase break" << std::endl;
-    std::cerr << "        --batch-size N      index the haplotypes in batches of N samples (default 200)" << std::endl; // FIXME source for the default
-    std::cerr << "        --sample-range X-Y  index samples X to Y (inclusive, 0-based)" << std::endl;
-    std::cerr << "        --rename V=P        VCF contig V matches path P in the graph (may repeat)" << std::endl;
-    std::cerr << "        --vcf-variants      variants in the graph use VCF contig names instead of path names" << std::endl;
-    std::cerr << "        --vcf-region C:X-Y  restrict VCF contig C to coordinates X to Y (inclusive, 1-based; may repeat)" << std::endl;
-    std::cerr << "        --exclude-sample X  do not index the sample with name X (faster than -R; may repeat)" << std::endl;
-    std::cerr << "    -G, --gfa-input         index the walks or paths in the GFA file (one input arg)" << std::endl;
-    std::cerr << "        --max-node N        chop long segments into nodes of at most N bp (default " << gbwtgraph::MAX_NODE_LENGTH << ", use 0 to disable)" << std::endl;
-    std::cerr << "        --path-regex X      parse metadata as haplotypes from path names using regex X instead of vg-parser-compatible rules" << std::endl;
-    std::cerr << "        --path-fields X     parse metadata as haplotypes, mapping regex submatches to these fields instead of using vg-parser-compatible rules" << std::endl;
-    std::cerr << "        --translation FILE  write the segment to node translation table to FILE" << std::endl;
-    std::cerr << "    -Z, --gbz-input         extract GBWT and GBWTGraph from GBZ input (one input arg)" << std::endl;
-    std::cerr << "    -I, --gg-in FILE        load GBWTGraph from FILE and GBWT from input (one input arg) " << std::endl;
-    std::cerr << "    -E, --index-paths       index the embedded non-alt paths in the graph (requires -x, no input args)" << std::endl;
-    std::cerr << "    -A, --alignment-input   index the alignments in the GAF files specified in input args (requires -x)" << std::endl;
-    std::cerr << "        --gam-format        the input files are in GAM format instead of GAF format" << std::endl;
+    std::cerr << "  -v, --vcf-input         index the haplotypes in the VCF files specified in" << std::endl;
+    std::cerr << "                          input args in parallel (requires -x, implies -f);" << std::endl;
+    std::cerr << "                          (inputs must be over different contigs," << std::endl;
+    std::cerr << "                          does not store graph contigs in the GBWT)" << std::endl;
+    std::cerr << "      --preset X          use preset X (available: 1000gp)" << std::endl;
+    std::cerr << "      --inputs-as-jobs    create one build job for each input" << std::endl;
+    std::cerr << "                          instead of using first-fit heuristic" << std::endl;
+    std::cerr << "      --parse-only        store the VCF parses without building GBWTs" << std::endl;
+    std::cerr << "                          (use -o for file name prefix; skips later steps)" << std::endl;
+    std::cerr << "      --ignore-missing    don't warn when variants are missing from the graph" << std::endl;
+    std::cerr << "      --actual-phasing    don't treat unphased homozygous genotypes as phased" << std::endl;
+    std::cerr << "      --force-phasing     replace unphased genotypes with randomly phased ones" << std::endl;
+    std::cerr << "      --discard-overlaps  skip overlapping alternate alleles if the overlap" << std::endl;
+    std::cerr << "                          cannot be resolved instead of creating a phase break" << std::endl;
+    // FIXME source for the default
+    std::cerr << "      --batch-size N      index the haplotypes in batches of N samples [200]" << std::endl; 
+    std::cerr << "      --sample-range X-Y  index samples X to Y (inclusive, 0-based)" << std::endl;
+    std::cerr << "      --rename V=P        VCF contig V matches path P in the graph (may repeat)" << std::endl;
+    std::cerr << "      --vcf-variants      variants in graph use VCF contig names, not path names" << std::endl;
+    std::cerr << "      --vcf-region C:X-Y  restrict VCF contig C to coordinates X to Y" << std::endl;
+    std::cerr << "                          (inclusive, 1-based; may repeat)" << std::endl;
+    std::cerr << "      --exclude-sample X  do not index the sample with name X" << std::endl;
+    std::cerr << "                          (faster than -R; may repeat)" << std::endl;
+    std::cerr << "  -G, --gfa-input         index walks or paths in the GFA file (one input arg)" << std::endl;
+    std::cerr << "      --max-node N        chop long segments into nodes of at most N bp" << std::endl;
+    std::cerr << "                          (use 0 to disable) [" << gbwtgraph::MAX_NODE_LENGTH << "]" << std::endl;
+    std::cerr << "      --path-regex X      parse metadata as haplotypes from path names" << std::endl;
+    std::cerr << "                          using regex X instead of vg-parser-compatible rules" << std::endl;
+    std::cerr << "      --path-fields X     parse metadata as haplotypes, mapping regex submatches" << std::endl;
+    std::cerr << "                          to these fields instead of vg-parser-compatible rules" << std::endl;
+    std::cerr << "      --translation FILE  write the segment to node translation table to FILE" << std::endl;
+    std::cerr << "  -Z, --gbz-input         extract GBWT & GBWTGraph from GBZ from (one) input arg" << std::endl;
+    std::cerr << "  -I, --gg-in FILE        load GBWTGraph from FILE and GBWT from (one) input arg" << std::endl;
+    std::cerr << "  -E, --index-paths       index the embedded non-alt paths in the graph" << std::endl;
+    std::cerr << "                          (requires -x, no input args)" << std::endl;
+    std::cerr << "  -A, --alignment-input   index the alignments in the GAF files specified" << std::endl;
+    std::cerr << "                          in input args (requires -x)" << std::endl;
+    std::cerr << "      --gam-format        input files are in GAM format instead of GAF format" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 2: Merge multiple input GBWTs (requires -o):" << std::endl;
-    std::cerr << "    -m, --merge             use the insertion algorithm" << std::endl;
-    std::cerr << "    -f, --fast              fast merging algorithm (node ids must not overlap)" << std::endl;
-    std::cerr << "    -b, --parallel          use the parallel algorithm" << std::endl;
-    std::cerr << "        --chunk-size N      search in chunks of N sequences (default " << gbwt::MergeParameters::CHUNK_SIZE << ")" << std::endl;
-    std::cerr << "        --pos-buffer N      use N MiB position buffers for each search thread (default " << gbwt::MergeParameters::POS_BUFFER_SIZE << ")" << std::endl;
-    std::cerr << "        --thread-buffer N   use N MiB thread buffers for each search thread (default " << gbwt::MergeParameters::THREAD_BUFFER_SIZE << ")" << std::endl;
-    std::cerr << "        --merge-buffers N   merge 2^N thread buffers into one file per merge job (default " << gbwt::MergeParameters::MERGE_BUFFERS << ")" << std::endl;
-    std::cerr << "        --merge-jobs N      run N parallel merge jobs (default " << GBWTConfig::default_merge_jobs() << ")" << std::endl;
+    std::cerr << "  -m, --merge             use the insertion algorithm" << std::endl;
+    std::cerr << "  -f, --fast              fast merging algorithm (node ids must not overlap)" << std::endl;
+    std::cerr << "  -b, --parallel          use the parallel algorithm" << std::endl;
+    std::cerr << "      --chunk-size N      search in chunks of N sequences "
+                                        << "[" << gbwt::MergeParameters::CHUNK_SIZE << "]" << std::endl;
+    std::cerr << "      --pos-buffer N      use N MiB position buffers for each search thread "
+                                        << "[" << gbwt::MergeParameters::POS_BUFFER_SIZE << "]" << std::endl;
+    std::cerr << "      --thread-buffer N   use N MiB thread buffers for each search thread "
+                                        << "[" << gbwt::MergeParameters::THREAD_BUFFER_SIZE << "]" << std::endl;
+    std::cerr << "      --merge-buffers N   merge 2^N thread buffers into one file per merge "
+                                        << "[" << gbwt::MergeParameters::MERGE_BUFFERS << "]" << std::endl;
+    std::cerr << "      --merge-jobs N      run N parallel merge jobs "
+                                        << "[" << GBWTConfig::default_merge_jobs() << "]" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 3: Alter GBWT (requires -o and one input GBWT):" << std::endl;
-    std::cerr << "    -R, --remove-sample X   remove the sample with name X from the index (may repeat)" << std::endl;
-    std::cerr << "        --set-tag K=V       set a GBWT tag (may repeat)" << std::endl;
-    std::cerr << "        --set-reference X   set sample X as the reference (may repeat)" << std::endl;
+    std::cerr << "  -R, --remove-sample X   remove sample X from the index (may repeat)" << std::endl;
+    std::cerr << "      --set-tag K=V       set a GBWT tag (may repeat)" << std::endl;
+    std::cerr << "      --set-reference X   set sample X as the reference (may repeat)" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Step 4: Path cover GBWT construction (requires an input graph, -o, and one of { -a, -l, -P }):" << std::endl;
-    std::cerr << "    -a, --augment-gbwt      add a path cover of missing components (one input GBWT)" << std::endl;
-    std::cerr << "    -l, --local-haplotypes  sample local haplotypes (one input GBWT)" << std::endl;
-    std::cerr << "    -P, --path-cover        build a greedy path cover (no input GBWTs)" << std::endl;
-    std::cerr << "    -n, --num-paths N       find N paths per component (default " << GBWTConfig::default_num_paths_local() << " for -l, " << GBWTConfig::default_num_paths() << " otherwise)" << std::endl;
-    std::cerr << "    -k, --context-length N  use N-node contexts (default " << GBWTConfig::default_context_length() << ")" << std::endl;
-    std::cerr << "        --pass-paths        include named graph paths in local haplotype or greedy path cover GBWT" << std::endl;
+    std::cerr << "Step 4: Path cover GBWT construction " << std::endl;
+    std::cerr << "(requires an input graph, -o, and one of { -a, -l, -P }):" << std::endl;
+    std::cerr << "  -a, --augment-gbwt      add path cover of missing components (one input GBWT)" << std::endl;
+    std::cerr << "  -l, --local-haplotypes  sample local haplotypes (one input GBWT)" << std::endl;
+    std::cerr << "  -P, --path-cover        build a greedy path cover (no input GBWTs)" << std::endl;
+    std::cerr << "  -n, --num-paths N       find N paths per component"
+                                         << "[" << GBWTConfig::default_num_paths_local() << " for -l, " 
+                                         << GBWTConfig::default_num_paths() << " otherwise]" << std::endl;
+    std::cerr << "  -k, --context-length N  use N-node contexts [" << GBWTConfig::default_context_length() << "]" << std::endl;
+    std::cerr << "      --pass-paths        include named graph paths in local haplotype" << std::endl;
+    std::cerr << "                          or greedy path cover GBWT" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 5: GBWTGraph construction (requires an input graph and one input GBWT):" << std::endl;
-    std::cerr << "    -g, --graph-name FILE   build GBWTGraph and store it in FILE" << std::endl;
-    std::cerr << "        --gbz-format        serialize both GBWT and GBWTGraph in GBZ format (makes -o unnecessary)" << std::endl;
+    std::cerr << "  -g, --graph-name FILE   build GBWTGraph and store it in FILE" << std::endl;
+    std::cerr << "      --gbz-format        serialize both GBWT and GBWTGraph in GBZ format" << std::endl;
+    std::cerr << "                          (makes -o unnecessary)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 6: R-index construction (one input GBWT):" << std::endl;
-    std::cerr << "    -r, --r-index FILE      build an r-index and store it in FILE" << std::endl;
+    std::cerr << "  -r, --r-index FILE      build an r-index and store it in FILE" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 7: Metadata (one input GBWT):" << std::endl;
-    std::cerr << "    -M, --metadata          print basic metadata" << std::endl;
-    std::cerr << "    -C, --contigs           print the number of contigs" << std::endl;
-    std::cerr << "    -H, --haplotypes        print the number of haplotypes" << std::endl;
-    std::cerr << "    -S, --samples           print the number of samples" << std::endl;
-    std::cerr << "    -L, --list-names        list contig/sample names (use with -C or -S)" << std::endl;
-    std::cerr << "    -T, --path-names        list path names" << std::endl;
-    std::cerr << "        --tags              list GBWT tags" << std::endl;
+    std::cerr << "  -M, --metadata          print basic metadata" << std::endl;
+    std::cerr << "  -C, --contigs           print the number of contigs" << std::endl;
+    std::cerr << "  -H, --haplotypes        print the number of haplotypes" << std::endl;
+    std::cerr << "  -S, --samples           print the number of samples" << std::endl;
+    std::cerr << "  -L, --list-names        list contig/sample names (use with -C or -S)" << std::endl;
+    std::cerr << "  -T, --path-names        list path names" << std::endl;
+    std::cerr << "      --tags              list GBWT tags" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Step 8: Paths (one input GBWT):" << std::endl;
-    std::cerr << "    -c, --count-paths       print the number of paths" << std::endl;
-    std::cerr << "    -e, --extract FILE      extract paths in SDSL format to FILE" << std::endl;
+    std::cerr << "  -c, --count-paths       print the number of paths" << std::endl;
+    std::cerr << "  -e, --extract FILE      extract paths in SDSL format to FILE" << std::endl;
     std::cerr << std::endl;
 }
 
@@ -370,11 +397,13 @@ void no_multiple_cover_types(const GBWTConfig& config) {
     }
 }
 
-void check_tag_validity(const std::string& key, const std::string& value, const std::unordered_set<char>& prohibited, const std::string& description) {
+void check_tag_validity(const std::string& key, const std::string& value, 
+                        const std::unordered_set<char>& prohibited, const std::string& description) {
     for (auto& letter : value) {
         if (prohibited.count(letter)) {
             // This letter isn't allowed.
-            std::cerr << "error: [vg gbwt] tag \"" << key << "\" contains prohibited character \"" << letter << "\". It needs to be " << description << " and may not contain any of:";
+            std::cerr << "error: [vg gbwt] tag \"" << key << "\" contains prohibited character \"" << letter 
+                      << "\". It needs to be " << description << " and may not contain any of:";
             for (auto& c : prohibited) {
                 std::cerr << " '" << c << "'";
             }
@@ -431,7 +460,8 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
     // Make a collection of all the known tags and their descriptions. Use an ordered map so that we can do some typo guessing.
     // Values are description and list of prohibited characters.
     const std::map<std::string, std::pair<std::string, std::unordered_set<char>>> KNOWN_TAGS = {
-        {gbwtgraph::REFERENCE_SAMPLE_LIST_GBWT_TAG, {"a space-separated list of PanSN-valid sample/assembly names of references in the graph", {'#'}}}
+        {gbwtgraph::REFERENCE_SAMPLE_LIST_GBWT_TAG, 
+            {"a space-separated list of PanSN-valid sample/assembly names of references in the graph", {'#'}}}
     };
 
     static struct option long_options[] =
@@ -780,7 +810,9 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
                     // Tag is either known, or is unknown but there's a known tag to compare it with.
                     if (tag_name != tag_record->first) {
                         // This is an unknown tag, but we have an idea what it should be.
-                        std::cerr << "warning: [vg gbwt] tag \"" << tag_name << "\" is not a tag with a meaning recognized by vg; maybe you meant \"" << tag_record->first << "\" which would be " << tag_description << std::endl;
+                        std::cerr << "warning: [vg gbwt] tag \"" << tag_name 
+                                  << "\" is not a tag with a meaning recognized by vg; maybe you meant \""
+                                  << tag_record->first << "\" which would be " << tag_description << std::endl;
                     } else {
                         // This is a known tag, so validate it.
                         check_tag_validity(tag_name, tag_value, tag_prohibited_characters, tag_description);
@@ -933,13 +965,15 @@ GBWTConfig parse_gbwt_config(int argc, char** argv) {
 void validate_gbwt_config(GBWTConfig& config) {
     // We can either write GBWT in SDSL format to a separate file or with GBWTGraph in GBZ format.
     // However, `--parse-only` uses `gbwt_output` for other purposes.
-    bool has_gbwt_output = !config.gbwt_output.empty() || (config.gbz_format && !config.graph_output.empty() && !config.parse_only);
+    bool has_gbwt_output = (!config.gbwt_output.empty() 
+                         || (config.gbz_format && !config.graph_output.empty() && !config.parse_only));
 
     // We have one input GBWT after steps 1-4.
     bool one_input_gbwt = config.input_filenames.size() == 1 || config.produces_one_gbwt;
 
     // We can load a PathHandleGraph from a file, get a SequenceSource from parsing GFA, or get a GBWTGraph from GBZ or GG/GBWT.
-    bool has_graph_input = !config.graph_name.empty() || config.build == GBWTConfig::build_gfa || config.build == GBWTConfig::build_gbz || config.build == GBWTConfig::build_gbwtgraph;
+    bool has_graph_input = (!config.graph_name.empty() || config.build == GBWTConfig::build_gfa 
+                          || config.build == GBWTConfig::build_gbz || config.build == GBWTConfig::build_gbwtgraph);
 
     if (config.build == GBWTConfig::build_gbz) {
         // If we "build" a GBWT by loading it from a GBZ, we just need to make
@@ -1034,7 +1068,8 @@ void validate_gbwt_config(GBWTConfig& config) {
     }
 
     if (config.path_cover != GBWTConfig::path_cover_none) {
-        if (!has_gbwt_output || (config.graph_name.empty() && config.build != GBWTConfig::build_gbz && config.build != GBWTConfig::build_gbwtgraph)) {
+        if (!has_gbwt_output || (config.graph_name.empty() && config.build != GBWTConfig::build_gbz 
+                                 && config.build != GBWTConfig::build_gbwtgraph)) {
             // Path cover options needs a graph. We can use the provided graph or the GBZ/GBWTGraph
             // we took as an input. In the latter case, we know that the corresponding GBWT has not
             // been modified and the graph is hence safe to use.
@@ -1045,7 +1080,8 @@ void validate_gbwt_config(GBWTConfig& config) {
             std::cerr << "error: [vg gbwt] greedy path cover does not use input GBWTs" << std::endl;
             std::exit(EXIT_FAILURE);
         }
-        if ((config.path_cover == GBWTConfig::path_cover_local || config.path_cover == GBWTConfig::path_cover_augment) && !(config.input_filenames.size() == 1 || config.merge != GBWTConfig::merge_none)) {
+        if ((config.path_cover == GBWTConfig::path_cover_local || config.path_cover == GBWTConfig::path_cover_augment)
+            && !(config.input_filenames.size() == 1 || config.merge != GBWTConfig::merge_none)) {
             std::cerr << "error: [vg gbwt] path cover options -a and -l require one input GBWT" << std::endl;
             std::exit(EXIT_FAILURE);
         }
@@ -1054,7 +1090,8 @@ void validate_gbwt_config(GBWTConfig& config) {
             std::exit(EXIT_FAILURE);
         }
         if (config.context_length < gbwtgraph::PATH_COVER_MIN_K) {
-            std::cerr << "error: [vg gbwt] context length must be at least " << gbwtgraph::PATH_COVER_MIN_K << " for path cover" << std::endl;
+            std::cerr << "error: [vg gbwt] context length must be at least "
+                      << gbwtgraph::PATH_COVER_MIN_K << " for path cover" << std::endl;
             std::exit(EXIT_FAILURE);
         }
     }
@@ -1232,7 +1269,8 @@ std::vector<job_type> determine_jobs(std::unique_ptr<PathHandleGraph>& graph, co
                 continue;
             }
             if (path_found_in[j] < config.input_filenames.size()) {
-                std::cerr << "error: [vg gbwt] contig " << contig_name << " found in files " << config.input_filenames[path_found_in[j]] << " and " << filename << std::endl;
+                std::cerr << "error: [vg gbwt] contig " << contig_name << " found in files " 
+                          << config.input_filenames[path_found_in[j]] << " and " << filename << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             paths_by_file[i].insert(paths[j]);
@@ -1286,7 +1324,8 @@ std::vector<job_type> determine_jobs(std::unique_ptr<PathHandleGraph>& graph, co
     return result;
 }
 
-void use_or_save(std::unique_ptr<gbwt::DynamicGBWT>& index, GBWTHandler& gbwts, std::vector<std::string>& filenames, size_t i, bool show_progress) {
+void use_or_save(std::unique_ptr<gbwt::DynamicGBWT>& index, GBWTHandler& gbwts,
+                 std::vector<std::string>& filenames, size_t i, bool show_progress) {
     if (filenames.size() == 1) {
         gbwts.use(*index);
     } else {
@@ -1308,7 +1347,8 @@ void step_1_build_gbwts(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& co
         std::cerr << "Building input GBWTs" << std::endl;
     }
     gbwts.unbacked(); // We will build a new GBWT.
-    if (config.build != GBWTConfig::build_gfa && config.build != GBWTConfig::build_gbz && config.build != GBWTConfig::build_gbwtgraph) {
+    if (config.build != GBWTConfig::build_gfa && config.build != GBWTConfig::build_gbz 
+        && config.build != GBWTConfig::build_gbwtgraph) {
         graphs.get_graph(config);
     }
 
@@ -1324,7 +1364,8 @@ void step_1_build_gbwts(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& co
         }
         std::vector<std::vector<std::string>> vcf_parses(jobs.size());
         if (config.show_progress) {
-            std::cerr << "Parsing " << jobs.size() << " VCF files using up to " << config.build_jobs << " parallel jobs" << std::endl;
+            std::cerr << "Parsing " << jobs.size() << " VCF files using up to " 
+                      << config.build_jobs << " parallel jobs" << std::endl;
         }
         #pragma omp parallel for schedule(dynamic, 1)
         for (size_t i = 0; i < jobs.size(); i++) {
@@ -1339,13 +1380,15 @@ void step_1_build_gbwts(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& co
                     std::cerr << " }" << std::endl;
                 }
             }
-            vcf_parses[i] = config.haplotype_indexer.parse_vcf(jobs[i].filename, *(graphs.path_graph), jobs[i].paths, job_name);
+            vcf_parses[i] = config.haplotype_indexer.parse_vcf(
+                jobs[i].filename, *(graphs.path_graph), jobs[i].paths, job_name);
         }
         graphs.clear(); // Delete the graph to save memory.
         if (!config.parse_only) {
             std::vector<std::string> gbwt_files(vcf_parses.size(), "");
             if (config.show_progress) {
-                std::cerr << "Building " << vcf_parses.size() << " GBWTs using up to " << config.build_jobs << " parallel jobs" << std::endl;
+                std::cerr << "Building " << vcf_parses.size() << " GBWTs using up to " 
+                          << config.build_jobs << " parallel jobs" << std::endl;
             }
             #pragma omp parallel for schedule(dynamic, 1)
             for (size_t i = 0; i < vcf_parses.size(); i++) {
@@ -1389,7 +1432,8 @@ void step_1_build_gbwts(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& co
             std::cerr << "Input type: " << (config.gam_format ? "GAM" : "GAF") << std::endl;
         }
         std::unique_ptr<gbwt::GBWT> temp =
-            config.haplotype_indexer.build_gbwt(*(graphs.path_graph), config.input_filenames, (config.gam_format ? "GAM" : "GAF"), config.build_jobs);
+            config.haplotype_indexer.build_gbwt(*(graphs.path_graph), config.input_filenames, 
+                                                (config.gam_format ? "GAM" : "GAF"), config.build_jobs);
         gbwts.use(*temp);
     }
 
@@ -1411,7 +1455,8 @@ void step_2_merge_gbwts(GBWTHandler& gbwts, GBWTConfig& config) {
         } else if (config.merge == GBWTConfig::merge_parallel) {
             algo_name = "parallel";
         }
-        std::cerr << "Merging " << config.input_filenames.size() << " input GBWTs (" << algo_name << " algorithm)" << std::endl;
+        std::cerr << "Merging " << config.input_filenames.size() << " input GBWTs (" 
+                  << algo_name << " algorithm)" << std::endl;
     }
 
     if (config.merge == GBWTConfig::merge_fast) {
@@ -1431,11 +1476,13 @@ void step_2_merge_gbwts(GBWTHandler& gbwts, GBWTConfig& config) {
             gbwt::GBWT next;
             load_gbwt(next, config.input_filenames[i], config.show_progress);
             if (next.size() > 2 * gbwts.dynamic.size()) {
-                std::cerr << "warning: [vg gbwt] merging " << config.input_filenames[i] << " into a substantially smaller index" << std::endl;
+                std::cerr << "warning: [vg gbwt] merging " << config.input_filenames[i] 
+                          << " into a substantially smaller index" << std::endl;
                 std::cerr << "warning: [vg gbwt] merging would be faster in another order" << std::endl;
             }
             if (config.show_progress) {
-                std::cerr << "Inserting " << next.sequences() << " sequences of total length " << next.size() << std::endl;
+                std::cerr << "Inserting " << next.sequences() << " sequences of total length " 
+                          << next.size() << std::endl;
             }
             gbwts.dynamic.merge(next);
         }
@@ -1447,7 +1494,8 @@ void step_2_merge_gbwts(GBWTHandler& gbwts, GBWTConfig& config) {
             gbwt::DynamicGBWT next;
             load_gbwt(next, config.input_filenames[i], config.show_progress);
             if (next.size() > 2 * gbwts.dynamic.size()) {
-                std::cerr << "warning: [vg gbwt] merging " << config.input_filenames[i] << " into a substantially smaller index" << std::endl;
+                std::cerr << "warning: [vg gbwt] merging " << config.input_filenames[i] 
+                          << " into a substantially smaller index" << std::endl;
                 std::cerr << "warning: [vg gbwt] merging would be faster in another order" << std::endl;
             }
             if (config.show_progress) {
@@ -1473,7 +1521,8 @@ void remove_samples(GBWTHandler& gbwts, GBWTConfig& config) {
     }
 
     gbwts.use_dynamic();
-    if (!(gbwts.dynamic.hasMetadata() && gbwts.dynamic.metadata.hasPathNames() && gbwts.dynamic.metadata.hasSampleNames())) {
+    if (!(gbwts.dynamic.hasMetadata() && gbwts.dynamic.metadata.hasPathNames() 
+          && gbwts.dynamic.metadata.hasSampleNames())) {
         std::cerr << "error: [vg gbwt] the index does not contain metadata with path and sample names" << std::endl;
         std::exit(EXIT_FAILURE);
     }
@@ -1540,7 +1589,8 @@ void step_3_alter_gbwt(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& con
 void step_4_path_cover(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& config) {
     double start = gbwt::readTimer();
     if (config.show_progress) {
-        std::cerr << "Finding a " << config.num_paths << "-path cover with context length " << config.context_length << std::endl;
+        std::cerr << "Finding a " << config.num_paths << "-path cover with context length " 
+                  << config.context_length << std::endl;
     }
 
     // Select the appropriate graph.
@@ -1605,7 +1655,8 @@ void step_5_gbwtgraph(GBWTHandler& gbwts, GraphHandler& graphs, GBWTConfig& conf
         if (config.show_progress) {
             std::cerr << "Starting the construction" << std::endl;
         }
-        graph = gbwtgraph::GBWTGraph(gbwts.compressed, *(graphs.path_graph), vg::algorithms::find_translation(graphs.path_graph.get()));
+        graph = gbwtgraph::GBWTGraph(gbwts.compressed, *(graphs.path_graph), 
+                                     vg::algorithms::find_translation(graphs.path_graph.get()));
     }
     if (config.gbz_format) {
         save_gbz(gbwts.compressed, graph, config.graph_output, config.show_progress);

--- a/src/subcommand/genotype_main.cpp
+++ b/src/subcommand/genotype_main.cpp
@@ -19,21 +19,21 @@ void help_genotype(char** argv) {
          << "options:" << endl
          << "    -j, --json              output in JSON" << endl
          << "    -v, --vcf               output in VCF" << endl
-         << "    -V, --recall-vcf VCF    recall variants in a specific VCF file." << endl
-         << "    -F, --fasta  FASTA" << endl
-         << "    -I, --insertions INS" << endl
+         << "    -V, --recall-vcf FILE   recall variants in a specific VCF file." << endl
+         << "    -F, --fasta FILE" << endl
+         << "    -I, --insertions FILE" << endl
          << "    -r, --ref PATH          use the given path name as the reference path" << endl
          << "    -c, --contig NAME       use the given name as the VCF contig name" << endl
          << "    -s, --sample NAME       name the sample in the VCF with the given name" << endl
          << "    -o, --offset INT        offset variant positions by this amount" << endl
          << "    -l, --length INT        override total sequence length" << endl
          << "    -a, --augmented FILE    dump augmented graph to FILE" << endl
-         << "    -Q, --ignore_mapq       do not use mapping qualities" << endl
-         << "    -A, --no_indel_realign  disable indel realignment" << endl
-         << "    -d, --het_prior_denom   denominator for prior probability of heterozygousness" << endl
-         << "    -P, --min_per_strand    min unique reads per strand for a called allele to accept a call" << endl
-         << "    -E, --no_embed          don't embed gam edits into graph" << endl
-         << "    -T, --traversal         traversal finder to use {reads, exhaustive, representative, adaptive} (adaptive)" << endl
+         << "    -Q, --ignore-mapq       do not use mapping qualities" << endl
+         << "    -A, --no-indel-realign  disable indel realignment" << endl
+         << "    -d, --het-prior-denom DOUBLE  denominator for prior probability of heterozygousness" << endl
+         << "    -P, --min-per-strand INT      min unique reads per strand for a called allele to accept a call" << endl
+         << "    -E, --no-embed          don't embed gam edits into graph" << endl
+         << "    -T, --traversal STR     traversal finder to use {reads, exhaustive, representative, adaptive} (adaptive)" << endl
          << "    -p, --progress          show progress" << endl
          << "    -t, --threads N         number of threads to use" << endl;
 }
@@ -94,6 +94,7 @@ int main_genotype(int argc, char** argv) {
     while (true) {
         static struct option long_options[] =
             {
+                {"help", no_argument, 0, 'h'},
                 {"json", no_argument, 0, 'j'},
                 {"vcf", no_argument, 0, 'v'},
                 {"ref", required_argument, 0, 'r'},
@@ -102,23 +103,23 @@ int main_genotype(int argc, char** argv) {
                 {"offset", required_argument, 0, 'o'},
                 {"length", required_argument, 0, 'l'},
                 {"augmented", required_argument, 0, 'a'},
-                {"ignore_mapq", no_argument, 0, 'Q'},
-                {"no_indel_realign", no_argument, 0, 'A'},
-                {"het_prior_denom", required_argument, 0, 'd'},
-                {"min_per_strand", required_argument, 0, 'P'},
+                {"ignore-mapq", no_argument, 0, 'Q'},
+                {"no-indel-realign", no_argument, 0, 'A'},
+                {"het-prior-denom", required_argument, 0, 'd'},
+                {"min-per-strand", required_argument, 0, 'P'},
                 {"progress", no_argument, 0, 'p'},
                 {"threads", required_argument, 0, 't'},
                 {"recall-vcf", required_argument, 0, 'V'},
                 {"fasta", required_argument, 0, 'F'},
                 {"insertions", required_argument, 0, 'I'},
                 {"call", no_argument, 0, 'z'},
-                {"no_embed", no_argument, 0, 'E'},
+                {"no-embed", no_argument, 0, 'E'},
                 {"traversal", required_argument, 0, 'T'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hjvr:c:s:o:l:a:QAd:P:pt:V:I:F:zET:",
+        c = getopt_long (argc, argv, "h?jvr:c:s:o:l:a:QAd:P:pt:V:I:F:zET:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */

--- a/src/subcommand/genotype_main.cpp
+++ b/src/subcommand/genotype_main.cpp
@@ -17,25 +17,27 @@ void help_genotype(char** argv) {
          << "Compute genotypes from a graph and a collection of reads" << endl
          << endl
          << "options:" << endl
-         << "    -j, --json              output in JSON" << endl
-         << "    -v, --vcf               output in VCF" << endl
-         << "    -V, --recall-vcf FILE   recall variants in a specific VCF file." << endl
-         << "    -F, --fasta FILE" << endl
-         << "    -I, --insertions FILE" << endl
-         << "    -r, --ref PATH          use the given path name as the reference path" << endl
-         << "    -c, --contig NAME       use the given name as the VCF contig name" << endl
-         << "    -s, --sample NAME       name the sample in the VCF with the given name" << endl
-         << "    -o, --offset INT        offset variant positions by this amount" << endl
-         << "    -l, --length INT        override total sequence length" << endl
-         << "    -a, --augmented FILE    dump augmented graph to FILE" << endl
-         << "    -Q, --ignore-mapq       do not use mapping qualities" << endl
-         << "    -A, --no-indel-realign  disable indel realignment" << endl
-         << "    -d, --het-prior-denom DOUBLE  denominator for prior probability of heterozygousness" << endl
-         << "    -P, --min-per-strand INT      min unique reads per strand for a called allele to accept a call" << endl
-         << "    -E, --no-embed          don't embed gam edits into graph" << endl
-         << "    -T, --traversal STR     traversal finder to use {reads, exhaustive, representative, adaptive} (adaptive)" << endl
-         << "    -p, --progress          show progress" << endl
-         << "    -t, --threads N         number of threads to use" << endl;
+         << "  -j, --json                   output in JSON" << endl
+         << "  -v, --vcf                    output in VCF" << endl
+         << "  -V, --recall-vcf FILE        recall variants in a specific VCF file." << endl
+         << "  -F, --fasta FILE             use this linear reference" << endl
+         << "  -I, --insertions FILE        use reference insertions in this FASTA file" << endl
+         << "  -r, --ref PATH               use the given path name as the reference path" << endl
+         << "  -c, --contig NAME            use the given name as the VCF contig name" << endl
+         << "  -s, --sample NAME            name the sample in the VCF with the given name" << endl
+         << "  -o, --offset INT             offset variant positions by this amount" << endl
+         << "  -l, --length INT             override total sequence length" << endl
+         << "  -a, --augmented FILE         dump augmented graph to FILE" << endl
+         << "  -Q, --ignore-mapq            do not use mapping qualities" << endl
+         << "  -A, --no-indel-realign       disable indel realignment" << endl
+         << "  -d, --het-prior-denom FLOAT  denominator for prior prob of heterozygousness" << endl
+         << "  -P, --min-per-strand INT     min unique reads per strand for a called allele" << endl
+         << "  -E, --no-embed               don't embed gam edits into graph" << endl
+         << "  -T, --traversal STR          traversal finder to use [adaptive]" << endl 
+         << "                               {reads, exhaustive, representative, adaptive}" << endl
+         << "  -p, --progress               show progress" << endl
+         << "  -t, --threads N              number of threads to use" << endl
+         << "  -h, --help                   print this help message to stderr and exit" << endl;
 }
 
 int main_genotype(int argc, char** argv) {

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -790,9 +790,7 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
              << "                                (implies --track-provenance)" << endl
              << "      --track-position          coarsely track linear reference positions of" << endl
              << "                                good intermediate alignment candidates" << endl
-             << "                                (implies --track-provenance)" << endl
-             << "  -B, --batch-size INT          number of reads or pairs per batch" << endl
-             << "                                to distribute to threads [" << vg::io::DEFAULT_PARALLEL_BATCHSIZE << "]" << endl;
+             << "                                (implies --track-provenance)" << endl;
 
         auto helps = parser.get_help();
         print_table(helps, cerr);
@@ -1182,7 +1180,6 @@ int main_giraffe(int argc, char** argv) {
         {"fastq-in", required_argument, 0, 'f'},
         {"interleaved", no_argument, 0, 'i'},
         {"comments-as-tags", no_argument, 0, OPT_COMMENTS_AS_TAGS},
-        {"max-multimaps", required_argument, 0, 'M'},
         {"sample", required_argument, 0, 'N'},
         {"read-group", required_argument, 0, 'R'},
         {"output-format", required_argument, 0, 'o'},
@@ -1202,14 +1199,13 @@ int main_giraffe(int argc, char** argv) {
         {"track-provenance", no_argument, 0, OPT_TRACK_PROVENANCE},
         {"track-correctness", no_argument, 0, OPT_TRACK_CORRECTNESS},
         {"track-position", no_argument, 0, OPT_TRACK_POSITION},
-        {"batch-size", required_argument, 0, 'B'},
         {"show-work", no_argument, 0, OPT_SHOW_WORK},
         {"threads", required_argument, 0, 't'},
     };
     parser->make_long_options(long_options);
     long_options.push_back({0, 0, 0, 0});
     
-    std::string short_options = "h?Z:x:g:H:m:z:d:pG:f:iM:N:R:o:Pnb:t:A:B:";
+    std::string short_options = "h?Z:x:g:H:m:z:d:pG:f:iN:R:o:Pnb:t:A:";
     parser->make_short_options(short_options);
 
     if (argc == 2) {

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -699,23 +699,22 @@ std::string sample_haplotypes(
 //----------------------------------------------------------------------------
 
 void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std::string, Preset>& presets, bool full_help) {
-    cerr
-    << "usage:" << endl
-    << "  " << argv[0] << " giraffe -Z graph.gbz [-d graph.dist -m graph.min] <input options> [other options] > output.gam" << endl
-    << "  " << argv[0] << " giraffe -Z graph.gbz --haplotype-name graph.hapl --kff-name sample.kff <input options> [other options] > output.gam" << endl
-    << endl
-    << "Fast haplotype-aware read mapper." << endl
-    << endl;
+    cerr << "usage:" << endl
+         << "  " << argv[0] << " giraffe -Z graph.gbz [-d graph.dist -m graph.min] <input options> [other options] > output.gam" << endl
+         << "  " << argv[0] << " giraffe -Z graph.gbz --haplotype-name graph.hapl --kff-name sample.kff <input options> [other options] > output.gam" << endl
+         << endl
+         << "Fast haplotype-aware read mapper." << endl
+         << endl;
 
-    cerr
-    << "basic options:" << endl
-    << "  -Z, --gbz-name FILE           map to this GBZ graph" << endl
-    << "  -m, --minimizer-name FILE     use this minimizer index" << endl
-    << "  -z, --zipcode-name FILE       use these additional distance hints" << endl
-    << "  -d, --dist-name FILE          cluster using this distance index" << endl
-    << "  -p, --progress                show progress" << endl
-    << "  -t, --threads N               number of mapping threads to use" << endl
-    << "  -b, --parameter-preset NAME   set computational parameters (";
+    cerr << "basic options:" << endl
+         << "  -Z, --gbz-name FILE           map to this GBZ graph" << endl
+         << "  -m, --minimizer-name FILE     use this minimizer index" << endl
+         << "  -z, --zipcode-name FILE       use these additional distance hints" << endl
+         << "  -d, --dist-name FILE          cluster using this distance index" << endl
+         << "  -p, --progress                show progress" << endl
+         << "  -t, --threads N               number of mapping threads to use" << endl
+         << "  -b, --parameter-preset NAME   set computational parameters [default]" << endl
+         << "                                (";
     for (auto p = presets.begin(); p != presets.end(); ++p) {
         // Announce each preset name, slash-separated
         cerr << p->first;
@@ -726,58 +725,74 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
             cerr << " / ";
         }
     }
-    cerr << ") [default]" << endl
-    << "  -h, --help                    print full help with all available options" << endl;
+    cerr << ")" << endl
+         << "  -h, --help                    print full help with all available options" << endl;
 
-    cerr
-    << "input options:" << endl
-    << "  -G, --gam-in FILE             read and realign GAM-format reads from FILE" << endl
-    << "  -f, --fastq-in FILE           read and align FASTQ- or FASTA-format reads from FILE (two are allowed, one for each mate)" << endl
-    << "  -i, --interleaved             GAM/FASTQ/FASTA input is interleaved pairs, for paired-end alignment" << endl
-    << "  --comments-as-tags            intepret comments in name lines as SAM-style tags and annotate alignments with them" << endl;
+    cerr << "input options:" << endl
+         << "  -G, --gam-in FILE             read and realign these GAM-format reads" << endl
+         << "  -f, --fastq-in FILE           read and align these FASTQ/FASTA-format reads" << endl
+         << "                                (two are allowed, one for each mate)" << endl
+         << "  -i, --interleaved             GAM/FASTQ/FASTA input is interleaved pairs," << endl
+         << "                                for paired-end alignment" << endl
+         << "      --comments-as-tags        treat comments in name lines as SAM-style tags" << endl
+         << "                                and annotate alignments with them" << endl;
 
-    cerr
-    << "haplotype sampling:" << endl
-    << "  --haplotype-name FILE         sample from haplotype information in FILE" << endl
-    << "  --kff-name FILE               sample according to kmer counts in FILE" << endl
-    << "  --index-basename STR          name prefix for generated graph/index files (default: from graph name)" << endl
-    << "  --set-reference STR           include this sample as a reference in the personalized graph (may repeat)" << endl;
+    cerr << "haplotype sampling:" << endl
+         << "      --haplotype-name FILE     sample from haplotype information in FILE" << endl
+         << "      --kff-name FILE           sample according to kmer counts in FILE" << endl
+         << "      --index-basename STR      name prefix for generated graph/index files" << endl
+         << "                                (default: from graph name)" << endl
+         << "      --set-reference STR       include this sample as a reference" << endl
+         << "                                in the personalized graph (may repeat)" << endl;
 
-    cerr
-    << "alternate graphs:" << endl
-    << "  -x, --xg-name FILE            map to this graph (if no -Z / -g), or use this graph for HTSLib output" << endl
-    << "  -g, --graph-name FILE         map to this GBWTGraph (if no -Z)" << endl
-    << "  -H, --gbwt-name FILE          use this GBWT index (when mapping to -x / -g)" << endl;
+    cerr << "alternate graphs:" << endl
+         << "  -x, --xg-name FILE            map to this graph (if no -Z / -g)," << endl
+         << "                                or use this graph for HTSLib output" << endl
+         << "  -g, --graph-name FILE         map to this GBWTGraph (if no -Z)" << endl
+         << "  -H, --gbwt-name FILE          use this GBWT index (when mapping to -x / -g)" << endl;
 
-    cerr
-    << "output options:" << endl
-    << "  -N, --sample NAME             add this sample name" << endl
-    << "  -R, --read-group NAME         add this read group" << endl
-    << "  -o, --output-format NAME      output the alignments in NAME format (gam / gaf / json / tsv / SAM / BAM / CRAM) [gam]" << endl
-    << "  --ref-paths FILE              ordered list of paths in the graph, one per line or HTSlib .dict, for HTSLib @SQ headers" << endl
-    << "  --ref-name NAME               name of reference assembly in the graph to use for HTSlib output" << endl
-    << "  --named-coordinates           produce GAM/GAF outputs in named-segment (GFA) space" << endl;
+    cerr << "output options:" << endl
+         << "  -N, --sample NAME             add this sample name" << endl
+         << "  -R, --read-group NAME         add this read group" << endl
+         << "  -o, --output-format NAME      output the alignments in NAME format [gam]" << endl
+         << "                                {gam / gaf / json / tsv / SAM / BAM / CRAM} " << endl
+         << "      --ref-paths FILE          ordered list of paths in the graph, one per line" << endl
+         << "                                or HTSlib .dict, for HTSLib @SQ headers" << endl
+         << "      --ref-name NAME           name of reference in the graph for HTSlib output" << endl
+         << "      --named-coordinates       make GAM/GAF output in named-segment (GFA) space" << endl;
     if (full_help) {
-        cerr
-        << "  -P, --prune-low-cplx          prune short and low complexity anchors during linear format realignment" << endl
-        << "  --add-graph-aln               annotate linear formats with the graph alignment in the GR tag as a cs-style difference string" << endl
-        << "  -n, --discard                 discard all output alignments (for profiling)" << endl
-        << "  --output-basename NAME        write output to a GAM file beginning with the given prefix for each setting combination" << endl
-        << "  --report-name NAME            write a TSV of output file and mapping speed to the given file" << endl
-        << "  --show-work                   log how the mapper comes to its conclusions about mapping locations" << endl;
+        cerr << "  -P, --prune-low-cplx          prune short and low complexity anchors" << endl
+             << "                                during linear format realignment" << endl
+             << "      --add-graph-aln           annotate linear formats with graph alignment" << endl
+             << "                                in the GR tag as a cs-style difference string" << endl
+             << "  -n, --discard                 discard all output alignments (for profiling)" << endl
+             << "      --output-basename NAME    write output to a GAM file with the given prefix" << endl
+             << "                                for each setting combination" << endl
+             << "      --report-name FILE        write a TSV of output file and mapping speed" << endl
+             << "      --show-work               log how the mapper comes to its conclusions" << endl
+             << "                                about mapping locations (use one read at a time)" << endl;
     }
 
     if (full_help) {
-        cerr
-        << "Giraffe parameters:" << endl
-        << "  -A, --rescue-algorithm NAME   use algorithm NAME for rescue (none / dozeu / gssw) [dozeu]" << endl
-        << "  --fragment-mean FLOAT         force the fragment length distribution to have this mean (requires --fragment-stdev)" << endl
-        << "  --fragment-stdev FLOAT        force the fragment length distribution to have this standard deviation (requires --fragment-mean)" << endl
-        << "  --set-refpos                  set refpos field on reads to reference path positions they visit" << endl
-        << "  --track-provenance            track how internal intermediate alignment candidates were arrived at" << endl
-        << "  --track-correctness           track if internal intermediate alignment candidates are correct (implies --track-provenance)" << endl
-        << "  --track-position              coarsely track linear reference positions of good intermediate alignment candidates (implies --track-provenance)" << endl
-        << "  -B, --batch-size INT          number of reads or pairs per batch to distribute to threads [" << vg::io::DEFAULT_PARALLEL_BATCHSIZE << "]" << endl;
+        cerr << "Giraffe parameters:" << endl
+             << "  -A, --rescue-algorithm NAME   use this rescue algorithm [dozeu]" << endl
+             << "                                {none / dozeu / gssw}" << endl
+             << "      --fragment-mean FLOAT     force fragment length distribution to have this" << endl
+             << "                                mean (requires --fragment-stdev)" << endl
+             << "      --fragment-stdev FLOAT    force fragment length distribution to have this" << endl
+             << "                                standard deviation (requires --fragment-mean)" << endl
+             << "      --set-refpos              set refpos field on reads" << endl
+             << "                                to reference path positions they visit" << endl
+             << "      --track-provenance        track how internal intermediate alignment" << endl
+             << "                                candidates were arrived at" << endl
+             << "      --track-correctness       track if internal intermediate alignment" << endl
+             << "                                candidates are correct" << endl
+             << "                                (implies --track-provenance)" << endl
+             << "      --track-position          coarsely track linear reference positions of" << endl
+             << "                                good intermediate alignment candidates" << endl
+             << "                                (implies --track-provenance)" << endl
+             << "  -B, --batch-size INT          number of reads or pairs per batch" << endl
+             << "                                to distribute to threads [" << vg::io::DEFAULT_PARALLEL_BATCHSIZE << "]" << endl;
 
         auto helps = parser.get_help();
         print_table(helps, cerr);
@@ -1947,7 +1962,8 @@ int main_giraffe(int argc, char** argv) {
         minimizer_mapper.read_group = read_group;
 
         // Apply scoring parameters, after they have been parsed
-        minimizer_mapper.set_alignment_scores(scoring_options.match, scoring_options.mismatch, scoring_options.gap_open, scoring_options.gap_extend, scoring_options.full_length_bonus);
+        minimizer_mapper.set_alignment_scores(scoring_options.match, scoring_options.mismatch, 
+            scoring_options.gap_open, scoring_options.gap_extend, scoring_options.full_length_bonus);
 
         // Work out the number of threads we will have
         size_t thread_count = omp_get_max_threads();
@@ -1957,7 +1973,8 @@ int main_giraffe(int argc, char** argv) {
         
         // For timing, we may run one thread first and then switch to all threads. So track both start times.
         std::chrono::time_point<std::chrono::system_clock> first_thread_start;
-        std::chrono::time_point<std::chrono::system_clock> all_threads_start = std::chrono::time_point<std::chrono::system_clock>::min();
+        std::chrono::time_point<std::chrono::system_clock> all_threads_start \
+            = std::chrono::time_point<std::chrono::system_clock>::min();
         
         // We also time in terms of CPU time
         clock_t cpu_time_before;
@@ -2099,7 +2116,8 @@ int main_giraffe(int argc, char** argv) {
                             // Report that it is now ready
                             #pragma omp critical (cerr)
                             {
-                                cerr << "Using fragment length estimate: " << minimizer_mapper.get_fragment_length_mean() << " +/- " << minimizer_mapper.get_fragment_length_stdev() << endl;
+                                cerr << "Using fragment length estimate: " << minimizer_mapper.get_fragment_length_mean()
+                                     << " +/- " << minimizer_mapper.get_fragment_length_stdev() << endl;
                             }
                         }
                         
@@ -2194,12 +2212,14 @@ int main_giraffe(int argc, char** argv) {
                     });
                 } else if (!fastq_filename_2.empty()) {
                     //A pair of FASTQ files to map
-                    fastq_paired_two_files_for_each_parallel_after_wait(fastq_filename_1, fastq_filename_2, map_read_pair, distribution_is_ready, comments_as_tags, main_options.batch_size);
+                    fastq_paired_two_files_for_each_parallel_after_wait(fastq_filename_1, fastq_filename_2, map_read_pair,
+                        distribution_is_ready, comments_as_tags, main_options.batch_size);
 
 
                 } else if ( !fastq_filename_1.empty()) {
                     // An interleaved FASTQ file to map, map all its pairs in parallel.
-                    fastq_paired_interleaved_for_each_parallel_after_wait(fastq_filename_1, map_read_pair, distribution_is_ready, comments_as_tags, main_options.batch_size);
+                    fastq_paired_interleaved_for_each_parallel_after_wait(fastq_filename_1, map_read_pair,
+                        distribution_is_ready, comments_as_tags, main_options.batch_size);
                 }
 
                 // Now map all the ambiguous pairs
@@ -2310,8 +2330,12 @@ int main_giraffe(int argc, char** argv) {
 #endif
         
         // Compute wall clock elapsed
-        std::chrono::duration<double> all_threads_seconds = (all_threads_start == std::chrono::time_point<std::chrono::system_clock>::min()) ? std::chrono::duration<double>(0.0) : end - all_threads_start;
-        std::chrono::duration<double> first_thread_additional_seconds = (all_threads_start == std::chrono::time_point<std::chrono::system_clock>::min()) ? end - first_thread_start : all_threads_start - first_thread_start;
+        std::chrono::duration<double> all_threads_seconds = (
+            all_threads_start == std::chrono::time_point<std::chrono::system_clock>::min()
+        ) ? std::chrono::duration<double>(0.0) : end - all_threads_start;
+        std::chrono::duration<double> first_thread_additional_seconds = (
+            all_threads_start == std::chrono::time_point<std::chrono::system_clock>::min()
+        ) ? end - first_thread_start : all_threads_start - first_thread_start;
         
         // Compute CPU time elapsed
         double cpu_seconds = (cpu_time_after - cpu_time_before) / (double)CLOCKS_PER_SEC;

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -714,7 +714,7 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
     << "  -z, --zipcode-name FILE       use these additional distance hints" << endl
     << "  -d, --dist-name FILE          cluster using this distance index" << endl
     << "  -p, --progress                show progress" << endl
-    << "  -t, --threads INT             number of mapping threads to use" << endl
+    << "  -t, --threads N               number of mapping threads to use" << endl
     << "  -b, --parameter-preset NAME   set computational parameters (";
     for (auto p = presets.begin(); p != presets.end(); ++p) {
         // Announce each preset name, slash-separated
@@ -1172,6 +1172,7 @@ int main_giraffe(int argc, char** argv) {
         {"read-group", required_argument, 0, 'R'},
         {"output-format", required_argument, 0, 'o'},
         {"ref-paths", required_argument, 0, OPT_REF_PATHS},
+        {"ref-name", required_argument, 0, OPT_REF_NAME},
         {"prune-low-cplx", no_argument, 0, 'P'},
         {"add-graph-aln", no_argument, 0, OPT_ADD_GRAPH_ALIGNMENT},
         {"named-coordinates", no_argument, 0, OPT_NAMED_COORDINATES},
@@ -1186,13 +1187,14 @@ int main_giraffe(int argc, char** argv) {
         {"track-provenance", no_argument, 0, OPT_TRACK_PROVENANCE},
         {"track-correctness", no_argument, 0, OPT_TRACK_CORRECTNESS},
         {"track-position", no_argument, 0, OPT_TRACK_POSITION},
+        {"batch-size", required_argument, 0, 'B'},
         {"show-work", no_argument, 0, OPT_SHOW_WORK},
         {"threads", required_argument, 0, 't'},
     };
     parser->make_long_options(long_options);
     long_options.push_back({0, 0, 0, 0});
     
-    std::string short_options = "hZ:x:g:H:m:z:d:pG:f:iM:N:R:o:Pnb:t:A:";
+    std::string short_options = "h?Z:x:g:H:m:z:d:pG:f:iM:N:R:o:Pnb:t:A:B:";
     parser->make_short_options(short_options);
 
     if (argc == 2) {

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -200,14 +200,14 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "Haplotype sampling based on kmer counts." << std::endl;
     std::cerr << std::endl;
     std::cerr << "Output files:" << std::endl;
-    std::cerr << "    -g, --gbz-output X        write the output GBZ to X" << std::endl;
-    std::cerr << "    -H, --haplotype-output X  write haplotype information to X" << std::endl;
+    std::cerr << "    -g, --gbz-output FILE        write the output GBZ to file" << std::endl;
+    std::cerr << "    -H, --haplotype-output FILE  write haplotype information to file" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Input files:" << std::endl;
-    std::cerr << "    -d, --distance-index X    use this distance index (default: <basename>.dist)" << std::endl;
-    std::cerr << "    -r, --r-index X           use this r-index (default: <basename>.ri)" << std::endl;
-    std::cerr << "    -i, --haplotype-input X   use this haplotype information (default: generate)" << std::endl;
-    std::cerr << "    -k, --kmer-input X        use kmer counts from this KFF file (required for --gbz-output)" << std::endl;
+    std::cerr << "    -d, --distance-index FILE    use this distance index (default: <basename>.dist)" << std::endl;
+    std::cerr << "    -r, --r-index FILE           use this r-index (default: <basename>.ri)" << std::endl;
+    std::cerr << "    -i, --haplotype-input FILE   use this haplotype information (default: generate)" << std::endl;
+    std::cerr << "    -k, --kmer-input FILE        use kmer counts from this KFF file (required for --gbz-output)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Options for generating haplotype information:" << std::endl;
     std::cerr << "        --kmer-length N       kmer length for building the minimizer index (default: " << haplotypes_defaults::k() << ")" << std::endl;
@@ -216,7 +216,7 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "        --linear-structure    extend subchains to avoid haplotypes visiting them multiple times" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Options for sampling haplotypes:" << std::endl;
-    std::cerr << "        --preset X            use preset X (default, haploid, diploid)" << std::endl;
+    std::cerr << "        --preset STR          use preset X (default, haploid, diploid)" << std::endl;
     std::cerr << "        --coverage N          kmer coverage in the KFF file (default: estimate)" << std::endl;
     std::cerr << "        --num-haplotypes N    generate N haplotypes (default: " << haplotypes_defaults::n() << ")" << std::endl;
     std::cerr << "                              sample from N candidates (with --diploid-sampling; default: " << haplotypes_defaults::candidates() << ")" << std::endl;
@@ -228,7 +228,7 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "        --extra-fragments     in diploid sampling, select all candidates in bad subchains" << std::endl;
     std::cerr << "        --badness F           threshold for the badness of a subchain (default: " << haplotypes_defaults::badness() << ")" << std::endl;
     std::cerr << "        --include-reference   include named and reference paths in the output" << std::endl;
-    std::cerr << "        --set-reference X     use sample X as a reference sample (may repeat)" << std::endl;
+    std::cerr << "        --set-reference NAME  use sample X as a reference sample (may repeat)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
     std::cerr << "    -v, --verbosity N         verbosity level (0 = silent, 1 = basic, 2 = detailed, 3 = debug; default: 0)" << std::endl;
@@ -237,7 +237,7 @@ void help_haplotypes(char** argv, bool developer_options) {
     if (developer_options) {
         std::cerr << "Developer options:" << std::endl;
         std::cerr << "        --validate            validate the generated information (may be slow)" << std::endl;
-        std::cerr << "        --statistics X        output subchain statistics over reference sample X" << std::endl;
+        std::cerr << "        --statistics NAME     output subchain statistics over a reference sample" << std::endl;
         std::cerr << std::endl;
     }
 }
@@ -292,6 +292,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
         { "threads", required_argument, 0, 't' },
         { "validate", no_argument, 0,  OPT_VALIDATE },
         { "statistics", required_argument, 0, OPT_STATISTICS },
+        { "help", no_argument, 0, 'h' },
         { 0, 0, 0, 0 }
     };
 
@@ -301,7 +302,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
     bool num_haplotypes_set = false;
     while (true) {
         int option_index = 0;
-        c = getopt_long(argc, argv, "g:H:d:r:i:k:v:t:h", long_options, &option_index);
+        c = getopt_long(argc, argv, "g:H:d:r:i:k:v:t:h?", long_options, &option_index);
         if (c == -1) { break; } // End of options.
 
         switch (c)

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -188,7 +188,7 @@ static vg::subcommand::Subcommand vg_haplotypes("haplotypes", "haplotype samplin
 
 void help_haplotypes(char** argv, bool developer_options) {
     std::string usage = "    " + std::string(argv[0]) + " " + std::string(argv[1]) + " [options] ";
-    std::cerr << "Usage:" << std::endl;
+    std::cerr << "usage:" << std::endl;
     std::cerr << usage << "-k kmers.kff -g output.gbz graph.gbz" << std::endl;
     std::cerr << usage << "-H output.hapl graph.gbz" << std::endl;
     std::cerr << usage << "-i graph.hapl -k kmers.kff -g output.gbz graph.gbz" << std::endl;
@@ -200,44 +200,57 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "Haplotype sampling based on kmer counts." << std::endl;
     std::cerr << std::endl;
     std::cerr << "Output files:" << std::endl;
-    std::cerr << "    -g, --gbz-output FILE        write the output GBZ to file" << std::endl;
-    std::cerr << "    -H, --haplotype-output FILE  write haplotype information to file" << std::endl;
+    std::cerr << "  -g, --gbz-output FILE        write the output GBZ to file (requires -k)" << std::endl;
+    std::cerr << "  -H, --haplotype-output FILE  write haplotype information to file" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Input files:" << std::endl;
-    std::cerr << "    -d, --distance-index FILE    use this distance index (default: <basename>.dist)" << std::endl;
-    std::cerr << "    -r, --r-index FILE           use this r-index (default: <basename>.ri)" << std::endl;
-    std::cerr << "    -i, --haplotype-input FILE   use this haplotype information (default: generate)" << std::endl;
-    std::cerr << "    -k, --kmer-input FILE        use kmer counts from this KFF file (required for --gbz-output)" << std::endl;
+    std::cerr << "  -d, --distance-index FILE    use this distance index [<basename>.dist]" << std::endl;
+    std::cerr << "  -r, --r-index FILE           use this r-index [<basename>.ri]" << std::endl;
+    std::cerr << "  -i, --haplotype-input FILE   use this .hapl file (default: generate)" << std::endl;
+    std::cerr << "  -k, --kmer-input FILE        use kmer counts from this KFF file" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Options for generating haplotype information:" << std::endl;
-    std::cerr << "        --kmer-length N       kmer length for building the minimizer index (default: " << haplotypes_defaults::k() << ")" << std::endl;
-    std::cerr << "        --window-length N     window length for building the minimizer index (default: " << haplotypes_defaults::w() << ")" << std::endl;
-    std::cerr << "        --subchain-length N   target length (in bp) for subchains (default: " << haplotypes_defaults::subchain_length() << ")" << std::endl;
-    std::cerr << "        --linear-structure    extend subchains to avoid haplotypes visiting them multiple times" << std::endl;
+    std::cerr << "      --kmer-length N          kmer length for building minimizer index"
+                                             << "[" << haplotypes_defaults::k() << "]" << std::endl;
+    std::cerr << "      --window-length N        window length for building minimizer index "
+                                             << "[" << haplotypes_defaults::w() << "]" << std::endl;
+    std::cerr << "      --subchain-length N      target length (in bp) for subchains "
+                                             << "[" << haplotypes_defaults::subchain_length() << "]" << std::endl;
+    std::cerr << "      --linear-structure       extend subchains to avoid haplotypes" << std::endl;
+    std::cerr << "                               visiting them multiple times" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Options for sampling haplotypes:" << std::endl;
-    std::cerr << "        --preset STR          use preset X (default, haploid, diploid)" << std::endl;
-    std::cerr << "        --coverage N          kmer coverage in the KFF file (default: estimate)" << std::endl;
-    std::cerr << "        --num-haplotypes N    generate N haplotypes (default: " << haplotypes_defaults::n() << ")" << std::endl;
-    std::cerr << "                              sample from N candidates (with --diploid-sampling; default: " << haplotypes_defaults::candidates() << ")" << std::endl;
-    std::cerr << "        --present-discount F  discount scores for present kmers by factor F (default: " << haplotypes_defaults::discount() << ")" << std::endl;
-    std::cerr << "        --het-adjustment F    adjust scores for heterozygous kmers by F (default: " << haplotypes_defaults::adjustment() << ")" << std::endl;
-    std::cerr << "        --absent-score F      score absent kmers -F/+F (default: " << haplotypes_defaults::absent()  << ")" << std::endl;
-    std::cerr << "        --haploid-scoring     use a scoring model without heterozygous kmers" << std::endl;
-    std::cerr << "        --diploid-sampling    choose the best pair from the sampled haplotypes" << std::endl;
-    std::cerr << "        --extra-fragments     in diploid sampling, select all candidates in bad subchains" << std::endl;
-    std::cerr << "        --badness F           threshold for the badness of a subchain (default: " << haplotypes_defaults::badness() << ")" << std::endl;
-    std::cerr << "        --include-reference   include named and reference paths in the output" << std::endl;
-    std::cerr << "        --set-reference NAME  use sample X as a reference sample (may repeat)" << std::endl;
+    std::cerr << "      --preset STR             use preset X {default, haploid, diploid}" << std::endl;
+    std::cerr << "      --coverage N             kmer coverage in KFF file (default: estimate)" << std::endl;
+    std::cerr << "      --num-haplotypes N       generate N haplotypes [" << haplotypes_defaults::n() << "]" << std::endl;
+    std::cerr << "                               with --diploid-sampling, use N candidates "
+                                             << "[" << haplotypes_defaults::candidates() << "]" << std::endl;
+    std::cerr << "      --present-discount F     discount scores for present kmers by factor F" << std::endl;
+    std::cerr << "                               [" << haplotypes_defaults::discount() << "]" << std::endl;
+    std::cerr << "      --het-adjustment F       adjust scores for heterozygous kmers by F "
+                                             << "[" << haplotypes_defaults::adjustment() << "]" << std::endl;
+    std::cerr << "      --absent-score F         score absent kmers -F/+F "
+                                             << "[" << haplotypes_defaults::absent()  << "]" << std::endl;
+    std::cerr << "      --haploid-scoring        use a scoring model without heterozygous kmers" << std::endl;
+    std::cerr << "      --diploid-sampling       choose the best pair from the sampled haplotypes" << std::endl;
+    std::cerr << "      --extra-fragments        select all candidates in bad subchains" << std::endl;
+    std::cerr << "                               in --diploid-sampling" << std::endl;
+    std::cerr << "      --badness F              threshold for badness of a subchain "
+                                             << "[" << haplotypes_defaults::badness() << "]" << std::endl;
+    std::cerr << "      --include-reference      include named and reference paths in the output" << std::endl;
+    std::cerr << "      --set-reference NAME     use sample X as a reference sample (may repeat)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
-    std::cerr << "    -v, --verbosity N         verbosity level (0 = silent, 1 = basic, 2 = detailed, 3 = debug; default: 0)" << std::endl;
-    std::cerr << "    -t, --threads N           approximate number of threads (default: " << haplotypes_defaults::threads() << " on this system)" << std::endl;
+    std::cerr << "  -v, --verbosity N            verbosity level [0]" << std::endl;
+    std::cerr << "                               {0 = silent, 1 = basic, 2 = detailed, 3 = debug}" << std::endl;
+    std::cerr << "  -t, --threads N              approximate number of threads "
+                                             << "[" << haplotypes_defaults::threads() << " on this system]" << std::endl;
+    std::cerr << "  -h, --help                   print this help message to stderr and exit" << std::endl;
     std::cerr << std::endl;
     if (developer_options) {
         std::cerr << "Developer options:" << std::endl;
-        std::cerr << "        --validate            validate the generated information (may be slow)" << std::endl;
-        std::cerr << "        --statistics NAME     output subchain statistics over a reference sample" << std::endl;
+        std::cerr << "      --validate               validate the generated information (may be slow)" << std::endl;
+        std::cerr << "      --statistics NAME        output subchain statistics over reference sample" << std::endl;
         std::cerr << std::endl;
     }
 }

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -70,7 +70,7 @@ int main_ids(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hci:d:jm:s",
+        c = getopt_long (argc, argv, "h?ci:d:jm:s",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -29,15 +29,16 @@ using namespace vg::subcommand;
 
 void help_ids(char** argv) {
     cerr << "usage: " << argv[0] << " ids [options] <graph1.vg> [graph2.vg ...] >new.vg" << endl
-        << "options:" << endl
-        << "    -c, --compact        minimize the space of integers used by the ids" << endl
-        << "    -i, --increment N    increase ids by N" << endl
-        << "    -d, --decrement N    decrease ids by N" << endl
-        << "    -j, --join           make a joint id space for all the graphs that are supplied" << endl
-        << "                         by iterating through the supplied graphs and incrementing" << endl
-        << "                         their ids to be non-conflicting (modifies original files)" << endl
-        << "    -m, --mapping FILE   create an empty node mapping for vg prune" << endl
-        << "    -s, --sort           assign new node IDs in (generalized) topological sort order" << endl;
+         << "options:" << endl
+         << "  -c, --compact        minimize the space of integers used by the ids" << endl
+         << "  -i, --increment N    increase ids by N" << endl
+         << "  -d, --decrement N    decrease ids by N" << endl
+         << "  -j, --join           make a joint ID space for all supplied graphs" << endl
+         << "                       by iterating through the supplied graphs and incrementing" << endl
+         << "                       their ids to be non-conflicting (modifies original files)" << endl
+         << "  -m, --mapping FILE   create an empty node mapping for vg prune" << endl
+         << "  -s, --sort           assign new node IDs in generalized topological sort order" << endl
+         << "  -h, --help           print this help message to stderr and exit" << endl;
 }
 
 int main_ids(int argc, char** argv) {
@@ -71,7 +72,7 @@ int main_ids(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?ci:d:jm:s",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -77,10 +77,10 @@ int main_index(int argc, char** argv) {
         return 1;
     }
 
-    #define OPT_BUILD_VGI_INDEX  1000
-    #define OPT_RENAME_VARIANTS  1001
-    #define OPT_DISTANCE_SNARL_LIMIT 1002
-    #define OPT_DISTANCE_NESTING 1003
+    constexpr int OPT_BUILD_VGI_INDEX = 1000;
+    constexpr int OPT_RENAME_VARIANTS = 1001;
+    constexpr int OPT_DISTANCE_SNARL_LIMIT = 1002;
+    constexpr int OPT_DISTANCE_NESTING = 1003;
 
     // Which indexes to build.
     bool build_xg = false, build_gcsa = false, build_dist = false;

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -38,29 +38,36 @@ void help_index(char** argv) {
          << "Creates an index on the specified graph or graphs. All graphs indexed must " << endl
          << "already be in a joint ID space." << endl
          << "general options:" << endl
-         << "    -b, --temp-dir DIR        use DIR for temporary files" << endl
-         << "    -t, --threads N           number of threads to use" << endl
-         << "    -p, --progress            show progress" << endl
+         << "  -h, --help                print this help message to stderr and exit" << endl
+         << "  -b, --temp-dir DIR        use DIR for temporary files" << endl
+         << "  -t, --threads N           number of threads to use" << endl
+         << "  -p, --progress            show progress" << endl
          << "xg options:" << endl
-         << "    -x, --xg-name FILE        use this file to store a succinct, queryable version of the graph(s), or read for GCSA or distance indexing" << endl
-         << "    -L, --xg-alts             include alt paths in xg" << endl
+         << "  -x, --xg-name FILE        use this file to store a succinct, queryable version" << endl
+         << "                            of graph(s), or read for GCSA or distance indexing" << endl
+         << "  -L, --xg-alts             include alt paths in xg" << endl
          << "gcsa options:" << endl
-         << "    -g, --gcsa-out FILE       output a GCSA2 index to the given file" << endl
-         //<< "    -i, --dbg-in FILE         use kmers from FILE instead of input VG (may repeat)" << endl
-         << "    -f, --mapping FILE        use this node mapping in GCSA2 construction" << endl
-         << "    -k, --kmer-size N         index kmers of size N in the graph (default " << gcsa::Key::MAX_LENGTH << ")" << endl
-         << "    -X, --doubling-steps N    use this number of doubling steps for GCSA2 construction (default " << gcsa::ConstructionParameters::DOUBLING_STEPS << ")" << endl
-         << "    -Z, --size-limit N        limit temporary disk space usage to N gigabytes (default " << gcsa::ConstructionParameters::SIZE_LIMIT << ")" << endl
-         << "    -V, --verify-index        validate the GCSA2 index using the input kmers (important for testing)" << endl
+         << "  -g, --gcsa-out FILE       output a GCSA2 index to the given file" << endl
+       //<< "  -i, --dbg-in FILE         use kmers from FILE instead of input VG (may repeat)" << endl
+         << "  -f, --mapping FILE        use this node mapping in GCSA2 construction" << endl
+         << "  -k, --kmer-size N         index kmers of size N in the graph [" << gcsa::Key::MAX_LENGTH << "]" << endl
+         << "  -X, --doubling-steps N    use N doubling steps for GCSA2 construction "
+                                     << "[" << gcsa::ConstructionParameters::DOUBLING_STEPS << "]" << endl
+         << "  -Z, --size-limit N        limit temp disk space usage to N GB "
+                                     << "[" << gcsa::ConstructionParameters::SIZE_LIMIT << "]" << endl
+         << "  -V, --verify-index        validate the GCSA2 index using the input kmers" << endl
+         << "                            (important for testing)" << endl
          << "gam indexing options:" << endl
-         << "    -l, --index-sorted-gam    input is sorted .gam format alignments, store a GAI index of the sorted GAM in INPUT.gam.gai" << endl
+         << "  -l, --index-sorted-gam    input is sorted .gam format alignments," << endl
+         << "                            store a GAI index of the sorted GAM in INPUT.gam.gai" << endl
          << "vg in-place indexing options:" << endl
-         << "    --index-sorted-vg         input is ID-sorted .vg format graph chunks, store a VGI index of the sorted vg in INPUT.vg.vgi" << endl
+         << "      --index-sorted-vg     input is ID-sorted .vg format graph chunks" << endl
+         << "                            store a VGI index of the sorted vg in INPUT.vg.vgi" << endl
          << "snarl distance index options" << endl
-         << "    -j, --dist-name FILE      use this file to store a snarl-based distance index" << endl
-         << "        --snarl-limit N       don't store snarl distances for snarls with more than N nodes (default 10000)" << endl
-         << "                              if N is 0 then don't store distances, only the snarl tree" << endl
-         << "        --no-nested-distance  only store distances along the top-level chain" << endl;
+         << "  -j, --dist-name FILE      use this file to store a snarl-based distance index" << endl
+         << "      --snarl-limit N       don't store distances for snarls > N nodes [10000]" << endl
+         << "                            if 0 then don't store distances, only the snarl tree" << endl
+         << "      --no-nested-distance  only store distances along the top-level chain" << endl;
 }
 
 int main_index(int argc, char** argv) {

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -57,7 +57,7 @@ void help_index(char** argv) {
          << "vg in-place indexing options:" << endl
          << "    --index-sorted-vg         input is ID-sorted .vg format graph chunks, store a VGI index of the sorted vg in INPUT.vg.vgi" << endl
          << "snarl distance index options" << endl
-         << "    -j  --dist-name FILE      use this file to store a snarl-based distance index" << endl
+         << "    -j, --dist-name FILE      use this file to store a snarl-based distance index" << endl
          << "        --snarl-limit N       don't store snarl distances for snarls with more than N nodes (default 10000)" << endl
          << "                              if N is 0 then don't store distances, only the snarl tree" << endl
          << "        --no-nested-distance  only store distances along the top-level chain" << endl;
@@ -116,10 +116,10 @@ int main_index(int argc, char** argv) {
             {"temp-dir", required_argument, 0, 'b'},
             {"threads", required_argument, 0, 't'},
             {"progress",  no_argument, 0, 'p'},
+            {"help",  no_argument, 0, 'h'},
 
             // XG
             {"xg-name", required_argument, 0, 'x'},
-            {"thread-db", required_argument, 0, 'F'},
             {"xg-alts", no_argument, 0, 'L'},
 
             // GBWT. These have been removed and will return an error.
@@ -164,8 +164,8 @@ int main_index(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "b:t:px:Lv:WTM:F:G:zPoB:u:n:R:r:I:E:g:i:f:k:X:Z:Vlj:h",
-                long_options, &option_index);
+        c = getopt_long (argc, argv, "b:t:px:Lv:WTM:F:G:zPoB:u:n:R:r:I:E:g:i:f:k:X:Z:Vlj:h?",
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/inject_main.cpp
+++ b/src/subcommand/inject_main.cpp
@@ -28,11 +28,12 @@ void help_inject(char** argv) {
     cerr << "usage: " << argv[0] << " inject -x graph.xg [options] input.[bam|sam|cram] >output.gam" << endl
          << endl
          << "options:" << endl
-         << "    -x, --xg-name FILE       use this graph or xg index (required, non-XG formats also accepted)" << endl
-         << "    -i, --add-identity       add the 'identity' statistic (\% of matching base pairs) to output GAM" << endl
-         << "    -r, --rescore            re-score alignments" << endl
-         << "    -o, --output-format NAME output the alignments in NAME format (gam / gaf / json) [gam]" << endl
-         << "    -t, --threads N          number of threads to use" << endl;
+         << "  -x, --xg-name FILE        use this graph or xg index (required, non-XG okay)" << endl
+         << "  -i, --add-identity        calculate & add 'identity' statistic to output GAM" << endl
+         << "  -r, --rescore             re-score alignments" << endl
+         << "  -o, --output-format NAME  output alignment format {gam / gaf / json} [gam]" << endl
+         << "  -t, --threads N           number of threads to use" << endl
+         << "  -h, --help                print this help message to stderr and exit" << endl;
 }
 
 int main_inject(int argc, char** argv) {

--- a/src/subcommand/inject_main.cpp
+++ b/src/subcommand/inject_main.cpp
@@ -63,7 +63,7 @@ int main_inject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:ro:t:",
+        c = getopt_long (argc, argv, "h?x:iro:t:",
                          long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/join_main.cpp
+++ b/src/subcommand/join_main.cpp
@@ -42,7 +42,7 @@ int main_join(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "h",
+        c = getopt_long (argc, argv, "h?",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/join_main.cpp
+++ b/src/subcommand/join_main.cpp
@@ -20,9 +20,10 @@ using namespace vg::subcommand;
 
 void help_join(char** argv) {
     cerr << "usage: " << argv[0] << " join [options] <graph1.vg> [graph2.vg ...] >joined.vg" << endl
-        << "Joins graphs and sub-graphs into a single variant graph by connecting their" << endl
-        << "heads to a single root node with sequence 'N'." << endl
-        << "Assumes a single id namespace for all graphs to join." << endl;
+         << "Joins graphs and sub-graphs into a single variant graph by connecting their" << endl
+         << "heads to a single root node with sequence 'N'." << endl
+         << "Assumes a single id namespace for all graphs to join." << endl
+         << "  -h, --help                print this help message to stderr and exit" << endl;
 }
 
 int main_join(int argc, char** argv) {
@@ -43,7 +44,7 @@ int main_join(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/kmers_main.cpp
+++ b/src/subcommand/kmers_main.cpp
@@ -26,17 +26,17 @@ void help_kmers(char** argv) {
          << "Generates kmers from both strands of the graph(s). Output is: kmer id pos" << endl
          << endl
          << "general options:" << endl
-         << "    -k, --kmer-size N     print kmers of size N in the graph" << endl
-         << "    -t, --threads N       number of threads to use" << endl
-         << "    -p, --progress        show progress" << endl
+         << "  -k, --kmer-size N     print kmers of size N in the graph" << endl
+         << "  -t, --threads N       number of threads to use" << endl
+         << "  -p, --progress        show progress" << endl
          << "gcsa options:" << endl
-         << "    -g, --gcsa-out        output a table suitable for input to GCSA2:" << endl
-         << "                          kmer, starting position, previous characters," << endl
-         << "                          successive characters, successive positions." << endl
-         << "    -B, --gcsa-binary     write the GCSA graph in binary format (implies -g)" << endl
-         << "    -H, --head-id N       use the specified ID for the GCSA2 head sentinel node" << endl
-         << "    -T, --tail-id N       use the specified ID for the GCSA2 tail sentinel node" << endl
-         << "" << endl;
+         << "  -g, --gcsa-out        output a table suitable for input to GCSA2:" << endl
+         << "                        kmer, starting position, previous characters," << endl
+         << "                        successive characters, successive positions." << endl
+         << "  -B, --gcsa-binary     write the GCSA graph in binary format (implies -g)" << endl
+         << "  -H, --head-id N       use the specified ID for the GCSA2 head sentinel node" << endl
+         << "  -T, --tail-id N       use the specified ID for the GCSA2 tail sentinel node" << endl
+         << "  -h, --help            print this help message to stderr and exit" << endl;
 }
 
 int main_kmers(int argc, char** argv) {
@@ -83,7 +83,7 @@ int main_kmers(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "k:t:pgBH:T:e:Fh?",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/kmers_main.cpp
+++ b/src/subcommand/kmers_main.cpp
@@ -82,7 +82,7 @@ int main_kmers(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "k:t:pgBH:T:e:Fh",
+        c = getopt_long (argc, argv, "k:t:pgBH:T:e:Fh?",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -42,7 +42,7 @@ void help_map(char** argv) {
          << "                                   candidate chains of seeds [1]" << endl
          << "  -E, --approx-mq-cap INT          weight MQ by suffix tree based estimate" << endl
          << "                                   when estimate less than FLOAT [0]" << endl
-         << "      --id-mq-weight N             scale mapping quality by the alignment score" << endl
+         << "  -7, --id-mq-weight N             scale mapping quality by the alignment score" << endl
          << "                                   identity to this power [2]" << endl
          << "  -W, --min-chain INT              discard a chain if seeded bases are" << endl
          << "                                   shorter than INT [0]" << endl
@@ -69,13 +69,13 @@ void help_map(char** argv) {
          << "                                   use -I without update" << endl
          << "  -p, --print-frag-model           suppress alignment output and print the" << endl
          << "                                   fragment model on stdout as per -I format" << endl
-         << "      --frag-calc INT              update the fragment model" << endl
+         << "  -4, --frag-calc INT              update the fragment model" << endl
          << "                                   every INT perfect pairs [10]" << endl
-         << "      --fragment-x FLOAT           calculate max fragment size as" << endl
+         << "  -3, --fragment-x FLOAT           calculate max fragment size as" << endl
          << "                                   frag_mean+frag_sd*FLOAT [10]" << endl
-         << "      --mate-rescues INT           attempt up to INT mate rescues per pair [64]" << endl
+         << "  -0, --mate-rescues INT           attempt up to INT mate rescues per pair [64]" << endl
          << "  -S, --unpaired-cost INT          penalty for an unpaired read pair [17]" << endl
-         << "      --no-patch-aln               do not patch banded alignments by" << endl 
+         << "  -8, --no-patch-aln               do not patch banded alignments by" << endl 
          << "                                   locally aligning unaligned regions" << endl
          << "      --xdrop-alignment            use X-drop heuristic" << endl
          << "                                   (much faster for long-read alignment)" << endl
@@ -89,7 +89,7 @@ void help_map(char** argv) {
          << "  -o, --gap-open INT               use this gap open penalty [6]" << endl
          << "  -y, --gap-extend INT             use this gap extension penalty [1]" << endl
          << "  -L, --full-l-bonus INT           the full-length alignment bonus [5]" << endl
-         << "      --drop-full-l-bonus          remove the full length bonus from the score" << endl
+         << "  -2, --drop-full-l-bonus          remove the full length bonus from the score" << endl
          << "                                   before sorting and MQ calculation" << endl
          << "  -a, --hap-exp FLOAT              the exponent for haplotype consistency" << endl
          << "                                   likelihood in alignment score [1]" << endl
@@ -126,12 +126,12 @@ void help_map(char** argv) {
          << "  -j, --output-json                output JSON rather than an alignment stream" << endl
          << "                                   (helpful for debugging)" << endl
          << "  -%, --gaf                        output alignments in GAF format" << endl
-         << "      --surject-to TYPE            surject the output into the graph's paths," << endl
+         << "  -5, --surject-to TYPE            surject the output into the graph's paths," << endl
          << "                                   writing TYPE {bam, sam, cram}" << endl
          << "      --ref-paths FILE             ordered list of paths in graph, one per line" << endl
          << "                                   or HTSlib .dict, for HTSLib @SQ headers" << endl
          << "      --ref-name NAME              reference assembly in graph for HTSlib output" << endl
-         << "      --buffer-size INT            buffer this many alignments together" << endl
+         << "  -9, --buffer-size INT            buffer this many alignments together" << endl
          << "                                   before outputting in GAM [512]" << endl
          << "  -X, --compare                    realign -G GAM input, writing alignment with" << endl
          << "                                   \"correct\" field set to overlap with input" << endl
@@ -143,7 +143,7 @@ void help_map(char** argv) {
          << "  -Q, --mq-max INT                 cap the mapping quality at INT [60]" << endl
          << "      --exclude-unaligned          exclude reads with no alignment" << endl
          << "  -D, --debug                      print debugging information to stderr" << endl
-         << "      --log-time                   print runtime to stderr" << endl
+         << "  -^, --log-time                   print runtime to stderr" << endl
          << "  -h, --help                       print this help message to stderr and exit" << endl;
 
 }

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -157,14 +157,14 @@ int main_map(int argc, char** argv) {
         return 1;
     }
 
-    #define OPT_SCORE_MATRIX 1000
-    #define OPT_RECOMBINATION_PENALTY 1001
-    #define OPT_EXCLUDE_UNALIGNED 1002
-    #define OPT_REF_PATHS 1003
-    #define OPT_REF_NAME 1004
-    #define OPT_COMMENTS_AS_TAGS 1005
-    #define OPT_MAX_GAP_LENGTH 1006
-    #define OPT_XDROP_ALIGNMENT 1007
+    constexpr int OPT_SCORE_MATRIX = 1000;
+    constexpr int OPT_RECOMBINATION_PENALTY = 1001;
+    constexpr int OPT_EXCLUDE_UNALIGNED = 1002;
+    constexpr int OPT_REF_PATHS = 1003;
+    constexpr int OPT_REF_NAME = 1004;
+    constexpr int OPT_COMMENTS_AS_TAGS = 1005;
+    constexpr int OPT_MAX_GAP_LENGTH = 1006;
+    constexpr int OPT_XDROP_ALIGNMENT = 1007;
     string matrix_file_name;
     string seq;
     string qual;

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -20,83 +20,131 @@ void help_map(char** argv) {
          << "Align reads to a graph." << endl
          << endl
          << "graph/index:" << endl
-         << "    -d, --base-name BASE          use BASE.xg and BASE.gcsa as the input index pair" << endl
-         << "    -x, --xg-name FILE            use this xg index or graph (defaults to <graph>.vg.xg)" << endl
-         << "    -g, --gcsa-name FILE          use this GCSA2 index (defaults to <graph>" << gcsa::GCSA::EXTENSION << ")" << endl
-         << "    -1, --gbwt-name FILE          use this GBWT haplotype index (defaults to <graph>"<<gbwt::GBWT::EXTENSION << ")" << endl
+         << "  -d, --base-name BASE             use BASE.xg and BASE.gcsa as input indexes" << endl
+         << "  -x, --xg-name FILE               use this xg index or graph [<graph>.vg.xg]" << endl
+         << "  -g, --gcsa-name FILE             use this GCSA2 index "
+                                            << "[<graph>" << gcsa::GCSA::EXTENSION << "]" << endl
+         << "  -1, --gbwt-name FILE             use this GBWT haplotype index "
+                                            << "[<graph>"<<gbwt::GBWT::EXTENSION << "]" << endl
          << "algorithm:" << endl
-         << "    -t, --threads N               number of compute threads to use" << endl
-         << "    -k, --min-mem INT             minimum MEM length (if 0 estimate via -e) [0]" << endl
-         << "    -e, --mem-chance FLOAT        set {-k} such that this fraction of {-k} length hits will by chance [5e-4]" << endl
-         << "    -c, --hit-max N               ignore MEMs who have >N hits in our index (0 for no limit) [2048]" << endl
-         << "    -Y, --max-mem INT             ignore mems longer than this length (unset if 0) [0]" << endl
-         << "    -r, --reseed-x FLOAT          look for internal seeds inside a seed longer than FLOAT*--min-seed [1.5]" << endl
-         << "    -u, --try-up-to INT           attempt to align up to the INT best candidate chains of seeds (1/2 for paired) [128]" << endl
-         << "    -l, --try-at-least INT        attempt to align at least the INT best candidate chains of seeds [1]" << endl
-         << "    -E, --approx-mq-cap INT       weight MQ by suffix tree based estimate when estimate less than FLOAT [0]" << endl
-         << "    --id-mq-weight N              scale mapping quality by the alignment score identity to this power [2]" << endl
-         << "    -W, --min-chain INT           discard a chain if seeded bases shorter than INT [0]" << endl
-         << "    -C, --drop-chain FLOAT        drop chains shorter than FLOAT fraction of the longest overlapping chain [0.45]" << endl
-         << "    -n, --mq-overlap FLOAT        scale MQ by count of alignments with this overlap in the query with the primary [0]" << endl
-         << "    -P, --min-ident FLOAT         accept alignment only if the alignment identity is >= FLOAT [0]" << endl
-         << "    -H, --max-target-x N          skip cluster subgraphs with length > N*read_length [100]" << endl
-         << "    -w, --band-width INT          band width for long read alignment [256]" << endl
-         << "    -O, --band-overlap INT        band overlap for long read alignment [{-w}/8]" << endl
-         << "    -J, --band-jump INT           the maximum number of bands of insertion we consider in the alignment chain model [128]" << endl
-         << "    -B, --band-multi INT          consider this many alignments of each band in banded alignment [16]" << endl
-         << "    -Z, --band-min-mq INT         treat bands with less than this MQ as unaligned [0]" << endl
-         << "    -I, --fragment STR            fragment length distribution specification STR=m:μ:σ:o:d [5000:0:0:0:1]" << endl
-         << "                                  max, mean, stdev, orientation (1=same, 0=flip), direction (1=forward, 0=backward)" << endl
-         << "    -U, --fixed-frag-model        don't learn the pair fragment model online, use {-I} without update" << endl
-         << "    -p, --print-frag-model        suppress alignment output and print the fragment model on stdout as per {-I} format" << endl
-         << "    --frag-calc INT               update the fragment model every INT perfect pairs [10]" << endl
-         << "    --fragment-x FLOAT            calculate max fragment size as frag_mean+frag_sd*FLOAT [10]" << endl
-         << "    --mate-rescues INT            attempt up to INT mate rescues per pair [64]" << endl
-         << "    -S, --unpaired-cost INT       penalty for an unpaired read pair [17]" << endl
-         << "    --no-patch-aln                do not patch banded alignments by locally aligning unaligned regions" << endl
-         << "    --xdrop-alignment             use X-drop heuristic (much faster for long-read alignment)" << endl
-         << "    --max-gap-length INT          maximum gap length allowed in each contiguous alignment (for X-drop alignment) [40]" << endl
+         << "  -t, --threads N                  number of compute threads to use" << endl
+         << "  -k, --min-mem INT                minimum MEM length (if 0 estimate via -e) [0]" << endl
+         << "  -e, --mem-chance FLOAT           this fraction of -k length hits" << endl
+         << "                                   will be by chance [5e-4]" << endl
+         << "  -c, --hit-max N                  ignore MEMs who have >N hits in our index" << endl
+         << "                                   (0 for no limit) [2048]" << endl
+         << "  -Y, --max-mem INT                ignore MEMs longer than INT (unset if 0) [0]" << endl
+         << "  -r, --reseed-x FLOAT             look for internal seeds inside a seed" << endl
+         << "                                   longer than FLOAT*--min-seed [1.5]" << endl
+         << "  -u, --try-up-to INT              attempt to align up to the INT best candidate" << endl
+         << "                                   chains of seeds (1/2 for paired) [128]" << endl
+         << "  -l, --try-at-least INT           attempt to align at least the INT best" << endl
+         << "                                   candidate chains of seeds [1]" << endl
+         << "  -E, --approx-mq-cap INT          weight MQ by suffix tree based estimate" << endl
+         << "                                   when estimate less than FLOAT [0]" << endl
+         << "      --id-mq-weight N             scale mapping quality by the alignment score" << endl
+         << "                                   identity to this power [2]" << endl
+         << "  -W, --min-chain INT              discard a chain if seeded bases are" << endl
+         << "                                   shorter than INT [0]" << endl
+         << "  -C, --drop-chain FLOAT           drop chains shorter than FLOAT fraction of" << endl
+         << "                                   the longest overlapping chain [0.45]" << endl
+         << "  -n, --mq-overlap FLOAT           scale MQ by count of alignments with FLOAT" << endl
+         << "                                   overlap in the query with the primary [0]" << endl
+         << "  -P, --min-ident FLOAT            accept alignment only if the alignment" << endl
+         << "                                   identity is >= FLOAT [0]" << endl
+         << "  -H, --max-target-x N             skip cluster subgraphs with" << endl 
+         << "                                   length > N*read_length [100]" << endl
+         << "  -w, --band-width INT             band width for long read alignment [256]" << endl
+         << "  -O, --band-overlap INT           band overlap for long read alignment [{-w}/8]" << endl
+         << "  -J, --band-jump INT              the maximum number of bands of insertion we" << endl
+         << "                                   consider in the alignment chain model [128]" << endl
+         << "  -B, --band-multi INT             consider this many alignments of each band" << endl
+         << "                                   in banded alignment [16]" << endl
+         << "  -Z, --band-min-mq INT            treat bands with < INT MQ as unaligned [0]" << endl
+         << "  -I, --fragment STR               fragment length distribution specification" << endl
+         << "                                   STR=m:μ:σ:o:d [5000:0:0:0:1]" << endl
+         << "                                   max:mean:stdev:orientation (1=same/0=flip):" << endl
+         << "                                   direction (1=forward, 0=backward)" << endl
+         << "  -U, --fixed-frag-model           don't learn the pair fragment model online," << endl
+         << "                                   use -I without update" << endl
+         << "  -p, --print-frag-model           suppress alignment output and print the" << endl
+         << "                                   fragment model on stdout as per -I format" << endl
+         << "      --frag-calc INT              update the fragment model" << endl
+         << "                                   every INT perfect pairs [10]" << endl
+         << "      --fragment-x FLOAT           calculate max fragment size as" << endl
+         << "                                   frag_mean+frag_sd*FLOAT [10]" << endl
+         << "      --mate-rescues INT           attempt up to INT mate rescues per pair [64]" << endl
+         << "  -S, --unpaired-cost INT          penalty for an unpaired read pair [17]" << endl
+         << "      --no-patch-aln               do not patch banded alignments by" << endl 
+         << "                                   locally aligning unaligned regions" << endl
+         << "      --xdrop-alignment            use X-drop heuristic" << endl
+         << "                                   (much faster for long-read alignment)" << endl
+         << "      --max-gap-length INT         maximum gap length allowed in each contiguous" << endl
+         << "                                   alignment (for X-drop alignment) [40]" << endl
          << "scoring:" << endl
-         << "    -q, --match INT               use this match score [1]" << endl
-         << "    -z, --mismatch INT            use this mismatch penalty [4]" << endl
-         << "    --score-matrix FILE           read a 4x4 integer substitution scoring matrix from a file" << endl
-         << "    -o, --gap-open INT            use this gap open penalty [6]" << endl
-         << "    -y, --gap-extend INT          use this gap extension penalty [1]" << endl
-         << "    -L, --full-l-bonus INT        the full-length alignment bonus [5]" << endl
-         << "    --drop-full-l-bonus           remove the full length bonus from the score before sorting and MQ calculation" << endl
-         << "    -a, --hap-exp FLOAT           the exponent for haplotype consistency likelihood in alignment score [1]" << endl
-         << "    --recombination-penalty FLOAT use this log recombination penalty for GBWT haplotype scoring [20.7]" << endl
-         << "    -A, --qual-adjust             perform base quality adjusted alignments (requires base quality input)" << endl
+         << "  -q, --match INT                  use this match score [1]" << endl
+         << "  -z, --mismatch INT               use this mismatch penalty [4]" << endl
+         << "      --score-matrix FILE          use this 4x4 integer substitution scoring" << endl
+         << "                                   matrix (in the order ACGT)" << endl
+         << "  -o, --gap-open INT               use this gap open penalty [6]" << endl
+         << "  -y, --gap-extend INT             use this gap extension penalty [1]" << endl
+         << "  -L, --full-l-bonus INT           the full-length alignment bonus [5]" << endl
+         << "      --drop-full-l-bonus          remove the full length bonus from the score" << endl
+         << "                                   before sorting and MQ calculation" << endl
+         << "  -a, --hap-exp FLOAT              the exponent for haplotype consistency" << endl
+         << "                                   likelihood in alignment score [1]" << endl
+         // This is NUM instead of FLOAT because the option name is so long
+         << "      --recombination-penalty NUM  use this log recombination penalty" << endl
+         << "                                   for GBWT haplotype scoring [20.7]" << endl
+         << "  -A, --qual-adjust                perform base quality adjusted alignments" << endl
+         << "                                   (requires base quality input)" << endl
          << "preset:" << endl
-         << "    -m, --alignment-model STR     use a preset alignment scoring model, either \"short\" (default) or \"long\" (for ONT/PacBio)" << endl
-         << "                                  \"long\" is equivalent to `-u 2 -L 63 -q 1 -z 2 -o 2 -y 1 -w 128 -O 32`" << endl
+         << "  -m, --alignment-model STR        use a preset alignment scoring model, either" << endl
+         << "                                   \"short\" (default) or \"long\" (ONT/PacBio)" << endl
+         << "                                   \"long\" is equivalent to" << endl
+         << "                                   `-u 2 -L 63 -q 1 -z 2 -o 2 -y 1 -w 128 -O 32`" << endl
          << "input:" << endl
-         << "    -s, --sequence STR            align a string to the graph in graph.vg using partial order alignment" << endl
-         << "    -V, --seq-name STR            name the sequence using this value (for graph modification with new named paths)" << endl
-         << "    -T, --reads FILE              take reads (one per line) from FILE, write alignments to stdout" << endl
-         << "    -b, --hts-input FILE          align reads from htslib-compatible FILE (BAM/CRAM/SAM) stdin (-), alignments to stdout" << endl
-         << "    -G, --gam-input FILE          realign GAM input" << endl
-         << "    -f, --fastq FILE              input fastq or (2-line format) fasta, possibly compressed, two are allowed, one for each mate" << endl
-         << "    -F, --fasta FILE              align the sequences in a FASTA file that may have multiple lines per reference sequence" << endl
-         << "    --comments-as-tags            intepret comments in name lines as SAM-style tags and annotate alignments with them" << endl
-         << "    -i, --interleaved             fastq or GAM is interleaved paired-ended" << endl
-         << "    -N, --sample NAME             for --reads input, add this sample" << endl
-         << "    -R, --read-group NAME         for --reads input, add this read group" << endl
+         << "  -s, --sequence STR               align a string to the graph in graph.vg" << endl
+         << "                                   using partial order alignment" << endl
+         << "  -V, --seq-name STR               name the sequence STR" << endl
+         << "                                   (for graph modification with new named paths)" << endl
+         << "  -T, --reads FILE                 take reads (one per line) from FILE," << endl 
+         << "                                   write alignments to stdout" << endl
+         << "  -b, --hts-input FILE             align reads from stdin htslib-compatible FILE" << endl
+         << "                                   (BAM/CRAM/SAM), alignments to stdout" << endl
+         << "  -G, --gam-input FILE             realign GAM input" << endl
+         << "  -f, --fastq FILE                 input FASTQ or (2-line format) FASTA, maybe" << endl
+         << "                                   compressed; two allowed, one for each mate" << endl
+         << "  -F, --fasta FILE                 align the sequences in a FASTA file that may" << endl
+         << "                                   have multiple lines per reference sequence" << endl
+         << "      --comments-as-tags           intepret comments in name lines as SAM-style" << endl
+         << "                                   tags and annotate alignments with them" << endl
+         << "  -i, --interleaved                FASTQ or GAM is interleaved paired-ended" << endl
+         << "  -N, --sample NAME                for --reads input, add this sample" << endl
+         << "  -R, --read-group NAME            for --reads input, add this read group" << endl
          << "output:" << endl
-         << "    -j, --output-json             output JSON rather than an alignment stream (helpful for debugging)" << endl
-         << "    -%, --gaf                     output alignments in GAF format" << endl
-         << "    --surject-to TYPE             surject the output into the graph's paths, writing TYPE := bam |sam | cram" << endl
-         << "    --ref-paths FILE              ordered list of paths in the graph, one per line or HTSlib .dict, for HTSLib @SQ headers" << endl
-         << "    --ref-name NAME               name of reference assembly in the graph for HTSlib output" << endl
-         << "    --buffer-size INT             buffer this many alignments together before outputting in GAM [512]" << endl
-         << "    -X, --compare                 realign GAM input (-G), writing alignment with \"correct\" field set to overlap with input" << endl
-         << "    -v, --refpos-table            for efficient testing output a table of name, chr, pos, mq, score" << endl
-         << "    -K, --keep-secondary          produce alignments for secondary input alignments in addition to primary ones" << endl
-         << "    -M, --max-multimaps INT       produce up to INT alignments for each read [1]" << endl
-         << "    -Q, --mq-max INT              cap the mapping quality at INT [60]" << endl
-         << "    --exclude-unaligned           exclude reads with no alignment" << endl
-         << "    -D, --debug                   print debugging information about alignment to stderr" << endl
-         << "    --log-time                    print runtime to stderr" << endl;
+         << "  -j, --output-json                output JSON rather than an alignment stream" << endl
+         << "                                   (helpful for debugging)" << endl
+         << "  -%, --gaf                        output alignments in GAF format" << endl
+         << "      --surject-to TYPE            surject the output into the graph's paths," << endl
+         << "                                   writing TYPE {bam, sam, cram}" << endl
+         << "      --ref-paths FILE             ordered list of paths in graph, one per line" << endl
+         << "                                   or HTSlib .dict, for HTSLib @SQ headers" << endl
+         << "      --ref-name NAME              reference assembly in graph for HTSlib output" << endl
+         << "      --buffer-size INT            buffer this many alignments together" << endl
+         << "                                   before outputting in GAM [512]" << endl
+         << "  -X, --compare                    realign -G GAM input, writing alignment with" << endl
+         << "                                   \"correct\" field set to overlap with input" << endl
+         << "  -v, --refpos-table               for efficient testing output a table of" << endl
+         << "                                   name, chr, pos, mq, score" << endl
+         << "  -K, --keep-secondary             produce alignments for secondary input" << endl
+         << "                                   alignments in addition to primary ones" << endl
+         << "  -M, --max-multimaps INT          produce up to INT alignments per read [1]" << endl
+         << "  -Q, --mq-max INT                 cap the mapping quality at INT [60]" << endl
+         << "      --exclude-unaligned          exclude reads with no alignment" << endl
+         << "  -D, --debug                      print debugging information to stderr" << endl
+         << "      --log-time                   print runtime to stderr" << endl
+         << "  -h, --help                       print this help message to stderr and exit" << endl;
 
 }
 
@@ -280,7 +328,8 @@ int main_map(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "s:J:Q:d:x:g:1:T:N:R:c:M:t:G:jb:Kf:iw:P:Dk:Y:r:W:H:Z:q:z:o:y:Au:B:I:S:l:e:C:V:O:L:a:n:E:XUpF:m:7:v5:824:3:9:0:%^h?",
+        c = getopt_long (argc, argv,
+        "s:J:Q:d:x:g:1:T:N:R:c:M:t:G:jb:Kf:iw:P:Dk:Y:r:W:H:Z:q:z:o:y:Au:B:I:S:l:e:C:V:O:L:a:n:E:XUpF:m:7:v5:824:3:9:0:%^h?",
                          long_options, &option_index);
 
 
@@ -625,15 +674,18 @@ int main_map(int argc, char** argv) {
     bool hts_output = (output_format == "SAM" || output_format == "BAM" || output_format == "CRAM");
 
     if (!ref_paths_name.empty() && !hts_output) {
-        cerr << "warning:[vg map] Reference path file (--ref-paths) is only used when output format (--surject-to) is SAM, BAM, or CRAM." << endl;
+        cerr << "warning:[vg map] Reference path file (--ref-paths) is only used when output format "
+             << "(--surject-to) is SAM, BAM, or CRAM." << endl;
         ref_paths_name = "";
     }
     if (!reference_assembly_names.empty() && !hts_output) {
-        cerr << "warning:[vg map] Reference assembly names (--ref-name) are only used when output format (--surject-to) is SAM, BAM, or CRAM." << endl;
+        cerr << "warning:[vg map] Reference assembly names (--ref-name) are only used when output format "
+             << "(--surject-to) is SAM, BAM, or CRAM." << endl;
         reference_assembly_names.clear();
     }
 
-    if (seq.empty() && read_file.empty() && hts_file.empty() && fastq1.empty() && gam_input.empty() && fasta_file.empty()) {
+    if (seq.empty() && read_file.empty() && hts_file.empty() && fastq1.empty()
+        && gam_input.empty() && fasta_file.empty()) {
         cerr << "error:[vg map] A sequence or read file is required when mapping." << endl;
         return 1;
     }
@@ -643,9 +695,10 @@ int main_map(int argc, char** argv) {
         return 1;
     }
 
-    if (qual_adjust_alignments && ((fastq1.empty() && hts_file.empty() && qual.empty() && gam_input.empty()) // must have some quality input
-                                   || (!seq.empty() && qual.empty())                                         // can't provide sequence without quality
-                                   || !read_file.empty()))                                                   // can't provide sequence list without qualities
+    if (qual_adjust_alignments &&
+        ((fastq1.empty() && hts_file.empty() && qual.empty() && gam_input.empty()) // must have some quality input
+         || (!seq.empty() && qual.empty()) // can't provide sequence without quality
+         || !read_file.empty()))           // can't provide sequence list without qualities
     {
         cerr << "error:[vg map] Quality adjusted alignments require base quality scores for all sequences." << endl;
         return 1;
@@ -773,7 +826,8 @@ int main_map(int argc, char** argv) {
     }
     
     // Set up output to an emitter that will handle serialization and surjection
-    unique_ptr<vg::io::AlignmentEmitter> alignment_emitter = get_alignment_emitter("-", output_format, paths, thread_count, xgidx);
+    unique_ptr<vg::io::AlignmentEmitter> alignment_emitter = get_alignment_emitter("-", output_format, paths, 
+                                                                                   thread_count, xgidx);
 
     // We have one function to dump alignments into
     auto output_alignments = [&](vector<Alignment>& alns1, vector<Alignment>& alns2) {
@@ -833,12 +887,14 @@ int main_map(int argc, char** argv) {
         m->max_sub_mem_recursion_depth = max_sub_mem_recursion_depth;
         m->max_target_factor = max_target_factor;
         if (matrix_stream.is_open()) {
-            m->set_alignment_scores(matrix_stream, gap_open, gap_extend, full_length_bonus, haplotype_consistency_exponent);
+            m->set_alignment_scores(matrix_stream, gap_open, gap_extend,
+                                    full_length_bonus, haplotype_consistency_exponent);
             // reset the stream for the next Mapper
             matrix_stream.seekg(0);
         }
         else {
-            m->set_alignment_scores(match, mismatch, gap_open, gap_extend, full_length_bonus, haplotype_consistency_exponent);
+            m->set_alignment_scores(match, mismatch, gap_open, gap_extend, 
+                                    full_length_bonus, haplotype_consistency_exponent);
         }
         m->strip_bonuses = strip_bonuses;
         m->max_xdrop_gap_length = max_gap_length;
@@ -987,7 +1043,8 @@ int main_map(int argc, char** argv) {
     if (!hts_file.empty()) {
         function<void(Alignment&)> lambda = [&](Alignment& alignment) {
             if(alignment.is_secondary() && !keep_secondary) {
-                // Skip over secondary alignments in the input; we don't want several output mappings for each input *mapping*.
+                // Skip over secondary alignments in the input;
+                // we don't want several output mappings for each input *mapping*.
                 return;
             }
 

--- a/src/subcommand/mask_main.cpp
+++ b/src/subcommand/mask_main.cpp
@@ -76,7 +76,7 @@ int main_mask(int argc, char** argv) {
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hb:gs:", long_options, &option_index);
+        c = getopt_long (argc, argv, "h?b:gs:", long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/mask_main.cpp
+++ b/src/subcommand/mask_main.cpp
@@ -26,7 +26,8 @@ vector<tuple<string, size_t, size_t>> parse_bed(istream& in){
     string token_buffer;
     while (getline(in, line_buffer)) {
         
-        if (line_buffer.empty() || line_buffer.front() == '#' || line_buffer.substr(0, 5) == "track" || line_buffer.substr(0, 7) == "browser") {
+        if (line_buffer.empty() || line_buffer.front() == '#'
+            || line_buffer.substr(0, 5) == "track" || line_buffer.substr(0, 7) == "browser") {
             // header line
             continue;
         }
@@ -46,15 +47,15 @@ vector<tuple<string, size_t, size_t>> parse_bed(istream& in){
 }
 
 void help_mask(char** argv) {
-  cerr << "usage: " << argv[0] << " [options] <graph>" << endl
-       << "Mask out specified regions of a graph with N's" << endl
-       << endl
-       << "input options: " << endl
-       << "    -b, --bed FILE       BED regions corresponding to path intervals of the graph to target (required)" << endl
-       << "    -g, --gbz-input      input graph is in GBZ format" << endl
-       << "    -s, --snarls FILE    snarls from vg snarls (computed directly if not provided)" << endl
-    
-       << endl;
+    cerr << "usage: " << argv[0] << " [options] <graph>" << endl
+         << "Mask out specified regions of a graph with N's" << endl
+         << endl
+         << "input options: " << endl
+         << "  -b, --bed FILE       BED regions corresponding to path intervals" << endl
+         << "                       of the graph to target (required)" << endl
+         << "  -g, --gbz-input      input graph is in GBZ format" << endl
+         << "  -s, --snarls FILE    snarls from vg snarls (computed directly if not provided)" << endl
+         << "  -h, --help           print this help message to stderr and exit" << endl;
 }    
 
 int main_mask(int argc, char** argv) {
@@ -88,7 +89,7 @@ int main_mask(int argc, char** argv) {
             case '?':
             case 'h':
                 help_mask(argv);
-                return 0;
+                return 1;
             case 'b':
                 bed_filepath = optarg;
                 break;

--- a/src/subcommand/mcmc_main.cpp
+++ b/src/subcommand/mcmc_main.cpp
@@ -34,7 +34,7 @@ void help_mcmc(char** argv) {
     << "  -i, --iteration-number INT        tells us the number of iterations to run mcmc_genotyper with" <<endl
     << "  -r, --seed INT                    the seed we will use for the random number generator " << endl
     << "  -s, --sample NAME                 sample name [default=SAMPLE]" << endl
-    << "  -p  --ref-path NAME               reference path to call on (multipile allowed.  defaults to all paths)"<< endl
+    << "  -p, --ref-path NAME               reference path to call on (multipile allowed.  defaults to all paths)"<< endl
     << "  -o, --ref-offset N                offset in reference path (multiple allowed, 1 per path)" << endl
     << "  -l, --ref-length N                override length of reference in the contig field of output VCF" << endl
     << "  -v, --vcf-out FILE                write VCF output to this file" << endl
@@ -82,7 +82,7 @@ int main_mcmc(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hi:s:p:o:l:r:v:b:g:",
+        c = getopt_long (argc, argv, "h?i:s:p:o:l:r:v:b:g:",
                          long_options, &option_index);
 
 

--- a/src/subcommand/mcmc_main.cpp
+++ b/src/subcommand/mcmc_main.cpp
@@ -1,5 +1,6 @@
 /**
- * \file mcmc_main.cpp: GFA (Graph Alignment Format) Fast Emitter: a new mapper that will be *extremely* fast once we actually write it
+ * \file mcmc_main.cpp: GFA (Graph Alignment Format) Fast Emitter:
+ * a new mapper that will be *extremely* fast once we actually write it
  */
 
 #include <omp.h>
@@ -26,20 +27,21 @@ using namespace vg;
 using namespace vg::subcommand;
 
 void help_mcmc(char** argv) {
-    cerr
-    << "usage: " << argv[0] << " mcmc [options] multipath_alns.mgam graph.vg sites.snarls > graph_with_paths.vg" << endl
-    << "Finds haplotypes based on reads using MCMC methods" << endl
-    << endl
-    << "basic options:" << endl
-    << "  -i, --iteration-number INT        tells us the number of iterations to run mcmc_genotyper with" <<endl
-    << "  -r, --seed INT                    the seed we will use for the random number generator " << endl
-    << "  -s, --sample NAME                 sample name [default=SAMPLE]" << endl
-    << "  -p, --ref-path NAME               reference path to call on (multipile allowed.  defaults to all paths)"<< endl
-    << "  -o, --ref-offset N                offset in reference path (multiple allowed, 1 per path)" << endl
-    << "  -l, --ref-length N                override length of reference in the contig field of output VCF" << endl
-    << "  -v, --vcf-out FILE                write VCF output to this file" << endl
-    << "  -b, --burn-in INT                 number of iterations to run original sample proposal only" <<endl
-    << "  -g, --gamma-freq INT              the frequency (every n iterations) for which to re-make the gamma set (starts after burn-in)" <<endl;
+    cerr << "usage: " << argv[0] << " mcmc [options] multipath_alns.mgam graph.vg sites.snarls > graph_with_paths.vg" << endl
+         << "Finds haplotypes based on reads using MCMC methods" << endl
+         << endl
+         << "basic options:" << endl
+         << "  -i, --iteration-number INT  run mcmc_genotyper with INT iterations" << endl
+         << "  -r, --seed INT              seed for the random number generator" << endl
+         << "  -s, --sample NAME           sample name [SAMPLE]" << endl
+         << "  -p, --ref-path NAME         reference path to call on (may repeat) [all]"<< endl
+         << "  -o, --ref-offset N          offset in reference path (may repeat; 1 per path)" << endl
+         << "  -l, --ref-length N          override reference length for output VCF contig" << endl
+         << "  -v, --vcf-out FILE          write VCF output to this file" << endl
+         << "  -b, --burn-in INT           run original sample proposal for INT interations" << endl
+         << "  -g, --gamma-freq INT        the frequency (every n iterations) for which to" << endl
+         << "                              re-make the gamma set (starts after burn-in)" << endl
+         << "  -h, --help                  print this help message to stderr and exit" << endl;
 }
 
 int main_mcmc(int argc, char** argv) {

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -122,12 +122,12 @@ int main_minimizer(int argc, char** argv) {
     int threads = get_default_threads();
     bool require_distance_index = true;
 
-    #define OPT_THRESHOLD 1001
-    #define OPT_ITERATIONS 1002
-    #define OPT_FAST_COUNTING 1003
-    #define OPT_SAVE_MEMORY 1004
-    #define OPT_HASH_TABLE 1005
-    #define OPT_NO_DIST 1100
+    constexpr int OPT_THRESHOLD = 1001;
+    constexpr int OPT_ITERATIONS = 1002;
+    constexpr int OPT_FAST_COUNTING = 1003;
+    constexpr int OPT_SAVE_MEMORY = 1004;
+    constexpr int OPT_HASH_TABLE = 1005;
+    constexpr int OPT_NO_DIST = 1100;
 
     int c;
     optind = 2; // force optind past command positional argument

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -60,38 +60,49 @@ size_t estimate_hash_table_size(const gbwtgraph::GBZ& gbz, bool progress);
 void help_minimizer(char** argv) {
     std::cerr << "usage: " << argv[0] << " minimizer [options] -d graph.dist -o graph.min graph" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Builds a (w, k)-minimizer index or a (k, s)-syncmer index of the threads in the GBWT" << std::endl;
-    std::cerr << "index. The graph can be any HandleGraph, which will be transformed into a GBWTGraph." << std::endl;
+    std::cerr << "Builds a (w, k)-minimizer index or a (k, s)-syncmer index of the threads in the" << std::endl;
+    std::cerr << "GBWT. The graph can be any HandleGraph, which will be made into a GBWTGraph." << std::endl;
     std::cerr << "The transformation can be avoided by providing a GBWTGraph or a GBZ graph." << std::endl;
     std::cerr << std::endl;
     std::cerr << "Required options:" << std::endl;
-    std::cerr << "    -d, --distance-index FILE annotate the hits with positions in this distance index" << std::endl;
-    std::cerr << "    -o, --output-name FILE  store the index in a file" << std::endl;
+    std::cerr << "  -d, --distance-index FILE  annotate hits with positions in this distance index" << std::endl;
+    std::cerr << "  -o, --output-name FILE     store the index in a file" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Minimizer options:" << std::endl;
-    std::cerr << "    -k, --kmer-length N     length of the kmers in the index (default " << IndexingParameters::short_read_minimizer_k << ", max " << gbwtgraph::DefaultMinimizerIndex::key_type::KMER_MAX_LENGTH << ")" << std::endl;
-    std::cerr << "    -w, --window-length N   choose the minimizer from a window of N kmers (default " << IndexingParameters::short_read_minimizer_w << ")" << std::endl;
-    std::cerr << "    -c, --closed-syncmers   index closed syncmers instead of minimizers" << std::endl;
-    std::cerr << "    -s, --smer-length N     use smers of length N in closed syncmers (default " << IndexingParameters::minimizer_s << ")" << std::endl;
+    std::cerr << "  -k, --kmer-length N        length of the kmers in the index "
+                                           << "[" << IndexingParameters::short_read_minimizer_k 
+                                           << "] (max " << gbwtgraph::DefaultMinimizerIndex::key_type::KMER_MAX_LENGTH 
+                                           << ")" << std::endl;
+    std::cerr << "  -w, --window-length N      choose minimizer from a window of N kmers "
+                                           << "[" << IndexingParameters::short_read_minimizer_w << "]" << std::endl;
+    std::cerr << "  -c, --closed-syncmers      index closed syncmers instead of minimizers" << std::endl;
+    std::cerr << "  -s, --smer-length N        use smers of length N in closed syncmers "
+                                           << "[" << IndexingParameters::minimizer_s << "]" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Weighted minimizers:" << std::endl;
-    std::cerr << "    -W, --weighted          use weighted minimizers" << std::endl;
-    std::cerr << "        --threshold N       downweight kmers with more than N hits (default " << DEFAULT_THRESHOLD << ")" << std::endl;
-    std::cerr << "        --iterations N      downweight frequent kmers by N iterations (default " << DEFAULT_ITERATIONS << ")" << std::endl;
-    std::cerr << "        --fast-counting     use the fast kmer counting algorithm (default)" << std::endl;
-    std::cerr << "        --save-memory       use the space-efficient kmer counting algorithm" << std::endl;
-    std::cerr << "        --hash-table N      use 2^N-cell hash tables for kmer counting (default: guess)" << std::endl;
+    std::cerr << "  -W, --weighted             use weighted minimizers" << std::endl;
+    std::cerr << "      --threshold N          downweight kmers with more than N hits "
+                                           << "[" << DEFAULT_THRESHOLD << "]" << std::endl;
+    std::cerr << "      --iterations N         downweight frequent kmers by N iterations "
+                                           << "[" << DEFAULT_ITERATIONS << "]" << std::endl;
+    std::cerr << "      --fast-counting        use the fast kmer counting algorithm (default)" << std::endl;
+    std::cerr << "      --save-memory          use the space-efficient kmer counting algorithm" << std::endl;
+    std::cerr << "      --hash-table N         use 2^N-cell hash tables for kmer counting" << std::endl;
+    std::cerr << "                             (default: guess)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
-    std::cerr << "    -z, --zipcode-name FILE store the distances that are too big in afile" << std::endl;
-    std::cerr << "                            if -z is not specified, some distances may be discarded" << std::endl;
-    std::cerr << "    -l, --load-index FILE   load the index from a file and insert the new kmers into it" << std::endl;
-    std::cerr << "                            (overrides minimizer / weighted minimizer options)" << std::endl;
-    std::cerr << "    -g, --gbwt-name FILE    use the GBWT index in a file (required with a non-GBZ graph)" << std::endl;
-    std::cerr << "    -p, --progress          show progress information" << std::endl;
-    std::cerr << "    -t, --threads N         use N threads for index construction (default " << get_default_threads() << ")" << std::endl;
-    std::cerr << "                            (using more than " << DEFAULT_MAX_THREADS << " threads rarely helps)" << std::endl;
-    std::cerr << "        --no-dist           build the index without distance index annotations (not recommended)" << std::endl;
+    std::cerr << "  -z, --zipcode-name FILE    store the distances that are too big in afile" << std::endl;
+    std::cerr << "                             if no -z, some distances may be discarded" << std::endl;
+    std::cerr << "  -l, --load-index FILE      load this index and insert the new kmers into it" << std::endl;
+    std::cerr << "                             (overrides minimizer / weighted minimizer options)" << std::endl;
+    std::cerr << "  -g, --gbwt-name FILE       use this GBWT index (required with a non-GBZ graph)" << std::endl;
+    std::cerr << "  -p, --progress             show progress information" << std::endl;
+    std::cerr << "  -t, --threads N            use N threads for index construction "
+                                           << "[" << get_default_threads() << "]" << std::endl;
+    std::cerr << "                             (using more than " << DEFAULT_MAX_THREADS << " threads rarely helps)" << std::endl;
+    std::cerr << "      --no-dist              build the index without distance index annotations" << std::endl;
+    std::cerr << "                             (not recommended)" << std::endl;
+    std::cerr << "  -h, --help                 print this help message to stderr and exit" << std::endl;
     std::cerr << std::endl;
 }
 
@@ -507,4 +518,5 @@ size_t estimate_hash_table_size(const gbwtgraph::GBZ& gbz, bool progress) {
 //------------------------------------------------------------------------------
 
 // Register subcommand
-static vg::subcommand::Subcommand vg_minimizer("minimizer", "build a minimizer index or a syncmer index", vg::subcommand::TOOLKIT, main_minimizer);
+static vg::subcommand::Subcommand vg_minimizer("minimizer", "build a minimizer index or a syncmer index",
+                                               vg::subcommand::TOOLKIT, main_minimizer);

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -65,8 +65,8 @@ void help_minimizer(char** argv) {
     std::cerr << "The transformation can be avoided by providing a GBWTGraph or a GBZ graph." << std::endl;
     std::cerr << std::endl;
     std::cerr << "Required options:" << std::endl;
-    std::cerr << "    -d, --distance-index X  annotate the hits with positions in this distance index" << std::endl;
-    std::cerr << "    -o, --output-name X     store the index to file X" << std::endl;
+    std::cerr << "    -d, --distance-index FILE annotate the hits with positions in this distance index" << std::endl;
+    std::cerr << "    -o, --output-name FILE  store the index in a file" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Minimizer options:" << std::endl;
     std::cerr << "    -k, --kmer-length N     length of the kmers in the index (default " << IndexingParameters::short_read_minimizer_k << ", max " << gbwtgraph::DefaultMinimizerIndex::key_type::KMER_MAX_LENGTH << ")" << std::endl;
@@ -83,11 +83,11 @@ void help_minimizer(char** argv) {
     std::cerr << "        --hash-table N      use 2^N-cell hash tables for kmer counting (default: guess)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
-    std::cerr << "    -z, --zipcode-name X    store the distances that are too big to file X" << std::endl;
+    std::cerr << "    -z, --zipcode-name FILE store the distances that are too big in afile" << std::endl;
     std::cerr << "                            if -z is not specified, some distances may be discarded" << std::endl;
-    std::cerr << "    -l, --load-index X      load the index from file X and insert the new kmers into it" << std::endl;
+    std::cerr << "    -l, --load-index FILE   load the index from a file and insert the new kmers into it" << std::endl;
     std::cerr << "                            (overrides minimizer / weighted minimizer options)" << std::endl;
-    std::cerr << "    -g, --gbwt-name X       use the GBWT index in file X (required with a non-GBZ graph)" << std::endl;
+    std::cerr << "    -g, --gbwt-name FILE    use the GBWT index in a file (required with a non-GBZ graph)" << std::endl;
     std::cerr << "    -p, --progress          show progress information" << std::endl;
     std::cerr << "    -t, --threads N         use N threads for index construction (default " << get_default_threads() << ")" << std::endl;
     std::cerr << "                            (using more than " << DEFAULT_MAX_THREADS << " threads rarely helps)" << std::endl;
@@ -111,12 +111,12 @@ int main_minimizer(int argc, char** argv) {
     int threads = get_default_threads();
     bool require_distance_index = true;
 
-    constexpr int OPT_THRESHOLD = 1001;
-    constexpr int OPT_ITERATIONS = 1002;
-    constexpr int OPT_FAST_COUNTING = 1003;
-    constexpr int OPT_SAVE_MEMORY = 1004;
-    constexpr int OPT_HASH_TABLE = 1005;
-    constexpr int OPT_NO_DIST = 1100;
+    #define OPT_THRESHOLD 1001
+    #define OPT_ITERATIONS 1002
+    #define OPT_FAST_COUNTING 1003
+    #define OPT_SAVE_MEMORY 1004
+    #define OPT_HASH_TABLE 1005
+    #define OPT_NO_DIST 1100
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -138,17 +138,18 @@ int main_minimizer(int argc, char** argv) {
             { "fast-counting", no_argument, 0, OPT_FAST_COUNTING },
             { "save-memory", no_argument, 0, OPT_SAVE_MEMORY },
             { "hash-table", required_argument, 0, OPT_HASH_TABLE },
-            { "zipcode-index", required_argument, 0, 'z' },
+            { "zipcode-name", required_argument, 0, 'z' },
             { "load-index", required_argument, 0, 'l' },
             { "gbwt-graph", no_argument, 0, 'G' }, // deprecated
             { "progress", no_argument, 0, 'p' },
             { "threads", required_argument, 0, 't' },
             { "no-dist", no_argument, 0, OPT_NO_DIST },
+            { "help", no_argument, 0, 'h' },
             { 0, 0, 0, 0 }
         };
 
         int option_index = 0;
-        c = getopt_long(argc, argv, "g:d:o:i:k:w:bcs:Wz:l:Gpt:h", long_options, &option_index);
+        c = getopt_long(argc, argv, "g:d:o:i:k:w:bcs:Wz:l:Gpt:h?", long_options, &option_index);
         if (c == -1) { break; } // End of options.
 
         switch (c)

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -31,49 +31,56 @@ void help_mod(char** argv) {
          << "Modifies graph, outputs modified on stdout." << endl
          << endl
          << "options:" << endl
-         << "    -P, --label-paths       don't edit with -i alignments, just use them for labeling the graph" << endl
-         << "    -c, --compact-ids       should we sort and compact the id space? (default false)" << endl
-         << "    -b, --break-cycles      use an approximate topological sort to break cycles in the graph" << endl
-         << "    -n, --normalize         normalize the graph so that edges are always non-redundant" << endl
-         << "                            (nodes have unique starting and ending bases relative to neighbors," << endl
-         << "                            and edges that do not introduce new paths are removed and neighboring" << endl
-         << "                            nodes are merged)" << endl
-         << "    -U, --until-normal N    iterate normalization until convergence, or at most N times" << endl
-         << "    -z, --nomerge-pre STR   do not let normalize (-n, -U) zip up any pair of nodes that both belong to path with prefix STR" << endl
-         << "    -E, --unreverse-edges   flip doubly-reversing edges so that they are represented on the" << endl
-         << "                            forward strand of the graph" << endl
-         << "    -s, --simplify          remove redundancy from the graph that will not change its path space" << endl
-         << "    -d, --dagify-step N     copy strongly connected components of the graph N times, forwarding" << endl
-         << "                            edges from old to new copies to convert the graph into a DAG" << endl
-         << "    -w, --dagify-to N       copy strongly connected components of the graph forwarding" << endl
-         << "                            edges from old to new copies to convert the graph into a DAG" << endl
-         << "                            until the shortest path through each SCC is N bases long" << endl
-         << "    -L, --dagify-len-max N  stop a dagification step if the unrolling component has this much sequence" << endl
-         << "    -f, --unfold N          represent inversions accessible up to N from the forward" << endl
-         << "                            component of the graph" << endl
-         << "    -O, --orient-forward    orient the nodes in the graph forward" << endl
-         << "    -N, --remove-non-path   keep only nodes and edges which are part of paths" << endl
-         << "    -A, --remove-path       keep only nodes and edges which are not part of any path" << endl
-         << "    -k, --keep-path NAME    keep only nodes and edges in the path (may repeat)" << endl
-         << "    -R, --remove-null       removes nodes that have no sequence, forwarding their edges" << endl
-         << "    -g, --subgraph ID       gets the subgraph rooted at node ID, multiple allowed" << endl
-         << "    -x, --context N         steps the subgraph out by N steps (default: 1)" << endl
-         << "    -p, --prune-complex     remove nodes that are reached by paths of --length which" << endl
-         << "                            cross more than --edge-max edges" << endl
-         << "    -S, --prune-subgraphs   remove subgraphs which are shorter than --length" << endl
-         << "    -l, --length N          for pruning complex regions and short subgraphs" << endl
-         << "    -X, --chop N            chop nodes in the graph so they are not more than N bp long" << endl
-         << "    -u, --unchop            where two nodes are only connected to each other and by one edge" << endl
-         << "                            replace the pair with a single node that is the concatenation of their labels" << endl
-         << "    -e, --edge-max N        only consider paths which make edge choices at <= this many points" << endl
-         << "    -M, --max-degree N      unlink nodes that have edge degree greater than N" << endl
-         << "    -m, --markers           join all head and tails nodes to marker nodes" << endl
-         << "                            ('###' starts and '$$$' ends) of --length, for debugging" << endl
-         << "    -y, --destroy-node ID   remove node with given id" << endl
-         << "    -a, --cactus            convert to cactus graph representation" << endl
-         << "    -v, --sample-vcf FILE   for a graph with allele paths, compute the sample graph from the given VCF" << endl
-         << "    -G, --sample-graph FILE subset an augmented graph to a sample graph using a Locus file" << endl
-         << "    -t, --threads N         for tasks that can be done in parallel, use this many threads" << endl;
+         << "  -c, --compact-ids        should we sort and compact the ID space? (default no)" << endl
+         << "  -b, --break-cycles       break graph cycles with approximate topological sort" << endl
+         << "  -n, --normalize          normalize graph so edges are always non-redundant" << endl
+         << "                           (nodes have unique starting and ending bases relative" << endl
+         << "                           to neighbors, edges that do not introduce new paths" << endl
+         << "                           are removed, and neighboring nodes are merged)" << endl
+         << "  -U, --until-normal N     iterate normalization at most N times" << endl
+         << "  -z, --nomerge-pre STR    do not let normalize (-n/-U) zip up any pair of nodes" << endl
+         << "                           that both belong to path with prefix STR" << endl
+         << "  -E, --unreverse-edges    flip doubly-reversing edges so that they are" << endl
+         << "                           represented on the forward strand of the graph" << endl
+         << "  -s, --simplify           remove redundancy from the graph" << endl
+         << "                           that will not change its path space" << endl
+         << "  -d, --dagify-step N      copy strongly connected components of graph N times," << endl
+         << "                           forwording edges from old to new copies" << endl 
+         << "                           to convert the graph into a DAG" << endl
+         << "  -w, --dagify-to N        copy strongly connected components of the graph," << endl
+         << "                           forwarding edges from old to new copies" << endl 
+         << "                           to convert the graph into a DAG" << endl
+         << "                           until shortest path through each SCC is N bases long" << endl
+         << "  -L, --dagify-len-max N   stop a dagification step if the unrolling component" << endl
+         << "                           has this much sequence" << endl
+         << "  -f, --unfold N           represent inversions accessible up to N from" << endl
+         << "                           the forward component of the graph" << endl
+         << "  -O, --orient-forward     orient the nodes in the graph forward" << endl
+         << "  -N, --remove-non-path    keep only nodes and edges which are part of paths" << endl
+         << "  -A, --remove-path        keep only nodes and edges which aren't part of a path" << endl
+         << "  -k, --keep-path NAME     keep only nodes and edges in the path (may repeat)" << endl
+         << "  -R, --remove-null        remove nodes with no sequence, forwarding their edges" << endl
+         << "  -g, --subgraph ID        gets the subgraph rooted at node ID (may repeat)" << endl
+         << "  -x, --context N          steps the subgraph out by N steps [1]" << endl
+         << "  -p, --prune-complex      remove nodes that are reached by paths of --length" << endl
+         << "                           which cross more than --edge-max edges" << endl
+         << "  -S, --prune-subgraphs    remove subgraphs which are shorter than --length" << endl
+         << "  -l, --length N           for pruning complex regions and short subgraphs" << endl
+         << "  -X, --chop N             chop nodes in the graph so they are <=N bp long" << endl
+         << "  -u, --unchop             where two nodes are only connected to each other and" << endl
+         << "                           by only one edge, replace the pair with a single node" << endl
+         << "                           that is the concatenation of their labels" << endl
+         << "  -e, --edge-max N         consider paths which make edge choices at <= N points" << endl
+         << "  -M, --max-degree N       unlink nodes that have edge degree greater than N" << endl
+         << "  -m, --markers            join all head and tails nodes to marker nodes" << endl
+         << "                           (### starts and $$$ ends) of --length, for debugging" << endl
+         << "  -y, --destroy-node ID    remove node with given id" << endl
+         << "  -a, --cactus             convert to cactus graph representation" << endl
+         << "  -v, --sample-vcf FILE    for a graph with allele paths," << endl
+         << "                           compute the sample graph from the given VCF" << endl
+         << "  -G, --sample-graph FILE  subset augmented graph to sample graph via Locus file" << endl
+         << "  -t, --threads N          for parallel tasks, use this many threads" << endl
+         << "  -h, --help               print this help message to stderr and exit" << endl;
 }
 
 int main_mod(int argc, char** argv) {
@@ -167,7 +174,7 @@ int main_mod(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?k:oi:q:Q:cpl:e:mt:SX:Psunz:NAf:g:x:RU:bd:Ow:L:y:Z:Eav:G:M:Dr:I",
-                long_options, &option_index);
+                         long_options, &option_index);
 
 
         // Detect the end of the options.

--- a/src/subcommand/mod_main.cpp
+++ b/src/subcommand/mod_main.cpp
@@ -97,7 +97,6 @@ int main_mod(int argc, char** argv) {
     bool normalize_graph = false;
     bool remove_non_path = false;
     bool remove_path = false;
-    bool compact_ranks = false;
     vector<nid_t> root_nodes;
     int32_t context_steps;
     bool remove_null = false;
@@ -127,7 +126,6 @@ int main_mod(int argc, char** argv) {
             {"include-loci", required_argument, 0, 'q'},
             {"include-gt", required_argument, 0, 'Q'},
             {"compact-ids", no_argument, 0, 'c'},
-            {"compact-ranks", no_argument, 0, 'C'},
             {"keep-path", required_argument, 0, 'k'},
             {"remove-orphans", no_argument, 0, 'o'},
             {"prune-complex", no_argument, 0, 'p'},
@@ -150,7 +148,7 @@ int main_mod(int argc, char** argv) {
             {"subgraph", required_argument, 0, 'g'},
             {"context", required_argument, 0, 'x'},
             {"remove-null", no_argument, 0, 'R'},
-            {"dagify-steps", required_argument, 0, 'd'},
+            {"dagify-step", required_argument, 0, 'd'},
             {"dagify-to", required_argument, 0, 'w'},
             {"dagify-len-max", required_argument, 0, 'L'},
             {"break-cycles", no_argument, 0, 'b'},
@@ -168,7 +166,7 @@ int main_mod(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hk:oi:q:Q:cpl:e:mt:SX:KPsunz:NAf:Cg:x:RTU:Bbd:Ow:L:y:Z:Eav:G:M:Dr:I",
+        c = getopt_long (argc, argv, "h?k:oi:q:Q:cpl:e:mt:SX:Psunz:NAf:g:x:RU:bd:Ow:L:y:Z:Eav:G:M:Dr:I",
                 long_options, &option_index);
 
 

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -27,16 +27,16 @@
 #include <bdsg/hash_graph.hpp>
 #include <xg.hpp>
 
-//constexpr int record_read_run_times
+//#define record_read_run_times
 
 #ifdef record_read_run_times
-constexpr int READ_TIME_FILE "_read_times.tsv"
+#define READ_TIME_FILE "_read_times.tsv"
 #include <ctime>
 #include <iostream>
 #endif
 
 #ifdef mpmap_instrument_mem_statistics
-constexpr int MEM_STATS_FILE "_mem_statistics.tsv"
+#define MEM_STATS_FILE "_mem_statistics.tsv"
 #endif
 
 using namespace std;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -87,88 +87,124 @@ pair<vector<double>, vector<pair<double, double>>> parse_intron_distr_file(ifstr
 }
 
 void help_mpmap(char** argv) {
-    cerr
-    << "usage: " << argv[0] << " mpmap [options] -x graph.xg -g index.gcsa [-f reads1.fq [-f reads2.fq] | -G reads.gam] > aln.gamp" << endl
-    << "Multipath align reads to a graph." << endl
-    << endl
-    << "basic options:" << endl
-    << "graph/index:" << endl
-    << "  -x, --graph-name FILE     graph (required; XG format recommended but other formats are valid, see `vg convert`) " << endl
-    << "  -g, --gcsa-name FILE      use this GCSA2/LCP index pair for MEMs (required; both FILE and FILE.lcp, see `vg index`)" << endl
-    //<< "  -H, --gbwt-name FILE         use this GBWT haplotype index for population-based MAPQs" << endl
-    << "  -d, --dist-name FILE      use this snarl distance index for clustering (recommended, see `vg index`)" << endl
-    //<< "      --linear-index FILE      use this sublinear Li and Stephens index file for population-based MAPQs" << endl
-    //<< "      --linear-path PATH       use the given path name as the path that the linear index is against" << endl
-    << "  -s, --snarls FILE         align to alternate paths in these snarls (unnecessary if providing -d, see `vg snarls`)" << endl
-    << "input:" << endl
-    << "  -f, --fastq FILE          input FASTQ (possibly gzipped), can be given twice for paired ends (for stdin use -)" << endl
-    << "  -i, --interleaved         input contains interleaved paired ends" << endl
-    << "  -C, --comments-as-tags    intepret comments in name lines as SAM-style tags and annotate alignments with them" << endl
-    << "algorithm presets:" << endl
-    << "  -n, --nt-type TYPE        sequence type preset: 'DNA' for genomic data, 'RNA' for transcriptomic data [RNA]" << endl
-    << "  -l, --read-length TYPE    read length preset: 'very-short', 'short', or 'long' (approx. <50bp, 50-500bp, and >500bp) [short]" << endl
-    << "  -e, --error-rate TYPE     error rate preset: 'low' or 'high' (approx. PHRED >20 and <20) [low]" << endl
-    << "output:" << endl
-    << "  -F, --output-fmt TYPE     format to output alignments in: 'GAMP for' multipath alignments, 'GAM' or 'GAF' for single-path" << endl
-    << "                            alignments, 'SAM', 'BAM', or 'CRAM' for linear reference alignments (may also require -S) [GAMP]" << endl
-    << "  -S, --ref-paths FILE      paths in the graph either 1) one per line in a text file, or 2) in an HTSlib .dict, to treat as" << endl
-    << "                            reference sequences for HTSlib formats (see -F) [all reference paths, all generic paths]" << endl
-    << "      --ref-name NAME       reference assembly in the graph to use for HTSlib formats (see -F) [all references]" << endl 
-    << "  -N, --sample NAME         add this sample name to output" << endl
-    << "  -R, --read-group NAME     add this read group to output" << endl
-    << "  -p, --suppress-progress   do not report progress to stderr" << endl
-    //<< "algorithm:" << endl
-    //<< "       --min-dist-cluster       use the minimum distance based clusterer (requires a distance index from -d)" << endl
-//    << "scoring:" << endl
-//    << "  -E, --long-read-scoring      set alignment scores to long-read defaults: -q1 -z1 -o1 -y1 -L0 (can be overridden)" << endl
-    << "computational parameters:" << endl
-    << "  -t, --threads INT         number of compute threads to use [all available]" << endl
-    << endl
-    << "advanced options:" << endl
-    << "algorithm:" << endl
-    //<< "  -v, --tvs-clusterer          use the target value search-based clusterer (requires a distance index from -d)" << endl
-    //<< "  -a, --alt-paths INT          align to (up to) this many alternate paths in snarls [10]" << endl
-    //<< "      --suppress-tail-anchors  don't produce extra anchors when aligning to alternate paths in snarls" << endl
-    //<< "  -T, --same-strand            read pairs are from the same strand of the DNA/RNA molecule" << endl
-    << "  -X, --not-spliced         do not form spliced alignments, even if aligning with --nt-type 'rna'" << endl
-    << "  -M, --max-multimaps INT   report (up to) this many mappings per read [10 rna / 1 dna]" << endl
-    << "  -a, --agglomerate-alns    combine separate multipath alignments into one (possibly disconnected) alignment" << endl
-    << "  -r, --intron-distr FILE   intron length distribution (from scripts/intron_length_distribution.py)" << endl
-    << "  -Q, --mq-max INT          cap mapping quality estimates at this much [60]" << endl
-    << "  -b, --frag-sample INT     look for this many unambiguous mappings to estimate the fragment length distribution [1000]" << endl
-    << "  -I, --frag-mean FLOAT     mean for a pre-determined fragment length distribution (also requires -D)" << endl
-    << "  -D, --frag-stddev FLOAT   standard deviation for a pre-determined fragment length distribution (also requires -I)" << endl
-    //<< "  -B, --no-calibrate           do not auto-calibrate mismapping dectection" << endl
-    << "  -G, --gam-input FILE      input GAM (for stdin, use -)" << endl
-    //<< "  -P, --max-p-val FLOAT        background model p-value must be less than this to avoid mismapping detection [0.0001]" << endl
-    //<< "  -U, --report-group-mapq   add an annotation for the collective mapping quality of all reported alignments" << endl
-    //<< "      --padding-mult FLOAT     pad dynamic programming bands in inter-MEM alignment FLOAT * sqrt(read length) [1.0]" << endl
-    << "  -u, --map-attempts INT    perform (up to) this many mappings per read (0 for no limit) [24 paired / 64 unpaired]" << endl
-    //<< "      --max-paths INT          consider (up to) this many paths per alignment for population consistency scoring, 0 to disable [10]" << endl
-    //<< "      --top-tracebacks         consider paths for each alignment based only on alignment score and not based on haplotypes" << endl
-    //<< "  -r, --reseed-length INT      reseed SMEMs for internal MEMs if they are at least this long (0 for no reseeding) [28]" << endl
-    //<< "  -W, --reseed-diff FLOAT      require internal MEMs to have length within this much of the SMEM's length [0.45]" << endl
-    //<< "  -K, --clust-length INT       minimum MEM length used in clustering [automatic]" << endl
-    //<< "  -F, --stripped-match         use stripped match algorithm instead of MEMs" << endl
-    << "  -c, --hit-max INT         use at most this many hits for any match seeds (0 for no limit) [1024 DNA / 100 RNA]" << endl
-    //<< "  --approx-exp FLOAT           let the approximate likelihood miscalculate likelihood ratios by this power [10.0 DNA / 5.0 RNA]" << endl
-    //<< "  --recombination-penalty FLOAT use this log recombination penalty for GBWT haplotype scoring [20.7]" << endl
-    //<< "  --always-check-population    always try to population-score reads, even if there is only a single mapping" << endl
-    //<< "  --delay-population           do not apply population scoring at intermediate stages of the mapping algorithm" << endl
-    //<< "  --force-haplotype-count INT  assume that INT haplotypes ought to run through each fixed part of the graph, if nonzero [0]" << endl
-    //<< "  --drop-subgraph FLOAT    drop alignment subgraphs whose MEMs cover this fraction less of the read than the best subgraph [0.2]" << endl
-    //<< "  --prune-exp FLOAT            prune MEM anchors if their approximate likelihood is this root less than the optimal anchors [1.25]" << endl
-    << "scoring:" << endl
-    << "  -A, --no-qual-adjust      do not perform base quality adjusted alignments even when base qualities are available" << endl
-    << "  -q, --match INT           use this match score [1]" << endl
-    << "  -z, --mismatch INT        use this mismatch penalty [4 low error, 1 high error]" << endl
-    << "  -o, --gap-open INT        use this gap open penalty [6 low error, 1 high error]" << endl
-    << "  -y, --gap-extend INT      use this gap extension penalty [1]" << endl
-    << "  -L, --full-l-bonus INT    add this score to alignments that align each end of the read [mismatch+1 short, 0 long]" << endl
-    << "  -w, --score-matrix FILE   read a 4x4 integer substitution scoring matrix from a file (in the order ACGT)" << endl
-    << "  -m, --remove-bonuses      remove full length alignment bonuses in reported scores" << endl;
-    //<< "computational parameters:" << endl
-    //<< "  -Z, --buffer-size INT        buffer this many alignments together (per compute thread) before outputting to stdout [200]" << endl;
+    cerr << "usage: " << argv[0] << " mpmap [options] -x graph.xg -g index.gcsa "
+         << "[-f reads1.fq [-f reads2.fq] | -G reads.gam] > aln.gamp" << endl
+         << "Multipath align reads to a graph." << endl
+         << endl
+         << "basic options:" << endl
+         << "  -h, --help                print this help message to stderr and exit" << endl
+         << "graph/index:" << endl
+         << "  -x, --graph-name FILE     graph (required; XG recommended but other formats" << endl
+         << "                            are acceptable: see `vg convert`)" << endl
+         << "  -g, --gcsa-name FILE      use this GCSA2 (FILE) & LCP (FILE.lcp) index pair" << endl
+         << "                            for MEMs (required; see `vg index`)" << endl
+       //<< "  -H, --gbwt-name FILE      use this GBWT haplotype index for population-based MAPQs" << endl
+         << "  -d, --dist-name FILE      use this snarl distance index for clustering" << endl
+         << "                            (recommended, see `vg index`)" << endl
+       //<< "      --linear-index FILE   use this sublinear Li and Stephens index file for population-based MAPQs" << endl
+       //<< "      --linear-path PATH    use the given path name as the path that the linear index is against" << endl
+         << "  -s, --snarls FILE         align to alternate paths in these snarls" << endl
+         << "                            (unnecessary if providing -d, see `vg snarls`)" << endl
+         << "input:" << endl
+         << "  -f, --fastq FILE          input FASTQ (possibly gzipped), can be given twice" << endl
+         << "                            for paired ends (for stdin use -)" << endl
+         << "  -i, --interleaved         input contains interleaved paired ends" << endl
+         << "  -C, --comments-as-tags    intepret comments in name lines as SAM-style tags" << endl
+         << "                            and annotate alignments with them" << endl
+         << "algorithm presets:" << endl
+         << "  -n, --nt-type TYPE        sequence type preset: 'DNA' for genomic data," << endl
+         << "                            'RNA' for transcriptomic data [RNA]" << endl
+         << "  -l, --read-length TYPE    read length preset: {very-short, short, long}" << endl
+         << "                            (approx. <50bp, 50-500bp, and >500bp) [short]" << endl
+         << "  -e, --error-rate TYPE     error rate preset: {low, high}" << endl
+         << "                            (approx. PHRED >20 and <20) [low]" << endl
+         << "output:" << endl
+         << "  -F, --output-fmt TYPE     format to output alignments in:" << endl
+         << "                            'GAMP' for multipath alignments," << endl
+         << "                            'GAM'/'GAF' for single-path alignments," << endl
+         << "                            'SAM'/'BAM'/'CRAM' for linear reference alignments" << endl
+         << "                            (may also require -S) [GAMP]" << endl
+         << "  -S, --ref-paths FILE      paths in graph are 1) one per line in a text file" << endl
+         << "                            or 2) in an HTSlib .dict, to treat as" << endl
+         << "                            reference sequences for HTSlib formats (see -F)" << endl
+         << "                            [all reference paths, all generic paths]" << endl
+         << "      --ref-name NAME       reference assembly in graph to use for" << endl
+         << "                            HTSlib formats (see -F) [all references]" << endl 
+         << "  -N, --sample NAME         add this sample name to output" << endl
+         << "  -R, --read-group NAME     add this read group to output" << endl
+         << "  -p, --suppress-progress   do not report progress to stderr" << endl
+       //<< "algorithm:" << endl
+       //<< "       --min-dist-cluster   use the minimum distance based clusterer" << endl
+       //<< "                            (requires a distance index from -d)" << endl
+       //<< "scoring:" << endl
+       //<< "  -E, --long-read-scoring   set alignment scores to long-read defaults:" << endl
+       //<< "                            -q1 -z1 -o1 -y1 -L0 (can be overridden)" << endl
+         << "computational parameters:" << endl
+         << "  -t, --threads INT         number of compute threads to use [all available]" << endl
+         << endl
+         << "advanced options:" << endl
+         << "algorithm:" << endl
+       //<< "  -v, --tvs-clusterer       use the target value search-based clusterer" << endl
+       //<< "                            (requires a distance index from -d)" << endl
+       //<< "  -a, --alt-paths INT       align to (up to) this many alternate paths in snarls [10]" << endl
+       //<< "  -T, --same-strand         read pairs are from the same strand of the DNA/RNA molecule" << endl
+         << "  -X, --not-spliced         do not form spliced alignments, even with -n RNA" << endl
+         << "  -M, --max-multimaps INT   report up to INT mappings per read [10 RNA / 1 DNA]" << endl
+         << "  -a, --agglomerate-alns    combine separate multipath alignments into" << endl
+         << "                            one (possibly disconnected) alignment" << endl
+         << "  -r, --intron-distr FILE   intron length distribution" << endl
+         << "                            (from scripts/intron_length_distribution.py)" << endl
+         << "  -Q, --mq-max INT          cap mapping quality estimates at this much [60]" << endl
+         << "  -b, --frag-sample INT     look for INT unambiguous mappings to" << endl
+         << "                            estimate the fragment length distribution [1000]" << endl
+         << "  -I, --frag-mean FLOAT     mean for pre-determined fragment length distribution" << endl
+         << "                            (also requires -D)" << endl
+         << "  -D, --frag-stddev FLOAT   standard deviation for pre-determined fragment" << endl
+         << "                            length distribution (also requires -I)" << endl
+       //<< "  -B, --no-calibrate        do not auto-calibrate mismapping dectection" << endl
+         << "  -G, --gam-input FILE      input GAM (for stdin, use -)" << endl
+       //<< "  -P, --max-p-val FLOAT     background model p-value must be less than this" << endl
+       //<< "                            to avoid mismapping detection [0.0001]" << endl
+       //<< "  -U, --report-group-mapq   add an annotation for the collective mapping quality" << endl
+       //<< "                            of all reported alignments" << endl
+       //<< "      --padding-mult FLOAT  pad dynamic programming bands in inter-MEM alignment" << endl
+       //<< "                            FLOAT * sqrt(read length) [1.0]" << endl
+         << "  -u, --map-attempts INT    perform up to INT mappings per read (0 for no limit)" << endl
+         << "                            [24 paired / 64 unpaired]" << endl
+       //<< "      --max-paths INT       consider (up to) this many paths per alignment" << endl
+       //<< "                            for population consistency scoring, 0 to disable [10]" << endl
+       //<< "      --top-tracebacks      consider paths for each alignment based only on" << endl
+       //<< "                            alignment score and not based on haplotypes" << endl
+       //<< "  -r, --reseed-length INT   reseed SMEMs for internal MEMs if they are at least" << endl
+       //<< "                            this long (0 for no reseeding) [28]" << endl
+       //<< "  -W, --reseed-diff FLOAT   require internal MEMs to have length within this much" << endl
+       //<< "                            of the SMEM's length [0.45]" << endl
+       //<< "  -F, --stripped-match      use stripped match algorithm instead of MEMs" << endl
+         << "  -c, --hit-max INT         use at most this many hits for any match seeds" << endl
+         << "                            (0 for no limit) [1024 DNA / 100 RNA]" << endl
+       //<< "  --approx-exp FLOAT           let the approximate likelihood miscalculate" << endl
+       //<< "                               likelihood ratios by this power [10.0 DNA / 5.0 RNA]" << endl
+       //<< "  --recombination-penalty FLOAT use this log recombination penalty for GBWT haplotype scoring [20.7]" << endl
+       //<< "  --always-check-population    always try to population-score reads," << endl
+       //<< "                               even if there is only a single mapping" << endl
+       //<< "  --force-haplotype-count INT  assume that INT haplotypes ought to run through" << endl
+       //<< "                               each fixed part of the graph, if nonzero [0]" << endl
+       //<< "  --drop-subgraph FLOAT        drop alignment subgraphs whose MEMs cover" << endl
+       //<< "                               this fraction less of the read than the best subgraph [0.2]" << endl
+       //<< "  --prune-exp FLOAT            prune MEM anchors if their approximate likelihood" << endl
+       //<< "                               is this root less than the optimal anchors [1.25]" << endl
+         << "scoring:" << endl
+         << "  -A, --no-qual-adjust      do not perform base quality adjusted alignments" << endl
+         << "                            even when base qualities are available" << endl
+         << "  -q, --match INT           use INT match score [1]" << endl
+         << "  -z, --mismatch INT        use INT mismatch penalty [4 low error, 1 high error]" << endl
+         << "  -o, --gap-open INT        use INT gap open penalty [6 low error, 1 high error]" << endl
+         << "  -y, --gap-extend INT      use INT gap extension penalty [1]" << endl
+         << "  -L, --full-l-bonus INT    add INT score to alignments that align each" << endl
+         << "                            end of the read [mismatch+1 short, 0 long]" << endl
+         << "  -w, --score-matrix FILE   use this 4x4 integer substitution scoring matrix" << endl
+         << "                            (in the order ACGT)" << endl
+         << "  -m, --remove-bonuses      remove full length alignment bonus in reported score" << endl;
 }
 
 
@@ -820,7 +856,8 @@ int main_mpmap(int argc, char** argv) {
                 break;
                 
             case 'E':
-                cerr << "warning:[vg mpmap] Long read scoring option (--long-read-scoring) is deprecated. Instead, use read length preset (--read-length)." << endl;
+                cerr << "warning:[vg mpmap] Long read scoring option (--long-read-scoring) is deprecated. "
+                     << "Instead, use read length preset (--read-length)." << endl;
                 read_length = "long";
                 break;
                 
@@ -892,7 +929,8 @@ int main_mpmap(int argc, char** argv) {
             {
                 int num_threads = parse<int>(optarg);
                 if (num_threads <= 0) {
-                    cerr << "error:[vg mpmap] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                    cerr << "error:[vg mpmap] Thread count (-t) set to " << num_threads
+                         << ", must set to a positive integer." << endl;
                     exit(1);
                 }
                 omp_set_num_threads(num_threads);
@@ -1019,7 +1057,8 @@ int main_mpmap(int argc, char** argv) {
     if (nt_type == "rna") {
         // RNA preset
         if (distance_index_name.empty()) {
-            cerr << "warning:[vg mpmap] It is HIGHLY recommended to use a distance index (-d) for clustering on splice graphs. Both accuracy and speed will suffer without one." << endl;
+            cerr << "warning:[vg mpmap] It is HIGHLY recommended to use a distance index (-d) "
+                 << "for clustering on splice graphs. Both accuracy and speed will suffer without one." << endl;
         }
         
         // we'll assume that there might be spliced alignments
@@ -1079,15 +1118,18 @@ int main_mpmap(int argc, char** argv) {
         !(hts_output && transcriptomic)) {
         // adjust parameters that produce irrelevant extra work single path mode
         if (!snarls_name.empty()) {
-            cerr << "warning:[vg mpmap] Snarl file (-s) is ignored for single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
+            cerr << "warning:[vg mpmap] Snarl file (-s) is ignored for "
+                 << "single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
         }
         
         if (snarl_cut_size != default_snarl_cut_size) {
-            cerr << "warning:[vg mpmap] Snarl cut limit (-X) is ignored for single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
+            cerr << "warning:[vg mpmap] Snarl cut limit (-X) is ignored for "
+                 << "single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
         }
         
         if (num_alt_alns != default_num_alt_alns) {
-            cerr << "warning:[vg mpmap] Number of alternate alignments (-a) for ignored in single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
+            cerr << "warning:[vg mpmap] Number of alternate alignments (-a) for ignored for "
+                 << "single path alignment formats (-F) without multipath population scoring (--max-paths)." << endl;
         }
         
         // don't cut inside snarls or load the snarl manager
@@ -1171,7 +1213,8 @@ int main_mpmap(int argc, char** argv) {
     // check for valid parameters
     
     if (std::isnan(frag_length_mean) != std::isnan(frag_length_stddev)) {
-        cerr << "error:[vg mpmap] Cannot specify only one of fragment length mean (-I) and standard deviation (-D)." << endl;
+        cerr << "error:[vg mpmap] Cannot specify only one of fragment length mean (-I) "
+             << "and standard deviation (-D)." << endl;
         exit(1);
     }
     
@@ -1186,7 +1229,8 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (interleaved_input && !fastq_name_2.empty()) {
-        cerr << "error:[vg mpmap] Cannot designate both interleaved paired ends (-i) and separate paired end file (-f)." << endl;
+        cerr << "error:[vg mpmap] Cannot designate both interleaved paired ends (-i) "
+             << "and separate paired end file (-f)." << endl;
         exit(1);
     }
     
@@ -1206,36 +1250,43 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (!ref_paths_name.empty() && !hts_output) {
-        cerr << "warning:[vg mpmap] Reference path file (-S) is only used when output format (-F) is SAM, BAM, or CRAM." << endl;
+        cerr << "warning:[vg mpmap] Reference path file (-S) is only used "
+             << "when output format (-F) is SAM, BAM, or CRAM." << endl;
         ref_paths_name = "";
     }
     if (!reference_assembly_names.empty() && !hts_output) {
-        cerr << "warning:[vg mpmap] Reference assembly names (--ref-name) are only used when output format (-F) is SAM, BAM, or CRAM." << endl;
+        cerr << "warning:[vg mpmap] Reference assembly names (--ref-name) are only used "
+             << "when output format (-F) is SAM, BAM, or CRAM." << endl;
         reference_assembly_names.clear();
     }
     
     if (num_alt_alns <= 0) {
-        cerr << "error:[vg mpmap] Number of alternate snarl paths (-a) set to " << num_alt_alns << ", must set to a positive integer." << endl;
+        cerr << "error:[vg mpmap] Number of alternate snarl paths (-a) set to " << num_alt_alns
+             << ", must set to a positive integer." << endl;
         exit(1);
     }
     
     if (frag_length_sample_size <= 0) {
-        cerr << "error:[vg mpmap] Fragment length distribution sample size (-b) set to " << frag_length_sample_size << ", must set to a positive integer." << endl;
+        cerr << "error:[vg mpmap] Fragment length distribution sample size (-b) set to " << frag_length_sample_size
+             << ", must set to a positive integer." << endl;
         exit(1);
     }
     
     if (snarl_cut_size < 0) {
-        cerr << "error:[vg mpmap] Max snarl cut size (-X) set to " << snarl_cut_size << ", must set to a positive integer or 0 for no maximum." << endl;
+        cerr << "error:[vg mpmap] Max snarl cut size (-X) set to " << snarl_cut_size
+             << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
     if (max_mapping_p_value <= 0.0) {
-        cerr << "error:[vg mpmap] Max mapping p-value (-P) set to " << max_mapping_p_value << ", must set to a positive number." << endl;
+        cerr << "error:[vg mpmap] Max mapping p-value (-P) set to " << max_mapping_p_value
+             << ", must set to a positive number." << endl;
         exit(1);
     }
     
     if (max_rescue_p_value <= 0.0) {
-        cerr << "error:[vg mpmap] Max mapping p-value (--max-rescue-p-val) set to " << max_rescue_p_value << ", must set to a positive number." << endl;
+        cerr << "error:[vg mpmap] Max mapping p-value (--max-rescue-p-val) set to " << max_rescue_p_value
+             << ", must set to a positive number." << endl;
         exit(1);
     }
     
@@ -1245,145 +1296,179 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (max_mapq <= 0) {
-        cerr << "error:[vg mpmap] Maximum mapping quality (-Q) set to " << max_mapq << ", must set to a positive integer." << endl;
+        cerr << "error:[vg mpmap] Maximum mapping quality (-Q) set to " << max_mapq
+             << ", must set to a positive integer." << endl;
         exit(1);
     }
     
     if (band_padding_multiplier < 0.0) {
-        cerr << "error:[vg mpmap] Band padding (-p) set to " << band_padding_multiplier << ", must set to a nonnegative number." << endl;
+        cerr << "error:[vg mpmap] Band padding (-p) set to " << band_padding_multiplier 
+             << ", must set to a nonnegative number." << endl;
         exit(1);
     }
     
     if (max_map_attempts_arg < 0) {
-        cerr << "error:[vg mpmap] Maximum number of mapping attempts (-u) set to " << max_map_attempts_arg << ", must set to a positive integer or 0 for no maximum." << endl;
+        cerr << "error:[vg mpmap] Maximum number of mapping attempts (-u) set to " << max_map_attempts_arg
+             << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
     if (population_max_paths < 0) {
-        cerr << "error:[vg mpmap] Maximum number of paths per alignment for population scoring (--max-paths) set to " << population_max_paths << ", must set to a nonnegative integer." << endl;
+        cerr << "error:[vg mpmap] Maximum number of paths per alignment for "
+             << "population scoring (--max-paths) set to " << population_max_paths
+             << ", must set to a nonnegative integer." << endl;
         exit(1);
     }
     
     if (population_max_paths != 10 && population_max_paths != 0 && gbwt_name.empty() && sublinearLS_name.empty()) {
         // Don't allow anything but the default or the "disabled" setting without an index.
         // TODO: This restriction makes neat auto-generation of command line options for different conditions hard.
-        cerr << "error:[vg mpmap] Maximum number of paths per alignment for population scoring (--max-paths) is specified but population database (-H or --linear-index) was not provided." << endl;
+        cerr << "error:[vg mpmap] Maximum number of paths per alignment for population scoring "
+             << "(--max-paths) is specified but population database (-H or --linear-index) "
+             << "was not provided." << endl;
         exit(1);
     }
     
     if (always_check_population && gbwt_name.empty() && sublinearLS_name.empty()) {
-        cerr << "error:[vg mpmap] Cannot --always-check-population if no population database (-H or --linear-index) is provided." << endl;
+        cerr << "error:[vg mpmap] Cannot --always-check-population if no population database "
+             << "(-H or --linear-index) is provided." << endl;
         exit(1);
     }
     
     if (force_haplotype_count != 0 && gbwt_name.empty() && sublinearLS_name.empty()) {
-        cerr << "warning:[vg mpmap] Cannot --force-haplotype-count if no population database (-H or --linear-index) is provided. Ignoring option." << endl;
+        cerr << "warning:[vg mpmap] Cannot --force-haplotype-count if no population database "
+             << "(-H or --linear-index) is provided. Ignoring option." << endl;
     }
     
     if (!sublinearLS_name.empty() && !gbwt_name.empty()) {
-        cerr << "error:[vg mpmap] GBWT index (-H) and linear haplotype index (--linear-index) both specified. Only one can be used." << endl;
+        cerr << "error:[vg mpmap] GBWT index (-H) and linear haplotype index (--linear-index) "
+             << "both specified. Only one can be used." << endl;
         exit(1);
     }
     
     if (!sublinearLS_name.empty() && sublinearLS_ref_path.empty()) {
-        cerr << "error:[vg mpmap] Linear haplotype index (--linear-index) cannot be used without a single reference path (--linear-path)." << endl;
+        cerr << "error:[vg mpmap] Linear haplotype index (--linear-index) cannot be used "
+             << "without a single reference path (--linear-path)." << endl;
         exit(1);
     }
     
     if (sublinearLS_name.empty() && !sublinearLS_ref_path.empty()) {
-        cerr << "error:[vg mpmap] Linear haplotype ref path (--linear-path) cannot be used without an index (--linear-index)." << endl;
+        cerr << "error:[vg mpmap] Linear haplotype ref path (--linear-path) cannot be used"
+             << "without an index (--linear-index)." << endl;
         exit(1);
     }
     
     if (max_num_mappings > max_map_attempts && max_map_attempts != 0) {
-        cerr << "warning:[vg mpmap] Reporting up to " << max_num_mappings << " mappings, but only computing up to " << max_map_attempts << " mappings." << endl;
+        cerr << "warning:[vg mpmap] Reporting up to " << max_num_mappings << " mappings, but only computing up to "
+             << max_map_attempts << " mappings." << endl;
     }
     
     if (max_rescue_attempts < 0) {
-        cerr << "error:[vg mpmap] Maximum number of rescue attempts (--max-rescues) set to " << max_rescue_attempts << ", must set to a non-negative integer (0 for no rescue)." << endl;
+        cerr << "error:[vg mpmap] Maximum number of rescue attempts (--max-rescues) set to " << max_rescue_attempts 
+             << ", must set to a non-negative integer (0 for no rescue)." << endl;
         exit(1);
     }
     
     if (max_rescue_attempts > max_single_end_mappings_for_rescue) {
-        cerr << "warning:[vg mpmap] Maximum number of rescue attempts (--max-rescues) of " << max_rescue_attempts << " is greater than number of mapping attempts for rescue " << max_single_end_mappings_for_rescue << endl;
+        cerr << "warning:[vg mpmap] Maximum number of rescue attempts (--max-rescues) of " << max_rescue_attempts
+             << " is greater than number of mapping attempts for rescue " << max_single_end_mappings_for_rescue << endl;
     }
     
     if (secondary_rescue_attempts < 0) {
-        cerr << "error:[vg mpmap] Maximum number of rescue attempts for secondary mappings (--max-secondary-rescues) set to " << secondary_rescue_attempts << ", must set to a non-negative integer (0 for no rescue)." << endl;
+        cerr << "error:[vg mpmap] Maximum number of rescue attempts for "
+             << "secondary mappings (--max-secondary-rescues) set to " << secondary_rescue_attempts
+             << ", must set to a non-negative integer (0 for no rescue)." << endl;
         exit(1);
     }
     
     if (secondary_rescue_score_diff < 0.0) {
-        cerr << "error:[vg mpmap] Max score difference for candidates clusters for secondary rescue (--secondary-diff) set to " << secondary_rescue_score_diff << ", must set to a non-negative number." << endl;
+        cerr << "error:[vg mpmap] Max score difference for candidates clusters "
+             << "for secondary rescue (--secondary-diff) set to " << secondary_rescue_score_diff
+             << ", must set to a non-negative number." << endl;
         exit(1);
     }
     
     if (max_num_mappings <= 0) {
-        cerr << "error:[vg mpmap] Maximum number of mappings per read (-M) set to " << max_num_mappings << ", must set to a positive integer." << endl;
+        cerr << "error:[vg mpmap] Maximum number of mappings per read (-M) set to " << max_num_mappings
+             << ", must set to a positive integer." << endl;
         exit(1);
     }
     
     if (reseed_length < 0) {
-        cerr << "error:[vg mpmap] Reseeding length (-r) set to " << reseed_length << ", must set to a positive integer or 0 for no reseeding." << endl;
+        cerr << "error:[vg mpmap] Reseeding length (-r) set to " << reseed_length
+             << ", must set to a positive integer or 0 for no reseeding." << endl;
         exit(1);
     }
     
     if ((reseed_diff <= 0 || reseed_diff >= 1.0) && reseed_length != 0) {
-        cerr << "error:[vg mpmap] Reseeding length difference (-W) set to " << reseed_diff << ", must set to a number between 0.0 and 1.0." << endl;
+        cerr << "error:[vg mpmap] Reseeding length difference (-W) set to " << reseed_diff
+             << ", must set to a number between 0.0 and 1.0." << endl;
         exit(1);
     }
     
     if (reseed_exp < 0 && reseed_length != 0 && use_adaptive_reseed) {
-        cerr << "error:[vg mpmap] Reseeding exponent set to " << reseed_exp << ",  must set to a nonnegative number." << endl;
+        cerr << "error:[vg mpmap] Reseeding exponent set to " << reseed_exp
+             << ",  must set to a nonnegative number." << endl;
         exit(1);
     }
     
     if (hard_hit_max_muliplier < 0) {
-        cerr << "error:[vg mpmap] Hard MEM hit max multipler (--hard-hit-mult) set to " << hard_hit_max_muliplier << ", must set to a positive integer or 0 for no maximum." << endl;
+        cerr << "error:[vg mpmap] Hard MEM hit max multipler (--hard-hit-mult) set to " << hard_hit_max_muliplier
+             << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
     if (hit_max < 0) {
-        cerr << "error:[vg mpmap] MEM hit max (-c) set to " << hit_max << ", must set to a positive integer or 0 for no maximum." << endl;
+        cerr << "error:[vg mpmap] MEM hit max (-c) set to " << hit_max 
+             << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
     if (hard_hit_max < hit_max && hit_max && hard_hit_max) {
-        cerr << "warning:[vg mpmap] MEM hit query limit (-c) set to " << hit_max << ", which is higher than the threshold to ignore a MEM (" << hard_hit_max << ")." << endl;
+        cerr << "warning:[vg mpmap] MEM hit query limit (-c) set to " << hit_max 
+             << ", which is higher than the threshold to ignore a MEM (" << hard_hit_max << ")." << endl;
     }
     
     if (min_mem_length < 0) {
-        cerr << "error:[vg mpmap] Minimum MEM length set to " << min_mem_length << ", must set to a positive integer or 0 for no maximum." << endl;
+        cerr << "error:[vg mpmap] Minimum MEM length set to " << min_mem_length 
+             << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
     if (single_path_alignment_mode && agglomerate_multipath_alns) {
         // this could probably be just a warning, but it will really mess up the MAPQs
-        cerr << "error:[vg mpmap] Disconnected alignments cannot be agglomerated (-a) for single path alignment formats (-F)." << endl;
+        cerr << "error:[vg mpmap] Disconnected alignments cannot be agglomerated (-a) "
+             << "for single path alignment formats (-F)." << endl;
         exit(1);
     }
     
     if (stripped_match_alg_strip_length <= 0) {
-        cerr << "error:[vg mpmap] Match strip length (--strip-length) set to " << stripped_match_alg_strip_length << ", must set to a positive integer or 0 for no maximum." << endl;
+        cerr << "error:[vg mpmap] Match strip length (--strip-length) set to " << stripped_match_alg_strip_length
+             << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
     if (stripped_match_alg_max_length < 0) {
-        cerr << "error:[vg mpmap] Maximum seed match length set to " << stripped_match_alg_max_length << ", must set to a positive integer or 0 for no maximum." << endl;
+        cerr << "error:[vg mpmap] Maximum seed match length set to " << stripped_match_alg_max_length
+             << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
     if (stripped_match_alg_target_count < 0) {
-        cerr << "error:[vg mpmap] Target seed count (--strip-count) set to " << stripped_match_alg_target_count << ", must set to a positive integer or 0 for no maximum." << endl;
+        cerr << "error:[vg mpmap] Target seed count (--strip-count) set to " << stripped_match_alg_target_count
+             << ", must set to a positive integer or 0 for no maximum." << endl;
         exit(1);
     }
     
     if (stripped_match_alg_target_count != default_strip_count && !use_stripped_match_alg) {
-        cerr << "warning:[vg mpmap] Target stripped match count (--strip-count) set to " << stripped_match_alg_target_count << ", but stripped algorithm (--stripped-match) was not selected. Ignoring strip count." << endl;
+        cerr << "warning:[vg mpmap] Target stripped match count (--strip-count) set to "
+             << stripped_match_alg_target_count << ", but stripped algorithm (--stripped-match) was not selected. "
+             << "Ignoring strip count." << endl;
     }
     
     if (stripped_match_alg_strip_length != default_strip_length && !use_stripped_match_alg) {
-        cerr << "warning:[vg mpmap] Strip length (--strip-length) set to " << stripped_match_alg_strip_length << ", but stripped algorithm (--stripped-match) was not selected. Ignoring strip length." << endl;
+        cerr << "warning:[vg mpmap] Strip length (--strip-length) set to " << stripped_match_alg_strip_length 
+             << ", but stripped algorithm (--stripped-match) was not selected. Ignoring strip length." << endl;
     }
     
     // people shouldn't really be setting these anyway, but there may be combinations of presets that do this
@@ -1393,12 +1478,14 @@ int main_mpmap(int argc, char** argv) {
 //    }
     
     if (likelihood_approx_exp < 1.0) {
-        cerr << "error:[vg mpmap] Likelihood approximation exponent (--approx-exp) set to " << likelihood_approx_exp << ", must set to at least 1.0." << endl;
+        cerr << "error:[vg mpmap] Likelihood approximation exponent (--approx-exp) set to " 
+             << likelihood_approx_exp << ", must set to at least 1.0." << endl;
         exit(1);
     }
     
     if (cluster_ratio < 0.0 || cluster_ratio >= 1.0) {
-        cerr << "error:[vg mpmap] Cluster drop ratio (-C) set to " << cluster_ratio << ", must set to a number between 0.0 and 1.0." << endl;
+        cerr << "error:[vg mpmap] Cluster drop ratio (-C) set to " << cluster_ratio 
+             << ", must set to a number between 0.0 and 1.0." << endl;
         exit(1);
     }
     
@@ -1413,49 +1500,61 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (use_min_dist_clusterer && use_tvs_clusterer) {
-        cerr << "error:[vg mpmap] Cannot perform both minimum distance clustering (--min-dist-cluster) and target value clustering (-v)." << endl;
+        cerr << "error:[vg mpmap] Cannot perform both minimum distance clustering (--min-dist-cluster) "
+             << "and target value clustering (-v)." << endl;
         exit(1);
     }
     
     if (greedy_min_dist && !use_min_dist_clusterer) {
-        cerr << "warning:[vg mpmap] greedy minimum distance clustering (--greedy-min-dist) is ignored if not using minimum distance clustering (-d)" << endl;
+        cerr << "warning:[vg mpmap] greedy minimum distance clustering (--greedy-min-dist) "
+             << "is ignored if not using minimum distance clustering (-d)" << endl;
     }
     
     if (greedy_min_dist && component_min_dist) {
-        cerr << "error:[vg mpmap] cannot simultaneously use greedy (--greedy-min-dist) and component (--component-min-dist) clustering" << endl;
+        cerr << "error:[vg mpmap] cannot simultaneously use greedy (--greedy-min-dist) and "
+             << "component (--component-min-dist) clustering" << endl;
         exit(1);
     }
     
     if (no_clustering && !distance_index_name.empty() && !snarls_name.empty()) {
-        cerr << "warning:[vg mpmap] No clustering option (--no-cluster) causes distance index (-d) to be ignored when snarls (-s) are provided. This option is activated by default for 'very-short' read lengths (-l)." << endl;
+        cerr << "warning:[vg mpmap] No clustering option (--no-cluster) causes distance index (-d) "
+             << "to be ignored when snarls (-s) are provided. This option is activated by default for "
+             << "'very-short' read lengths (-l)." << endl;
     }
     
     if (suboptimal_path_exponent < 1.0) {
-        cerr << "error:[vg mpmap] Suboptimal path likelihood root (--prune-exp) set to " << suboptimal_path_exponent << ", must set to at least 1.0." << endl;
+        cerr << "error:[vg mpmap] Suboptimal path likelihood root (--prune-exp) set to "
+             << suboptimal_path_exponent << ", must set to at least 1.0." << endl;
         exit(1);
     }
     
     if (max_alignment_gap < 0) {
-        cerr << "error:[vg mpmap] Max alignment grap set to " << max_alignment_gap << ", must set to a non-negative integer." << endl;
+        cerr << "error:[vg mpmap] Max alignment grap set to " << max_alignment_gap 
+             << ", must set to a non-negative integer." << endl;
         exit(1);
     }
     
     if (filter_short_mems && (short_mem_filter_factor < 0.0 || short_mem_filter_factor > 1.0)) {
-        cerr << "error:[vg mpmap] Short MEM filtraction factor (--filter-factor) set to " << short_mem_filter_factor << ", must set to a number between 0.0 and 1.0." << endl;
+        cerr << "error:[vg mpmap] Short MEM filtraction factor (--filter-factor) set to "
+             << short_mem_filter_factor << ", must set to a number between 0.0 and 1.0." << endl;
         exit(1);
     }
     
     if (no_splice_log_odds <= 0.0) {
-        cerr << "warning:[vg mpmap] Log odds against splicing (--splice-odds) set to " << no_splice_log_odds << ", non-positive values can lead to spurious identification of spliced alignments." << endl;
+        cerr << "warning:[vg mpmap] Log odds against splicing (--splice-odds) set to " << no_splice_log_odds
+             << ", non-positive values can lead to spurious identification of spliced alignments." << endl;
     }
     
     if (max_motif_pairs < 0) {
-        cerr << "error:[vg mpmap] Maximum attempted splice motif pairs (--max-motif-pairs) set to " << max_motif_pairs << ", must set to a non-negative number." << endl;
+        cerr << "error:[vg mpmap] Maximum attempted splice motif pairs (--max-motif-pairs) set to "
+             << max_motif_pairs << ", must set to a non-negative number." << endl;
         exit(1);
     }
     
-    if ((match_score_arg != std::numeric_limits<int>::min() || mismatch_score_arg != std::numeric_limits<int>::min()) && !matrix_file_name.empty())  {
-        cerr << "error:[vg mpmap] Cannot choose custom scoring matrix (-w) and custom match/mismatch score (-q/-z) simultaneously." << endl;
+    if ((match_score_arg != std::numeric_limits<int>::min() || mismatch_score_arg != std::numeric_limits<int>::min()) 
+        && !matrix_file_name.empty())  {
+        cerr << "error:[vg mpmap] Cannot choose custom scoring matrix (-w) "
+             << "and custom match/mismatch score (-q/-z) simultaneously." << endl;
         exit(1);
     }
     
@@ -1463,7 +1562,8 @@ int main_mpmap(int argc, char** argv) {
         || gap_open_score > std::numeric_limits<int8_t>::max() || gap_extension_score > std::numeric_limits<int8_t>::max()
         || full_length_bonus > std::numeric_limits<int8_t>::max() || match_score < 0 || mismatch_score < 0
         || gap_open_score < 0 || gap_extension_score < 0 || full_length_bonus < 0) {
-        cerr << "error:[vg mpmap] All alignment scoring parameters (-qzoyL) must be between 0 and " << (int) std::numeric_limits<int8_t>::max() << endl;
+        cerr << "error:[vg mpmap] All alignment scoring parameters (-qzoyL) must be between 0 and " 
+             << (int) std::numeric_limits<int8_t>::max() << endl;
         exit(1);
     }
     
@@ -1546,7 +1646,8 @@ int main_mpmap(int argc, char** argv) {
             }
         }
         else {
-            cerr << "warning:[vg mpmap] Snarls file (-s) is unnecessary and will be ignored when the distance index (-d) is provided." << endl;
+            cerr << "warning:[vg mpmap] Snarls file (-s) is unnecessary and will be ignored "
+                 << "when the distance index (-d) is provided." << endl;
         }
     }
     
@@ -1680,7 +1781,8 @@ int main_mpmap(int argc, char** argv) {
             strm << "Graph is in " + type + " format. ";
             
             if (type == "XG") {
-                strm << "XG is a good graph format for most mapping use cases. PackedGraph may be selected if memory usage is too high. ";
+                strm << "XG is a good graph format for most mapping use cases. PackedGraph may be selected "
+                     << "if memory usage is too high. ";
             }
             else if (type == "HashGraph") {
                 strm << "HashGraph can have high memory usage. ";
@@ -1706,12 +1808,15 @@ int main_mpmap(int argc, char** argv) {
     }
     
     if (path_handle_graph->get_path_count() == 0 && distance_index_name.empty()) {
-        cerr << "warning:[vg mpmap] Using a distance index (-d) for clustering is highly recommended for graphs that lack embedded paths. Speed and accuracy are likely to suffer severely without one." << endl;
+        cerr << "warning:[vg mpmap] Using a distance index (-d) for clustering is highly recommended "
+             << "for graphs that lack embedded paths. Speed and accuracy are likely to suffer severely without one." << endl;
     }
     else if (path_handle_graph->get_path_count() == 0
              && get_rescue_graph_from_paths
              && (interleaved_input || !fastq_name_2.empty())) {
-        cerr << "warning:[vg mpmap] Identifying rescue subgraphs using embedded paths (--path-rescue-graph) is impossible on graphs that lack embedded paths. Pair rescue will not be used on this graph, potentially hurting accuracy." << endl;
+        cerr << "warning:[vg mpmap] Identifying rescue subgraphs using embedded paths (--path-rescue-graph) "
+             << "is impossible on graphs that lack embedded paths. Pair rescue will not be used on this graph, "
+             << "potentially hurting accuracy." << endl;
     }
     
     bdsg::ReferencePathOverlayHelper overlay_helper;
@@ -1723,7 +1828,8 @@ int main_mpmap(int argc, char** argv) {
     if (do_spliced_alignment) {
         // TODO: could let IO continue while doing this, but it risks increasing peak memory for some graphs...
         log_progress("Identifying reference paths");
-        vector<unordered_set<path_handle_t>> component_path_sets = vg::algorithms::component_paths_parallel(*path_position_handle_graph);
+        vector<unordered_set<path_handle_t>> component_path_sets \
+            = vg::algorithms::component_paths_parallel(*path_position_handle_graph);
         for (const auto& path_set : component_path_sets) {
             // remove dependency on system hash ordering
             vector<path_handle_t> ordered_path_set(path_set.begin(), path_set.end());
@@ -1918,7 +2024,8 @@ int main_mpmap(int argc, char** argv) {
              || gap_open_score != default_gap_open
              || gap_extension_score != default_gap_extension
              || full_length_bonus != default_full_length_bonus) {
-        multipath_mapper.set_alignment_scores(match_score, mismatch_score, gap_open_score, gap_extension_score, full_length_bonus);
+        multipath_mapper.set_alignment_scores(match_score, mismatch_score, gap_open_score,
+                                              gap_extension_score, full_length_bonus);
     }
     multipath_mapper.adjust_alignments_for_base_quality = qual_adjusted;
     multipath_mapper.strip_bonuses = strip_full_length_bonus;
@@ -2094,7 +2201,8 @@ int main_mpmap(int argc, char** argv) {
 #pragma omp atomic capture
                 n = num_reads_mapped += num_mapped;
                 if (n % progress_frequency == 0) {
-                    log_progress("Mapped " + to_string(n) + (!interleaved_input && fastq_name_2.empty() ? " reads" : " read pairs"));
+                    log_progress("Mapped " + to_string(n) + (!interleaved_input && fastq_name_2.empty() ? " reads" 
+                                                                                                        : " read pairs"));
                 }
                 thread_num_reads_mapped[thread_num] = 0;
             }
@@ -2176,7 +2284,8 @@ int main_mpmap(int argc, char** argv) {
 #ifdef record_read_run_times
         clock_t finish = clock();
 #pragma omp critical
-        read_time_file << alignment.name() << "\t" << alignment.sequence().size() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
+        read_time_file << alignment.name() << "\t" << alignment.sequence().size() << "\t" 
+                       << double(finish - start) / CLOCKS_PER_SEC << endl;
 #endif
     };
     
@@ -2222,7 +2331,8 @@ int main_mpmap(int argc, char** argv) {
         
         if (!same_strand) {
             for (auto& mp_aln_pair : mp_aln_pairs) {
-                rev_comp_multipath_alignment_in_place(&mp_aln_pair.second, [&](vg::id_t node_id) { return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id));
+                rev_comp_multipath_alignment_in_place(&mp_aln_pair.second, [&](vg::id_t node_id) {
+                    return path_position_handle_graph->get_length(path_position_handle_graph->get_handle(node_id));
                 });
             }
         }
@@ -2277,12 +2387,14 @@ int main_mpmap(int argc, char** argv) {
 #ifdef record_read_run_times
         clock_t finish = clock();
 #pragma omp critical
-        read_time_file << alignment_1.name() << "\t" << alignment_2.name() << "\t" << alignment_1.sequence().size() << "\t" << alignment_2.sequence().size() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
+        read_time_file << alignment_1.name() << "\t" << alignment_2.name() << "\t" << alignment_1.sequence().size() 
+                       << "\t" << alignment_2.sequence().size() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
 #endif
     };
     
     // do unpaired, independent multipath alignment, and write to buffer as paired
-    function<void(Alignment&, Alignment&)> do_independent_paired_alignments = [&](Alignment& alignment_1, Alignment& alignment_2) {
+    function<void(Alignment&, Alignment&)> do_independent_paired_alignments = 
+    [&](Alignment& alignment_1, Alignment& alignment_2) {
         // get reads on the same strand so that oriented distance estimation works correctly
         // but if we're clearing the ambiguous buffer we already RC'd these on the first pass
 
@@ -2366,7 +2478,8 @@ int main_mpmap(int argc, char** argv) {
 #ifdef record_read_run_times
         clock_t finish = clock();
 #pragma omp critical
-        read_time_file << alignment_1.name() << "\t" << alignment_2.name() << "\t" << alignment_1.sequence().size() << "\t" << alignment_2.sequence().size() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
+        read_time_file << alignment_1.name() << "\t" << alignment_2.name() << "\t" << alignment_1.sequence().size() 
+                       << "\t" << alignment_2.sequence().size() << "\t" << double(finish - start) / CLOCKS_PER_SEC << endl;
 #endif
     };
     
@@ -2377,7 +2490,9 @@ int main_mpmap(int argc, char** argv) {
     
     // FASTQ input
     if (!fastq_name_1.empty()) {
-        log_progress("Mapping reads from " + (fastq_name_1 == "-" ? string("STDIN") : fastq_name_1) + (fastq_name_2.empty() ? "" : " and " + (fastq_name_2 == "-" ? "STDIN" : fastq_name_2)) + " using " + to_string(thread_count) + " thread" + (thread_count > 1 ? "s" : ""));
+        log_progress("Mapping reads from " + (fastq_name_1 == "-" ? string("STDIN") : fastq_name_1) 
+                     + (fastq_name_2.empty() ? "" : " and " + (fastq_name_2 == "-" ? "STDIN" : fastq_name_2))
+                     + " using " + to_string(thread_count) + " thread" + (thread_count > 1 ? "s" : ""));
         
         if (interleaved_input) {
             fastq_paired_interleaved_for_each_parallel_after_wait(fastq_name_1, do_paired_alignments,
@@ -2394,7 +2509,8 @@ int main_mpmap(int argc, char** argv) {
     
     // GAM input
     if (!gam_file_name.empty()) {
-        log_progress("Mapping reads from " + (gam_file_name == "-" ? string("STDIN") : gam_file_name) + " using " + to_string(thread_count) + " thread" + (thread_count > 1 ? "s" : ""));
+        log_progress("Mapping reads from " + (gam_file_name == "-" ? string("STDIN") : gam_file_name) 
+                     + " using " + to_string(thread_count) + " thread" + (thread_count > 1 ? "s" : ""));
         
         function<void(istream&)> execute = [&](istream& gam_in) {
             if (!gam_in) {
@@ -2433,7 +2549,11 @@ int main_mpmap(int argc, char** argv) {
             }
         }
         else {
-            cerr << "warning:[vg mpmap] Could not find " << frag_length_sample_size << " (-b) unambiguous read pair mappings to estimate fragment length ditribution. This can happen due to data issues (e.g. unpaired reads being mapped as pairs) or because the sample size is too large for the read set. Mapping read pairs as independent single-ended reads." << endl;
+            cerr << "warning:[vg mpmap] Could not find " << frag_length_sample_size 
+                 << " (-b) unambiguous read pair mappings to estimate fragment length ditribution. "
+                 << "This can happen due to data issues (e.g. unpaired reads being mapped as pairs) "
+                 << "or because the sample size is too large for the read set. "
+                 << "Mapping read pairs as independent single-ended reads." << endl;
             
 #pragma omp parallel for
             for (size_t i = 0; i < ambiguous_pair_buffer.size(); i++) {
@@ -2460,19 +2580,13 @@ int main_mpmap(int argc, char** argv) {
         for (auto uncounted_mappings : thread_num_reads_mapped) {
             num_reads_mapped += uncounted_mappings;
         }
-        log_progress("Mapping finished. Mapped " + to_string(num_reads_mapped) + " " + (fastq_name_2.empty() && !interleaved_input ? "reads" : "read pairs") + ".");
+        log_progress("Mapping finished. Mapped " + to_string(num_reads_mapped) + " " 
+                     + (fastq_name_2.empty() && !interleaved_input ? "reads" : "read pairs") + ".");
     }
     
 #ifdef record_read_run_times
     read_time_file.close();
 #endif
-    
-    //cerr << "MEM length filtering efficiency: " << ((double) OrientedDistanceClusterer::MEM_FILTER_COUNTER) / OrientedDistanceClusterer::MEM_TOTAL << " (" << OrientedDistanceClusterer::MEM_FILTER_COUNTER << "/" << OrientedDistanceClusterer::MEM_TOTAL << ")" << endl;
-    //cerr << "MEM cluster filtering efficiency: " << ((double) OrientedDistanceClusterer::PRUNE_COUNTER) / OrientedDistanceClusterer::CLUSTER_TOTAL << " (" << OrientedDistanceClusterer::PRUNE_COUNTER << "/" << OrientedDistanceClusterer::CLUSTER_TOTAL << ")" << endl;
-    //cerr << "subgraph filtering efficiency: " << ((double) MultipathMapper::PRUNE_COUNTER) / MultipathMapper::SUBGRAPH_TOTAL << " (" << MultipathMapper::PRUNE_COUNTER << "/" << MultipathMapper::SUBGRAPH_TOTAL << ")" << endl;
-    //cerr << "attempted to split " << OrientedDistanceClusterer::SPLIT_ATTEMPT_COUNTER << " of " << OrientedDistanceClusterer::PRE_SPLIT_CLUSTER_COUNTER << " clusters with " << OrientedDistanceClusterer::SUCCESSFUL_SPLIT_ATTEMPT_COUNTER << " splits successful (" << 100.0 * double(OrientedDistanceClusterer::SUCCESSFUL_SPLIT_ATTEMPT_COUNTER) / OrientedDistanceClusterer::SPLIT_ATTEMPT_COUNTER << "%) resulting in " << OrientedDistanceClusterer::POST_SPLIT_CLUSTER_COUNTER << " total clusters (" << OrientedDistanceClusterer::POST_SPLIT_CLUSTER_COUNTER - OrientedDistanceClusterer::PRE_SPLIT_CLUSTER_COUNTER << " new)" << endl;
-    //cerr << "entered secondary rescue " << MultipathMapper::SECONDARY_RESCUE_TOTAL << " times with " << MultipathMapper::SECONDARY_RESCUE_COUNT << " actually attempting rescues, totaling " << MultipathMapper::SECONDARY_RESCUE_ATTEMPT << " rescues (" << double(MultipathMapper::SECONDARY_RESCUE_ATTEMPT) / MultipathMapper::SECONDARY_RESCUE_COUNT << " average per attempt)" << endl;
-    
     if (haplo_score_provider != nullptr) {
         delete haplo_score_provider;
     }

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -27,16 +27,16 @@
 #include <bdsg/hash_graph.hpp>
 #include <xg.hpp>
 
-//#define record_read_run_times
+//constexpr int record_read_run_times
 
 #ifdef record_read_run_times
-#define READ_TIME_FILE "_read_times.tsv"
+constexpr int READ_TIME_FILE "_read_times.tsv"
 #include <ctime>
 #include <iostream>
 #endif
 
 #ifdef mpmap_instrument_mem_statistics
-#define MEM_STATS_FILE "_mem_statistics.tsv"
+constexpr int MEM_STATS_FILE "_mem_statistics.tsv"
 #endif
 
 using namespace std;
@@ -217,47 +217,47 @@ int main_mpmap(int argc, char** argv) {
     }
 
     // initialize parameters with their default options
-    #define OPT_PRUNE_EXP 1000
-    #define OPT_RECOMBINATION_PENALTY 1001
-    #define OPT_ALWAYS_CHECK_POPULATION 1002
-    #define OPT_FORCE_HAPLOTYPE_COUNT 1004
-    #define OPT_SUPPRESS_TAIL_ANCHORS 1005
-    #define OPT_TOP_TRACEBACKS 1006
-    #define OPT_MIN_DIST_CLUSTER 1007
-    #define OPT_APPROX_EXP 1008
-    #define OPT_MAX_PATHS 1009
-    #define OPT_GREEDY_MIN_DIST 1010
-    #define OPT_COMPONENT_MIN_DIST 1011
-    #define OPT_BAND_PADDING_MULTIPLIER 1012
-    #define OPT_HARD_HIT_MAX_MULTIPLIER 1013
-    #define OPT_MAX_RESCUE_ATTEMPTS 1014
-    #define OPT_STRIP_LENGTH 1015
-    #define OPT_STRIP_COUNT 1016
-    #define OPT_SECONDARY_RESCUE_ATTEMPTS 1017
-    #define OPT_SECONDARY_MAX_DIFF 1018
-    #define OPT_NO_CLUSTER 1019
-    #define OPT_NO_GREEDY_MEM_RESTARTS 1020
-    #define OPT_GREEDY_MEM_RESTART_MAX_LCP 1021
-    #define OPT_SHORT_MEM_FILTER_FACTOR 1022
-    #define OPT_NO_OUTPUT 1023
-    #define OPT_STRIPPED_MATCH 1024
-    #define OPT_FAN_OUT_QUAL 1025
-    #define OPT_MAX_FANS_OUT 1026
-    #define OPT_FAN_OUT_DIFF 1027
-    #define OPT_PATH_RESCUE_GRAPH 1028
-    #define OPT_MAX_RESCUE_P_VALUE 1029
-    #define OPT_ALT_PATHS 1030
-    #define OPT_SUPPRESS_SUPPRESSION 1031
-    #define OPT_SNARL_MAX_CUT 1032
-    #define OPT_SPLICE_ODDS 1033
-    #define OPT_REPORT_ALLELIC_MAPQ 1034
-    #define OPT_RESEED_LENGTH 1035
-    #define OPT_MAX_MOTIF_PAIRS 1036
-    #define OPT_SUPPRESS_MISMAPPING_DETECTION 1037
-    #define OPT_DROP_SUBGRAPH 1038
-    #define OPT_REF_NAME 1039
-    #define OPT_LINEAR_PATH 1040
-    #define OPT_LINEAR_INDEX 1041
+    constexpr int OPT_PRUNE_EXP = 1000;
+    constexpr int OPT_RECOMBINATION_PENALTY = 1001;
+    constexpr int OPT_ALWAYS_CHECK_POPULATION = 1002;
+    constexpr int OPT_FORCE_HAPLOTYPE_COUNT = 1004;
+    constexpr int OPT_SUPPRESS_TAIL_ANCHORS = 1005;
+    constexpr int OPT_TOP_TRACEBACKS = 1006;
+    constexpr int OPT_MIN_DIST_CLUSTER = 1007;
+    constexpr int OPT_APPROX_EXP = 1008;
+    constexpr int OPT_MAX_PATHS = 1009;
+    constexpr int OPT_GREEDY_MIN_DIST = 1010;
+    constexpr int OPT_COMPONENT_MIN_DIST = 1011;
+    constexpr int OPT_BAND_PADDING_MULTIPLIER = 1012;
+    constexpr int OPT_HARD_HIT_MAX_MULTIPLIER = 1013;
+    constexpr int OPT_MAX_RESCUE_ATTEMPTS = 1014;
+    constexpr int OPT_STRIP_LENGTH = 1015;
+    constexpr int OPT_STRIP_COUNT = 1016;
+    constexpr int OPT_SECONDARY_RESCUE_ATTEMPTS = 1017;
+    constexpr int OPT_SECONDARY_MAX_DIFF = 1018;
+    constexpr int OPT_NO_CLUSTER = 1019;
+    constexpr int OPT_NO_GREEDY_MEM_RESTARTS = 1020;
+    constexpr int OPT_GREEDY_MEM_RESTART_MAX_LCP = 1021;
+    constexpr int OPT_SHORT_MEM_FILTER_FACTOR = 1022;
+    constexpr int OPT_NO_OUTPUT = 1023;
+    constexpr int OPT_STRIPPED_MATCH = 1024;
+    constexpr int OPT_FAN_OUT_QUAL = 1025;
+    constexpr int OPT_MAX_FANS_OUT = 1026;
+    constexpr int OPT_FAN_OUT_DIFF = 1027;
+    constexpr int OPT_PATH_RESCUE_GRAPH = 1028;
+    constexpr int OPT_MAX_RESCUE_P_VALUE = 1029;
+    constexpr int OPT_ALT_PATHS = 1030;
+    constexpr int OPT_SUPPRESS_SUPPRESSION = 1031;
+    constexpr int OPT_SNARL_MAX_CUT = 1032;
+    constexpr int OPT_SPLICE_ODDS = 1033;
+    constexpr int OPT_REPORT_ALLELIC_MAPQ = 1034;
+    constexpr int OPT_RESEED_LENGTH = 1035;
+    constexpr int OPT_MAX_MOTIF_PAIRS = 1036;
+    constexpr int OPT_SUPPRESS_MISMAPPING_DETECTION = 1037;
+    constexpr int OPT_DROP_SUBGRAPH = 1038;
+    constexpr int OPT_REF_NAME = 1039;
+    constexpr int OPT_LINEAR_PATH = 1040;
+    constexpr int OPT_LINEAR_INDEX = 1041;
     string matrix_file_name;
     string graph_name;
     string gcsa_name;

--- a/src/subcommand/mpmap_main.cpp
+++ b/src/subcommand/mpmap_main.cpp
@@ -220,6 +220,8 @@ int main_mpmap(int argc, char** argv) {
     #define OPT_SUPPRESS_MISMAPPING_DETECTION 1037
     #define OPT_DROP_SUBGRAPH 1038
     #define OPT_REF_NAME 1039
+    #define OPT_LINEAR_PATH 1040
+    #define OPT_LINEAR_INDEX 1041
     string matrix_file_name;
     string graph_name;
     string gcsa_name;
@@ -393,12 +395,13 @@ int main_mpmap(int argc, char** argv) {
             {"gcsa-name", required_argument, 0, 'g'},
             {"gbwt-name", required_argument, 0, 'H'},
             {"dist-name", required_argument, 0, 'd'},
-            {"linear-index", required_argument, 0, 1},
-            {"linear-path", required_argument, 0, 2},
+            {"linear-index", required_argument, 0, OPT_LINEAR_PATH},
+            {"linear-path", required_argument, 0, OPT_LINEAR_INDEX},
             {"fastq", required_argument, 0, 'f'},
             {"gam-input", required_argument, 0, 'G'},
             {"sample", required_argument, 0, 'N'},
             {"read-group", required_argument, 0, 'R'},
+            {"suppress-progress", no_argument, 0, 'p'},
             {"interleaved", no_argument, 0, 'i'},
             {"comments-as-tags", no_argument, 0, 'C'},
             {"same-strand", no_argument, 0, 'T'},
@@ -435,8 +438,8 @@ int main_mpmap(int argc, char** argv) {
             {"reseed-diff", required_argument, 0, 'W'},
             {"clustlength", required_argument, 0, 'K'},
             {"stripped-match", no_argument, 0, OPT_STRIPPED_MATCH},
-            {"strip-length", no_argument, 0, OPT_STRIP_LENGTH},
-            {"strip-count", no_argument, 0, OPT_STRIP_COUNT},
+            {"strip-length", required_argument, 0, OPT_STRIP_LENGTH},
+            {"strip-count", required_argument, 0, OPT_STRIP_COUNT},
             {"no-greedy-restart", no_argument, 0, OPT_NO_GREEDY_MEM_RESTARTS},
             {"greedy-max-lcp", required_argument, 0, OPT_GREEDY_MEM_RESTART_MAX_LCP},
             {"filter-factor", required_argument, 0, OPT_SHORT_MEM_FILTER_FACTOR},
@@ -477,7 +480,7 @@ int main_mpmap(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:H:d:f:G:N:R:iS:s:vXu:b:I:D:BP:Q:UpM:r:W:K:F:c:CR:En:l:e:q:z:w:o:y:L:mAt:a",
+        c = getopt_long (argc, argv, "h?x:g:H:d:f:G:N:R:iS:s:vXu:b:I:D:BP:Q:UpM:r:W:K:F:c:CTEn:l:e:q:z:w:o:y:L:mAt:a",
                          long_options, &option_index);
 
 
@@ -538,11 +541,11 @@ int main_mpmap(int argc, char** argv) {
                 get_rescue_graph_from_paths = true;;
                 break;
                 
-            case 1: // --linear-index
+            case OPT_LINEAR_INDEX: // --linear-index
                 sublinearLS_name = optarg;
                 break;
             
-            case 2: // --linear-path
+            case OPT_LINEAR_PATH: // --linear-path
                 sublinearLS_ref_path = optarg;
                 break;
                 

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -61,7 +61,7 @@ void help_msga(char** argv) {
          << "    -y, --gap-extend INT    use this gap extension penalty [1]" << endl
          << "    -L, --full-l-bonus INT  the full-length alignment bonus [32]" << endl
          << "    --xdrop-alignment       use X-drop heuristic (much faster for long-read alignment)" << endl
-         << "    --max-gap-length        maximum gap length allowed in each contiguous alignment (for X-drop alignment) [40]" << endl
+         << "    --max-gap-length INT    maximum gap length allowed in each contiguous alignment (for X-drop alignment) [40]" << endl
          << "index generation:" << endl
          << "    -K, --idx-kmer-size N   use kmers of this size for building the GCSA indexes [16]" << endl
         //<< "    -O, --idx-no-recomb     index only embedded paths, not recombinations of them" << endl
@@ -75,7 +75,6 @@ void help_msga(char** argv) {
          << "generic parameters:" << endl
          << "    -D, --debug             print debugging information about construction to stderr" << endl
          << "    -A, --debug-align       print debugging information about alignment to stderr" << endl
-         << "    -S, --align-progress    show a progress bar for each banded alignment" << endl
          << "    -t, --threads N         number of threads to use" << endl
          << endl
          << "Construct a multiple sequence alignment from all sequences in the" << endl
@@ -89,13 +88,19 @@ int main_msga(int argc, char** argv) {
     cerr << "!!!" << endl;
     cerr << "WARNING" << endl;
     cerr << "!!!" << endl;
-    cerr << "vg msga was an early prototype for constructing genome graphs from multiple sequence alignments, but it is no longer state-of-the-art or even actively maintained. VG team members have developed improved graph construction algorithms in Cactus and PGGB, and several other tools have been developed by other groups." << endl << endl;
+    cerr << "vg msga was an early prototype for constructing genome graphs from multiple sequence alignments, "
+         << "but it is no longer state-of-the-art or even actively maintained. "
+         << "VG team members have developed improved graph construction algorithms in Cactus and PGGB, "
+         << "and several other tools have been developed by other groups." << endl << endl;
     
     
     if (argc == 2) {
         help_msga(argv);
         return 1;
     }
+
+    #define OPT_MAX_GAP_LENGTH  1000
+    #define OPT_XDROP_ALIGNMENT  1001
 
     vector<string> fasta_files;
     set<string> seq_names;
@@ -173,15 +178,15 @@ int main_msga(int argc, char** argv) {
                 {"band-multi", required_argument, 0, 'B'},
                 {"debug", no_argument, 0, 'D'},
                 {"debug-align", no_argument, 0, 'A'},
-                {"context-depth", required_argument, 0, 'c'},
                 {"min-ident", required_argument, 0, 'P'},
-                {"min-banded-mq", required_argument, 0, 'F'},
+                {"min-band-mq", required_argument, 0, 'F'},
                 {"idx-edge-max", required_argument, 0, 'E'},
                 {"idx-prune-subs", required_argument, 0, 'Q'},
                 {"normalize", no_argument, 0, 'N'},
                 {"min-mem", required_argument, 0, 'k'},
                 {"max-mem", required_argument, 0, 'Y'},
                 {"hit-max", required_argument, 0, 'c'},
+                {"context-depth", required_argument, 0, 'c'},
                 {"mem-chance", required_argument, 0, 'e'},
                 {"reseed-x", required_argument, 0, 'r'},
                 {"threads", required_argument, 0, 't'},
@@ -200,13 +205,13 @@ int main_msga(int argc, char** argv) {
                 {"drop-chain", required_argument, 0, 'C'},
                 {"bigger-first", no_argument, 0, 'a'},
                 {"no-patch-aln", no_argument, 0, '8'},
-                {"max-gap-length", required_argument, 0, 1},
-                {"xdrop-alignment", no_argument, 0, 2},
+                {"max-gap-length", required_argument, 0, OPT_MAX_GAP_LENGTH},
+                {"xdrop-alignment", no_argument, 0, OPT_XDROP_ALIGNMENT},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hf:n:s:g:b:K:X:w:DAc:P:E:Q:NY:H:t:m:M:q:O:I:i:o:y:ZW:z:k:L:e:r:u:l:C:F:J:B:a8R:T:",
+        c = getopt_long (argc, argv, "h?f:n:s:g:b:K:X:w:DAc:P:E:Q:NY:H:t:m:M:q:O:o:y:ZW:z:k:L:e:r:u:l:C:F:J:B:a8R:T:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -385,9 +390,9 @@ int main_msga(int argc, char** argv) {
             patch_alignments = false;
             break;
 
-        case 1:
+        case OPT_MAX_GAP_LENGTH:
             max_gap_length = atoi(optarg);     // fall through
-        case 2:
+        case OPT_XDROP_ALIGNMENT:
             xdrop_alignment = true;
             break;
 

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -63,7 +63,7 @@ void help_msga(char** argv) {
          << "  -B, --band-multi INT      consider INT alignments of each band" << endl
          << "                            in banded alignment (overrides -u for bands) [16]" << endl
          << "  -M, --max-multimaps INT   consider INT extra alignments for whole sequence [1]" << endl
-         << "      --no-patch-aln        do not patch banded alignments" << endl
+         << "  -8, --no-patch-aln        do not patch banded alignments" << endl
          << "                            by locally aligning unaligned regions" << endl
          << "local alignment parameters:" << endl
          << "  -q, --match INT           use this match score [1]" << endl
@@ -114,8 +114,8 @@ int main_msga(int argc, char** argv) {
         return 1;
     }
 
-    #define OPT_MAX_GAP_LENGTH  1000
-    #define OPT_XDROP_ALIGNMENT  1001
+    constexpr int OPT_MAX_GAP_LENGTH = 1000;
+    constexpr int OPT_XDROP_ALIGNMENT = 1001;
 
     vector<string> fasta_files;
     set<string> seq_names;

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -25,57 +25,72 @@ void help_msga(char** argv) {
          << endl
          << "options:" << endl
          << "inputs:" << endl
-         << "    -f, --from FILE         use sequences in (fasta) FILE" << endl
-         << "    -n, --name NAME         include this sequence" << endl
-         << "                             (If any --name is specified, use only" << endl
-         << "                              specified sequences from FASTA files.)" << endl
-         << "    -b, --base NAME         use this sequence as the graph basis if graph is empty" << endl
-         << "    -s, --seq SEQUENCE      literally include this sequence" << endl
-         << "    -g, --graph FILE        include this graph" << endl
-         << "    -a, --fasta-order       build the graph in the order the sequences are seen in the FASTA (default: bigger first)" << endl
-         << "    -R, --position-bed FILE BED file mapping sequence names (col 4) to positions on reference path (cols 1-3)" << endl
-         << "    -T, --context STEPS     expand context around BED regions (-R) by this many steps [50]" << endl
+         << "  -f, --from FILE           use sequences in (fasta) FILE" << endl
+         << "  -n, --name NAME           include this sequence (may repeat;" << endl
+         << "                            if any --name is specified, use only" << endl
+         << "                            specified sequences from FASTA files.)" << endl
+         << "  -b, --base NAME           use this sequence as the graph basis" << endl
+         << "                            if graph is empty" << endl
+         << "  -s, --seq SEQUENCE        literally include this sequence" << endl
+         << "  -g, --graph FILE          include this graph" << endl
+         << "  -a, --fasta-order         build the graph in the order the sequences are seen" << endl
+         << "                            in the FASTA (default: bigger first)" << endl
+         << "  -R, --position-bed FILE   BED file mapping sequence names (col 4) to positions" << endl
+         << "                            on reference path (cols 1-3)" << endl
+         << "  -T, --context INT         expand context around -R regions by INT steps [50]" << endl
          << "alignment:" << endl
-         << "    -k, --min-mem INT       minimum MEM length (if 0 estimate via -e) [0]" << endl
-         << "    -e, --mem-chance FLOAT  set {-k} such that this fraction of {-k} length hits will by chance [5e-4]" << endl
-         << "    -c, --hit-max N         ignore MEMs who have >N hits in our index (0 for no limit) [2048]" << endl
-         << "    -Y, --max-mem INT       ignore mems longer than this length (unset if 0) [0]" << endl
-         << "    -r, --reseed-x FLOAT    look for internal seeds inside a seed longer than {-W} * FLOAT [1.5]" << endl
-         << "    -l, --try-at-least INT  attempt to align up to the INT best candidate chains of seeds [1]" << endl
-         << "    -u, --try-up-to INT     attempt to trace back up to this number of chains of bands (assuming we will band) [4]" << endl
-         << "    -W, --min-chain INT     discard a chain if seeded bases shorter than INT [0]" << endl
-         << "    -C, --drop-chain FLOAT  drop chains shorter than FLOAT fraction of the longest overlapping chain [0.45]" << endl
-         << "    -P, --min-ident FLOAT   accept alignment only if the alignment identity is >= FLOAT [0]" << endl
-         << "    -F, --min-band-mq INT   require mapping quality for each band to be at least this [0]" << endl
-         << "    -H, --max-target-x N    skip cluster subgraphs with length > N*read_length [100]" << endl
-         << "    -w, --band-width INT    band/chunk width for long read alignment [128]" << endl
-         << "    -O, --band-overlap INT  band overlap for long read alignment [{-w}*3/4]" << endl
-         << "    -J, --band-jump INT     the maximum number of bands of insertion we consider in the alignment chain model [128]" << endl
-         << "    -B, --band-multi INT    consider this many alignments of each band in banded alignment (overrides -u for bands) [16]" << endl
-         << "    -M, --max-multimaps INT consider this many alternate alignments for the entire sequence [1]" << endl
-         << "    --no-patch-aln          do not patch banded alignments by locally aligning unaligned regions" << endl
+         << "  -k, --min-mem INT         minimum MEM length (if 0 estimate via -e) [0]" << endl
+         << "  -e, --mem-chance FLOAT    this fraction of -k length hits are by chance [5e-4]" << endl
+         << "  -c, --hit-max N           ignore MEMs who have >N hits in our index" << endl
+         << "                            (0 for no limit) [2048]" << endl
+         << "  -Y, --max-mem INT         ignore mems longer than this length (unset if 0) [0]" << endl
+         << "  -r, --reseed-x FLOAT      look for internal seeds inside a seed" << endl
+         << "                            longer than {-W} * FLOAT [1.5]" << endl
+         << "  -l, --try-at-least INT    attempt to align up to the INT best" << endl
+         << "                            candidate chains of seeds [1]" << endl
+         << "  -u, --try-up-to INT       attempt to trace back up to INT chains of bands" << endl
+         << "                            (assuming we will band) [4]" << endl
+         << "  -W, --min-chain INT       discard a chain if seeded bases shorter than INT [0]" << endl
+         << "  -C, --drop-chain FLOAT    drop chains shorter than FLOAT fraction of" << endl
+         << "                            the longest overlapping chain [0.45]" << endl
+         << "  -P, --min-ident FLOAT     accept alignment only if identity is >= FLOAT [0]" << endl
+         << "  -F, --min-band-mq INT     require mapping quality for each band >= INT [0]" << endl
+         << "  -H, --max-target-x N      skip cluster subgraphs length >N*read_length [100]" << endl
+         << "  -w, --band-width INT      band/chunk width for long read alignment [128]" << endl
+         << "  -O, --band-overlap INT    band overlap for long read alignment [{-w}*3/4]" << endl
+         << "  -J, --band-jump INT       the maximum number of bands of insertion" << endl
+         << "                            we consider in the alignment chain model [128]" << endl
+         << "  -B, --band-multi INT      consider INT alignments of each band" << endl
+         << "                            in banded alignment (overrides -u for bands) [16]" << endl
+         << "  -M, --max-multimaps INT   consider INT extra alignments for whole sequence [1]" << endl
+         << "      --no-patch-aln        do not patch banded alignments" << endl
+         << "                            by locally aligning unaligned regions" << endl
          << "local alignment parameters:" << endl
-         << "    -q, --match INT         use this match score [1]" << endl
-         << "    -z, --mismatch INT      use this mismatch penalty [4]" << endl
-         << "    -o, --gap-open INT      use this gap open penalty [6]" << endl
-         << "    -y, --gap-extend INT    use this gap extension penalty [1]" << endl
-         << "    -L, --full-l-bonus INT  the full-length alignment bonus [32]" << endl
-         << "    --xdrop-alignment       use X-drop heuristic (much faster for long-read alignment)" << endl
-         << "    --max-gap-length INT    maximum gap length allowed in each contiguous alignment (for X-drop alignment) [40]" << endl
+         << "  -q, --match INT           use this match score [1]" << endl
+         << "  -z, --mismatch INT        use this mismatch penalty [4]" << endl
+         << "  -o, --gap-open INT        use this gap open penalty [6]" << endl
+         << "  -y, --gap-extend INT      use this gap extension penalty [1]" << endl
+         << "  -L, --full-l-bonus INT    the full-length alignment bonus [32]" << endl
+         << "      --xdrop-alignment     use X-drop heuristic" << endl
+         << "                            (much faster for long-read alignment)" << endl
+         << "      --max-gap-length INT  max gap length allowed in each contiguous alignment" << endl
+         << "                            (for X-drop alignment) [40]" << endl
          << "index generation:" << endl
-         << "    -K, --idx-kmer-size N   use kmers of this size for building the GCSA indexes [16]" << endl
-        //<< "    -O, --idx-no-recomb     index only embedded paths, not recombinations of them" << endl
-         << "    -E, --idx-edge-max N    reduce complexity of graph indexed by GCSA using this edge max [3]" << endl
-         << "    -Q, --idx-prune-subs N  prune subgraphs shorter than this length from input graph to GCSA (default: off)" << endl
-         << "    -m, --node-max N        chop nodes to be shorter than this length (default: 2* --idx-kmer-size)" << endl
-         << "    -X, --idx-doublings N   use this many doublings when building the GCSA indexes [2]" << endl
+         << "  -K, --idx-kmer-size N     use N-mers for building the GCSA indexes [16]" << endl
+         << "  -E, --idx-edge-max N      reduce complexity of GCSA graph using N edge max [3]" << endl
+         << "  -Q, --idx-prune-subs N    prune subgraphs shorter than length N" << endl
+         << "                            from input graph to GCSA (default: off)" << endl
+         << "  -m, --node-max N          chop nodes over length N [2*--idx-kmer-size]" << endl
+         << "  -X, --idx-doublings N     use N doublings when building the GCSA indexes [2]" << endl
          << "graph normalization:" << endl
-         << "    -N, --normalize         normalize the graph after assembly" << endl
-         << "    -Z, --circularize       the input sequences are from circular genomes, circularize them after inclusion" << endl
+         << "  -N, --normalize           normalize the graph after assembly" << endl
+         << "  -Z, --circularize         the input sequences are from circular genomes," << endl
+         << "                            circularize them after inclusion" << endl
          << "generic parameters:" << endl
-         << "    -D, --debug             print debugging information about construction to stderr" << endl
-         << "    -A, --debug-align       print debugging information about alignment to stderr" << endl
-         << "    -t, --threads N         number of threads to use" << endl
+         << "  -D, --debug               print debugging info about construction to stderr" << endl
+         << "  -A, --debug-align         print debugging info about alignment to stderr" << endl
+         << "  -t, --threads N           number of threads to use" << endl
+         << "  -h, --help                print this help message to stderr and exit" << endl
          << endl
          << "Construct a multiple sequence alignment from all sequences in the" << endl
          << "input fasta-format files, graphs, and sequences. Uses the MEM mapping algorithm." << endl
@@ -729,7 +744,8 @@ int main_msga(int argc, char** argv) {
             if (aln.path().mapping_size()) {
                 auto aln_seq = vg::algorithms::path_string(*graph, aln.path());
                 if (aln_seq != seq) {
-                    cerr << "[vg msga] alignment corrupted, failed to obtain correct banded alignment (alignment seq != input seq)" << endl;
+                    cerr << "[vg msga] alignment corrupted, failed to obtain correct banded alignment "
+                         << "(alignment seq != input seq)" << endl;
                     cerr << "expected " << seq << endl;
                     cerr << "got      " << aln_seq << endl;
                     ofstream f(name + "-failed-alignment-" + convert(j) + ".gam");

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -68,7 +68,7 @@ int main_pack(int argc, char** argv) {
             {"help", no_argument, 0, 'h'},
             {"xg", required_argument,0, 'x'},
             {"packs-out", required_argument,0, 'o'},
-            {"count-in", required_argument, 0, 'i'},
+            {"packs-in", required_argument, 0, 'i'},
             {"gam", required_argument, 0, 'g'},
             {"gaf", required_argument, 0, 'a'},
             {"as-table", no_argument, 0, 'd'},
@@ -86,7 +86,7 @@ int main_pack(int argc, char** argv) {
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:o:i:g:a:dDut:eb:n:N:Q:c:s:",
+        c = getopt_long (argc, argv, "h?x:o:i:g:a:dDut:eb:n:N:Q:c:s:",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/pack_main.cpp
+++ b/src/subcommand/pack_main.cpp
@@ -17,22 +17,25 @@ using namespace vg::subcommand;
 void help_pack(char** argv) {
     cerr << "usage: " << argv[0] << " pack [options]" << endl
          << "options:" << endl
-         << "    -x, --xg FILE          use this basis graph (any format accepted, does not have to be xg)" << endl
-         << "    -o, --packs-out FILE   write compressed coverage packs to this output file" << endl
-         << "    -i, --packs-in FILE    begin by summing coverage packs from each provided FILE" << endl
-         << "    -g, --gam FILE         read alignments from this GAM file (could be '-' for stdin)" << endl
-         << "    -a, --gaf FILE         read alignments from this GAF file (could be '-' for stdin)" << endl
-         << "    -d, --as-table         write table on stdout representing packs" << endl
-         << "    -D, --as-edge-table    write table on stdout representing edge coverage" << endl
-         << "    -u, --as-qual-table    write table on stdout representing average node mapqs" << endl
-         << "    -e, --with-edits       record and write edits rather than only recording graph-matching coverage" << endl
-         << "    -b, --bin-size N       number of sequence bases per CSA bin [default: inf]" << endl
-         << "    -n, --node ID          write table for only specified node(s)" << endl
-         << "    -N, --node-list FILE   a white space or line delimited list of nodes to collect" << endl
-         << "    -Q, --min-mapq N       ignore reads with MAPQ < N and positions with base quality < N [default: 0]" << endl
-         << "    -c, --expected-cov N   expected coverage.  used only for memory tuning [default : 128]" << endl
-         << "    -s, --trim-ends N      ignore the first and last N bases of each read" << endl 
-         << "    -t, --threads N        use N threads (defaults to numCPUs)" << endl;
+         << "  -x, --xg FILE          use this basis graph (does not have to be xg format)" << endl
+         << "  -o, --packs-out FILE   write compressed coverage packs to this output file" << endl
+         << "  -i, --packs-in FILE    begin by summing coverage packs from each provided FILE" << endl
+         << "  -g, --gam FILE         read alignments from this GAM file ('-' for stdin)" << endl
+         << "  -a, --gaf FILE         read alignments from this GAF file ('-' for stdin)" << endl
+         << "  -d, --as-table         write table on stdout representing packs" << endl
+         << "  -D, --as-edge-table    write table on stdout representing edge coverage" << endl
+         << "  -u, --as-qual-table    write table on stdout representing average node mapqs" << endl
+         << "  -e, --with-edits       record and write edits" << endl
+         << "                         rather than only recording graph-matching coverage" << endl
+         << "  -b, --bin-size N       number of sequence bases per CSA bin [inf]" << endl
+         << "  -n, --node ID          write table for only specified node(s)" << endl
+         << "  -N, --node-list FILE   white space or line delimited list of nodes to collect" << endl
+         << "  -Q, --min-mapq N       ignore reads with MAPQ < N" << endl
+         << "                         and positions with base quality < N [0]" << endl
+         << "  -c, --expected-cov N   expected coverage.  used only for memory tuning [128]" << endl
+         << "  -s, --trim-ends N      ignore the first and last N bases of each read" << endl 
+         << "  -t, --threads N        use N threads [numCPUs]" << endl
+         << "  -h, --help             print this help message to stderr and exit" << endl;
 }
 
 
@@ -87,7 +90,7 @@ int main_pack(int argc, char** argv) {
         };
         int option_index = 0;
         c = getopt_long (argc, argv, "h?x:o:i:g:a:dDut:eb:n:N:Q:c:s:",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -133,6 +133,7 @@ int main_paths(int argc, char** argv) {
         static struct option long_options[] =
 
         {
+            {"help", no_argument, 0, 'h'},
             {"vg", required_argument, 0, 'v'},
             {"xg", required_argument, 0, 'x'},
             {"gbwt", required_argument, 0, 'g'},
@@ -156,16 +157,17 @@ int main_paths(int argc, char** argv) {
             {"haplotype-paths", no_argument, 0, 'H'},
             {"coverage", no_argument, 0, 'c'},            
             {"overlay", no_argument, 0, 'o'},
+            {"threads", required_argument, 0, 't'},
 
             // Hidden options for backward compatibility.
-            {"threads", no_argument, 0, 'T'},
+            {"threads-old", no_argument, 0, 'T'},
             {"threads-by", required_argument, 0, 'q'},
 
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hLXv:x:g:Q:VEMCFAS:drnaGRHp:coTq:t:",
+        c = getopt_long (argc, argv, "h?LXv:x:g:Q:VEMCFAS:drnaGRHp:coTq:t:",
                 long_options, &option_index);
 
         // Detect the end of the options.
@@ -286,7 +288,7 @@ int main_paths(int argc, char** argv) {
             break;
 
         case 'T':
-            std::cerr << "warning: [vg paths] option --threads is obsolete and unnecessary" << std::endl;
+            std::cerr << "warning: [vg paths] option -T/--threads-old is obsolete; use -t/--threads" << std::endl;
             break;
 
         case 'q':

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -30,37 +30,43 @@ using namespace vg::subcommand;
 
 void help_paths(char** argv) {
     cerr << "usage: " << argv[0] << " paths [options]" << endl
-         << "options:" << endl
-         << "  input:" << endl
-         << "    -x, --xg FILE            use the paths and haplotypes in this graph FILE. Supports GBZ haplotypes." <<endl
-         << "                             (also accepts -v, --vg)" << endl
-         << "    -g, --gbwt FILE          use the threads in the GBWT index in FILE" << endl
-         << "                             (graph also required for most output options; -g takes priority over -x)" << endl
-         << "  output graph (.vg format)" << endl
-         << "    -V, --extract-vg         output a path-only graph covering the selected paths" << endl
-         << "    -d, --drop-paths         output a graph with the selected paths removed" << endl
-         << "    -r, --retain-paths       output a graph with only the selected paths retained" << endl
-         << "    -n, --normalize-paths    output a graph where all equivalent paths in a site a merged (using selected paths to snap to if possible)" << endl 
-         << "  output path data:" << endl
-         << "    -X, --extract-gam        print (as GAM alignments) the stored paths in the graph" << endl
-         << "    -A, --extract-gaf        print (as GAF alignments) the stored paths in the graph" << endl
-         << "    -L, --list               print (as a list of names, one per line) the path (or thread) names" << endl
-         << "    -E, --lengths            print a list of path names (as with -L) but paired with their lengths" << endl
-         << "    -M, --metadata           print a table of path names and their metadata" << endl
-         << "    -C, --cyclicity          print a list of path names (as with -L) but paired with flag denoting the cyclicity" << endl
-         << "    -F, --extract-fasta      print the paths in FASTA format" << endl
-         << "    -c, --coverage           print the coverage stats for selected paths (not including cylces)" << endl
-         << "  path selection:" << endl
-         << "    -p, --paths-file FILE    select the paths named in a file (one per line)" << endl
-         << "    -Q, --paths-by STR       select the paths with the given name prefix" << endl
-         << "    -S, --sample STR         select the haplotypes or reference paths for this sample" << endl
-         << "    -a, --variant-paths      select the variant paths added by 'vg construct -a'" << endl
-         << "    -G, --generic-paths      select the generic, non-reference, non-haplotype paths" << endl
-         << "    -R, --reference-paths    select the reference paths" << endl
-         << "    -H, --haplotype-paths    select the haplotype paths paths" << endl
-         << "  configuration:" << endl
-         << "    -o, --overlay            apply a ReferencePathOverlayHelper to the graph" << endl
-         << "    -t, --threads N          number of threads to use [all available]. applies only to snarl finding within -n" << endl;
+         << "  -h, --help               print this help message to stderr and exit" << endl
+         << "input:" << endl
+         << "  -x, --xg FILE            use the paths and haplotypes in this graph FILE." << endl
+         << "                           Supports GBZ haplotypes. (also accepts -v, --vg)" << endl
+         << "  -g, --gbwt FILE          use the threads in the GBWT index in FILE" << endl
+         << "                           (graph also required for most output options;" << endl
+         << "                           -g takes priority over -x)" << endl
+         << "output graph (.vg format)" << endl
+         << "  -V, --extract-vg         output a path-only graph covering the selected paths" << endl
+         << "  -d, --drop-paths         output a graph with the selected paths removed" << endl
+         << "  -r, --retain-paths       output a graph with only the selected paths retained" << endl
+         << "  -n, --normalize-paths    output a graph where equivalent paths in a site are" << endl
+         << "                           merged (using selected paths to snap to if possible)" << endl 
+         << "output path data:" << endl
+         << "  -X, --extract-gam        print (as GAM alignments) stored paths in the graph" << endl
+         << "  -A, --extract-gaf        print (as GAF alignments) stored paths in the graph" << endl
+         << "  -L, --list               print (one per line) path (or thread) names" << endl
+         << "  -E, --lengths            print a list of path names (as with -L)" << endl
+         << "                           but paired with their lengths" << endl
+         << "  -M, --metadata           print a table of path names and their metadata" << endl
+         << "  -C, --cyclicity          print a list of path names (as with -L)" << endl
+         << "                           but paired with flag denoting the cyclicity" << endl
+         << "  -F, --extract-fasta      print the paths in FASTA format" << endl
+         << "  -c, --coverage           print the coverage stats for selected paths" << endl
+         << "                           (not including cycles)" << endl
+         << "path selection:" << endl
+         << "  -p, --paths-file FILE    select paths named in a file (one per line)" << endl
+         << "  -Q, --paths-by STR       select paths with the given name prefix" << endl
+         << "  -S, --sample STR         select haplotypes or reference paths for this sample" << endl
+         << "  -a, --variant-paths      select variant paths added by 'vg construct -a'" << endl
+         << "  -G, --generic-paths      select generic, non-reference, non-haplotype paths" << endl
+         << "  -R, --reference-paths    select reference paths" << endl
+         << "  -H, --haplotype-paths    select haplotype paths paths" << endl
+         << "configuration:" << endl
+         << "  -o, --overlay            apply a ReferencePathOverlayHelper to the graph" << endl
+         << "  -t, --threads N          number of threads to use [all available]" << endl
+         << "                           applies only to snarl finding within -n" << endl;
 }
 
 /// Chunk a path and emit it in Graph messages.
@@ -340,9 +346,11 @@ int main_paths(int argc, char** argv) {
         std::exit(EXIT_FAILURE);
     }
     if (!gbwt_file.empty()) {
-        bool need_graph = (extract_as_gam || extract_as_gaf || extract_as_vg || drop_paths || retain_paths || extract_as_fasta || list_lengths);
+        bool need_graph = (extract_as_gam || extract_as_gaf || extract_as_vg || drop_paths
+                           || retain_paths || extract_as_fasta || list_lengths);
         if (need_graph && graph_file.empty()) {
-            std::cerr << "error: [vg paths] a graph is needed for extracting threads in -X, -A, -V, -d, -r, -n, -E or -F format" << std::endl;
+            std::cerr << "error: [vg paths] a graph is needed for extracting threads in "
+                      << "-X, -A, -V, -d, -r, -n, -E or -F format" << std::endl;
             std::exit(EXIT_FAILURE);
         }
         if (!need_graph && !graph_file.empty()) {
@@ -353,7 +361,8 @@ int main_paths(int argc, char** argv) {
         }
     } 
     if (output_formats != 1) {
-        std::cerr << "error: [vg paths] one output format (-X, -A, -V, -d, -r, -n, -L, -F, -E, -C or -c) must be specified" << std::endl;
+        std::cerr << "error: [vg paths] one output format (-X, -A, -V, -d, -r, -n, -L, -F, -E, -C or -c) "
+                  << "must be specified" << std::endl;
         std::exit(EXIT_FAILURE);
     }
     if (selection_criteria > 1) {
@@ -369,7 +378,8 @@ int main_paths(int argc, char** argv) {
         std::exit(EXIT_FAILURE);
     }
     if ((drop_paths || retain_paths || normalize_paths) && !gbwt_file.empty()) {
-        std::cerr << "error: [vg paths] dropping, retaining or normalizing paths only works on embedded graph paths, not GBWT threads" << std::endl;
+        std::cerr << "error: [vg paths] dropping, retaining or normalizing paths "
+                  << "only works on embedded graph paths, not GBWT threads" << std::endl;
         std::exit(EXIT_FAILURE);
     }
     if (coverage && !gbwt_file.empty()) {
@@ -765,13 +775,17 @@ int main_paths(int argc, char** argv) {
                         // Dump fields for all the metadata
                         cout << "\t" << SENSE_TO_STRING.at(graph->get_sense(path_handle));
                         auto sample = graph->get_sample_name(path_handle);
-                        cout << "\t" << (sample == PathMetadata::NO_SAMPLE_NAME ? "NO_SAMPLE_NAME" : sample);
+                        cout << "\t" << (sample == PathMetadata::NO_SAMPLE_NAME ? "NO_SAMPLE_NAME"
+                                                                                : sample);
                         auto haplotype = graph->get_haplotype(path_handle);
-                        cout << "\t" << (haplotype == PathMetadata::NO_HAPLOTYPE ? "NO_HAPLOTYPE" : std::to_string(haplotype));
+                        cout << "\t" << (haplotype == PathMetadata::NO_HAPLOTYPE ? "NO_HAPLOTYPE"
+                                                                                 : std::to_string(haplotype));
                         auto locus = graph->get_locus_name(path_handle);
-                        cout << "\t" << (locus == PathMetadata::NO_LOCUS_NAME ? "NO_LOCUS_NAME" : locus);
+                        cout << "\t" << (locus == PathMetadata::NO_LOCUS_NAME ? "NO_LOCUS_NAME"
+                                                                              : locus);
                         auto phase_block = graph->get_phase_block(path_handle);
-                        cout << "\t" << (phase_block == PathMetadata::NO_PHASE_BLOCK ? "NO_PHASE_BLOCK" : std::to_string(phase_block));
+                        cout << "\t" << (phase_block == PathMetadata::NO_PHASE_BLOCK ? "NO_PHASE_BLOCK" 
+                                                                                     : std::to_string(phase_block));
                         auto subrange = graph->get_subrange(path_handle);
                         cout << "\t";
                         if (subrange == PathMetadata::NO_SUBRANGE) {

--- a/src/subcommand/primers_main.cpp
+++ b/src/subcommand/primers_main.cpp
@@ -93,20 +93,20 @@ int main_primers(int argc, char** argv) {
           {"help",                no_argument,       0, 'h'},
           {"xg-path",             required_argument, 0, 'x'},
           {"dist-index",          required_argument, 0, 'd'},
-          {"ri-path",             required_argument, 0, 'r'},
-          {"gbz-path",            required_argument, 0, 'g'},
+          {"r-index",             required_argument, 0, 'r'},
+          {"gbz",                 required_argument, 0, 'g'},
           {"minimizers",          required_argument, 0, 'M'},
           {"zipcodes",            required_argument, 0, 'Z'},
           {"variation-threshold", required_argument, 0, 'v'},
           {"tolerance",           required_argument, 0, 'l'},
           {"minimum-size",        required_argument, 0, 'n'},
           {"maximum-size",        required_argument, 0, 'm'},
-          {"all-primers",         required_argument, 0, 'a'},
+          {"all-primers",         no_argument,       0, 'a'},
           {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:d:r:g:M:Z:v:l:n:m:a", long_options, &option_index);
+        c = getopt_long (argc, argv, "h?x:d:r:g:M:Z:v:l:n:m:a", long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1) break;

--- a/src/subcommand/primers_main.cpp
+++ b/src/subcommand/primers_main.cpp
@@ -16,17 +16,22 @@ void help_primers(char** argv) {
     cerr << "usage: " << argv[0] << " primers [options] input.primer3 > filtered_primers.out" << endl
          << endl
          << "options:" << endl
-         << "    -x, --xg-path FILE                 use this xg graph (required)" << endl
-         << "    -d, --dist-index FILE              use this distance index (required)" << endl
-         << "    -r, --r-index FILE                 use this r index (required)" << endl
-         << "    -g, --gbz FILE                     use this gbz file (required)" << endl
-         << "    -M, --minimizers FILE              use this minimizer file for mapping the template sequence, if necessary" << endl
-         << "    -Z, --zipcodes FILE                use this zipcode file for mapping the template sequence, if necessary" << endl
-         << "    -v, --variation-threshold DOUBLE   output primers that work for at least this percentage of haplotypes (default: 0.8)" << endl
-         << "    -l, --tolerance INT                allow this much difference between minimum and maximum sizes compared to the linear product size (default: 10)" << endl
-         << "    -n, --minimum-size INT             minimum product size allowed (has precedence over --tolerance)" << endl
-         << "    -m, --maximum-size INT             maximum product size allowed (has precedence over --tolerance)" << endl
-         << "    -a, --all-primers                  output all primers" << endl;
+         << "  -x, --xg-path FILE               use this xg graph (required)" << endl
+         << "  -d, --dist-index FILE            use this distance index (required)" << endl
+         << "  -r, --r-index FILE               use this r index (required)" << endl
+         << "  -g, --gbz FILE                   use this gbz file (required)" << endl
+         << "  -M, --minimizers FILE            use this minimizer file for mapping" << endl
+         << "                                   the template sequence, if necessary" << endl
+         << "  -Z, --zipcodes FILE              use this zipcode file for mapping" << endl
+         << "                                   the template sequence, if necessary" << endl
+         << "  -v, --variation-threshold FLOAT  output primers that work for at least" << endl
+         << "                                   this share of haplotypes [0.8]" << endl
+         << "  -l, --tolerance INT              allow INT difference between min & max sizes" << endl
+         << "                                   compared to the linear product size [10]" << endl
+         << "  -n, --minimum-size INT           minimum product size allowed (overrides -l)" << endl
+         << "  -m, --maximum-size INT           maximum product size allowed (overrides -l)" << endl
+         << "  -a, --all-primers                output all primers" << endl
+         << "  -h, --help                       print this help message to stderr and exit" << endl;
 }
 
 size_t difference(const size_t& a, const size_t& b) {
@@ -218,7 +223,8 @@ int main_primers(int argc, char** argv) {
     MinimizerMapper minimizer_mapper (gbwt_graph, *minimizer_index, &distance_index, &zipcodes);
     if (!min_path.empty()) {
         //Set parameters
-        //TODO: I'm not actually sure about this because the sequence is long but it should match a path exactly so it should get the whole alignment at gapless extension
+        //TODO: I'm not actually sure about this because the sequence is long
+        //but it should match a path exactly so it should get the whole alignment at gapless extension
         minimizer_mapper.align_from_chains = true;
         giraffe_mapper = &minimizer_mapper;
     }

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -183,7 +183,7 @@ int main_prune(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long(argc, argv, "k:e:s:M:Pruvx:g:m:apt:dh", long_options, &option_index);
+        c = getopt_long(argc, argv, "k:e:s:M:Pruvxg:m:apt:dh?", long_options, &option_index);
         if (c == -1) { break; } // End of options.
 
         switch (c)

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -106,35 +106,36 @@ void print_defaults(const std::map<PruningMode, ValueType>& defaults) {
 void help_prune(char** argv) {
     std::cerr << "usage: " << argv[0] << " prune [options] <graph.vg> >[output.vg]" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Prunes the complex regions of the graph for GCSA2 indexing. Pruning the graph" << std::endl;
-    std::cerr << "removes embedded paths." << std::endl;
+    std::cerr << "Prunes the complex regions of the graph for GCSA2 indexing." << std::endl;
+    std::cerr << "Pruning the graph removes embedded paths." << std::endl;
     std::cerr << std::endl;
     std::cerr << "Pruning parameters:" << std::endl;
-    std::cerr << "    -k, --kmer-length N    kmer length used for pruning" << std::endl;
-    std::cerr << "                           "; print_defaults(PruningParameters::kmer_length);
-    std::cerr << "    -e, --edge-max N       remove the edges on kmers making > N edge choices" << std::endl;
-    std::cerr << "                           "; print_defaults(PruningParameters::edge_max);
-    std::cerr << "    -s, --subgraph-min N   remove subgraphs of < N bases" << std::endl;
-    std::cerr << "                           "; print_defaults(PruningParameters::subgraph_min);
-    std::cerr << "    -M, --max-degree N     if N > 0, remove nodes with degree > N before pruning" << std::endl;
-    std::cerr << "                           "; print_defaults(PruningParameters::max_degree);
+    std::cerr << "  -k, --kmer-length N    kmer length used for pruning" << std::endl;
+    std::cerr << "                         "; print_defaults(PruningParameters::kmer_length);
+    std::cerr << "  -e, --edge-max N       remove the edges on kmers making > N edge choices" << std::endl;
+    std::cerr << "                         "; print_defaults(PruningParameters::edge_max);
+    std::cerr << "  -s, --subgraph-min N   remove subgraphs of < N bases" << std::endl;
+    std::cerr << "                         "; print_defaults(PruningParameters::subgraph_min);
+    std::cerr << "  -M, --max-degree N     if N > 0, remove nodes with degree > N before pruning" << std::endl;
+    std::cerr << "                         "; print_defaults(PruningParameters::max_degree);
     std::cerr << std::endl;
     std::cerr << "Pruning modes (-P, -r, and -u are mutually exclusive):" << std::endl;
-    std::cerr << "    -P, --prune            simply prune the graph (default)" << std::endl;
-    std::cerr << "    -r, --restore-paths    restore the edges on non-alt paths" << std::endl;
-    std::cerr << "    -u, --unfold-paths     unfold non-alt paths and GBWT threads" << std::endl;
-    std::cerr << "    -v, --verify-paths     verify that the paths exist after pruning" << std::endl;
-    std::cerr << "                           (potentially very slow)" << std::endl;
+    std::cerr << "  -P, --prune            simply prune the graph (default)" << std::endl;
+    std::cerr << "  -r, --restore-paths    restore the edges on non-alt paths" << std::endl;
+    std::cerr << "  -u, --unfold-paths     unfold non-alt paths and GBWT threads" << std::endl;
+    std::cerr << "  -v, --verify-paths     verify that the paths exist after pruning" << std::endl;
+    std::cerr << "                         (potentially very slow)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Unfolding options:" << std::endl;
-    std::cerr << "    -g, --gbwt-name FILE   unfold the threads from this GBWT index" << std::endl;
-    std::cerr << "    -m, --mapping FILE     store the node mapping for duplicates in this file (required with -u)" << std::endl;
-    std::cerr << "    -a, --append-mapping   append to the existing node mapping" << std::endl;
+    std::cerr << "  -g, --gbwt-name FILE   unfold the threads from this GBWT index" << std::endl;
+    std::cerr << "  -m, --mapping FILE     store node mapping for duplicates (required with -u)" << std::endl;
+    std::cerr << "  -a, --append-mapping   append to the existing node mapping" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
-    std::cerr << "    -p, --progress         show progress" << std::endl;
-    std::cerr << "    -t, --threads N        use N threads (default: " << omp_get_max_threads() << ")" << std::endl;
-    std::cerr << "    -d, --dry-run          determine the validity of the combination of options" << std::endl;
+    std::cerr << "  -p, --progress         show progress" << std::endl;
+    std::cerr << "  -t, --threads N        use N threads [" << omp_get_max_threads() << "]" << std::endl;
+    std::cerr << "  -d, --dry-run          determine the validity of the combination of options" << std::endl;
+    std::cerr << "  -h, --help             print this help message to stderr and exit" << std::endl;
     std::cerr << std::endl;
 }
 
@@ -338,7 +339,8 @@ int main_prune(int argc, char** argv) {
     
     vg::id_t max_node_id = graph->max_node_id();
     if (show_progress) {
-        std::cerr << "Original graph " << vg_name << ": " << graph->get_node_count() << " nodes, " << graph->get_edge_count() << " edges" << std::endl;
+        std::cerr << "Original graph " << vg_name << ": " << graph->get_node_count() 
+                  << " nodes, " << graph->get_edge_count() << " edges" << std::endl;
     }
 
     // Remove the paths and build an XG index if needed.

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -22,42 +22,53 @@ using namespace vg;
 using namespace vg::subcommand;
 
 void help_rna(char** argv) {
-    cerr << "\nusage: " << argv[0] << " rna [options] graph.[vg|pg|hg|gbz] > splicing_graph.[vg|pg|hg]" << endl
+    cerr << "usage: " << argv[0] << " rna [options] graph.[vg|pg|hg|gbz] > splicing_graph.[vg|pg|hg]" << endl
 
-         << "\nGeneral options:" << endl
+         << endl 
+         << "General options:" << endl
 
-         << "    -t, --threads INT          number of compute threads to use [1]" << endl
-         << "    -p, --progress             show progress" << endl
-         << "    -h, --help                 print help message" << endl
+         << "  -t, --threads INT          number of compute threads to use [1]" << endl
+         << "  -p, --progress             show progress" << endl
+         << "  -h, --help                 print this help message to stderr and exit" << endl
 
-         << "\nInput options:" << endl
+         << endl
+         << "Input options:" << endl
 
-         << "    -n, --transcripts FILE     transcript file(s) in gtf/gff format; may repeat" << endl
-         << "    -m, --introns FILE         intron file(s) in bed format; may repeat" << endl
-         << "    -y, --feature-type NAME    parse only this feature type in the gtf/gff (parses all if empty) [exon]" << endl
-         << "    -s, --transcript-tag NAME  use this attribute tag in the gtf/gff file(s) as id [transcript_id]" << endl
-         << "    -l, --haplotypes FILE      project transcripts onto haplotypes in GBWT index file" << endl
-         << "    -z, --gbz-format           input graph is in GBZ format (contains both a graph and haplotypes (GBWT index))" << endl
+         << "  -n, --transcripts FILE     transcript file(s) in gtf/gff format (may repeat)" << endl
+         << "  -m, --introns FILE         intron file(s) in bed format (may repeat)" << endl
+         << "  -y, --feature-type NAME    parse only this feature type in the GTF/GFF" << endl
+         << "                             (parses all if empty) [exon]" << endl
+         << "  -s, --transcript-tag NAME  use this attribute tag in the GTF/GFf file(s) as ID" << endl
+         << "                             to group exons and name paths [transcript_id]" << endl
+         << "  -l, --haplotypes FILE      project transcripts onto haplotypes in GBWT index" << endl
+         << "  -z, --gbz-format           input graph is GBZ format (has graph & GBWT index)" << endl
 
-         << "\nConstruction options:" << endl
+         << endl
+         << "Construction options:" << endl
 
-         << "    -j, --use-hap-ref          use haplotype paths in GBWT index as reference sequences (disables projection)" << endl
-         << "    -e, --proj-embed-paths     project transcripts onto embedded haplotype paths" << endl
-         << "    -c, --path-collapse TYPE   collapse identical transcript paths across no|haplotype|all paths [haplotype]" << endl
-         << "    -k, --max-node-length INT  chop nodes longer than maximum node length (0 disables chopping) [0]" << endl
-         << "    -d, --remove-non-gene      remove intergenic and intronic regions (deletes all paths in the graph)" << endl
-         << "    -o, --do-not-sort          do not topological sort and compact the graph" << endl
-         << "    -r, --add-ref-paths        add reference transcripts as embedded paths in the graph" << endl
-         << "    -a, --add-hap-paths        add projected transcripts as embedded paths in the graph" << endl
+         << "  -j, --use-hap-ref          use haplotype paths in GBWT index as references" << endl
+         << "                             (disables projection)" << endl
+         << "  -e, --proj-embed-paths     project transcripts onto embedded haplotype paths" << endl
+         << "  -c, --path-collapse TYPE   collapse identical transcript paths across" << endl
+         << "                             no|haplotype|all paths [haplotype]" << endl
+         << "  -k, --max-node-length INT  chop nodes longer than INT (disable with 0) [0]" << endl
+         << "  -d, --remove-non-gene      remove intergenic and intronic regions" << endl
+         << "                             (deletes all paths in the graph)" << endl
+         << "  -o, --do-not-sort          do not topological sort and compact the graph" << endl
+         << "DON'T FORGET TO EMBED PATHS:" << endl
+         << "  -r, --add-ref-paths        add reference transcripts as embedded paths" << endl
+         << "  -a, --add-hap-paths        add projected transcripts as embedded paths" << endl
 
-         << "\nOutput options:" << endl
+         << endl
+         << "Output options:" << endl
 
-         << "    -b, --write-gbwt FILE      write pantranscriptome transcript paths as GBWT index file" << endl
-         << "    -v, --write-hap-gbwt FILE  write input haplotypes as a GBWT with node IDs matching the output graph" << endl
-         << "    -f, --write-fasta FILE     write pantranscriptome transcript sequences as fasta file" << endl
-         << "    -i, --write-info FILE      write pantranscriptome transcript info table as tsv file" << endl
-         << "    -q, --out-exclude-ref      exclude reference transcripts from pantranscriptome output" << endl
-         << "    -g, --gbwt-bidirectional   use bidirectional paths in GBWT index construction" << endl
+         << "  -b, --write-gbwt FILE      write pantranscriptome transcript paths as GBWT" << endl
+         << "  -v, --write-hap-gbwt FILE  write input haplotypes as a GBWT" << endl
+         << "                             with node IDs matching the output graph" << endl
+         << "  -f, --write-fasta FILE     write pantranscriptome transcript sequences to here" << endl
+         << "  -i, --write-info FILE      write pantranscriptome transcript info table as TSV" << endl
+         << "  -q, --out-exclude-ref      exclude reference transcripts from pantranscriptome" << endl
+         << "  -g, --gbwt-bidirectional   use bidirectional paths in GBWT index construction" << endl
 
          << endl;
 }
@@ -245,7 +256,8 @@ int32_t main_rna(int32_t argc, char** argv) {
 
     if (transcript_filenames.empty() && intron_filenames.empty()) {
 
-        cerr << "[vg rna] ERROR: No transcripts or introns were given. Use --transcripts FILE and/or --introns FILE." << endl;
+        cerr << "[vg rna] ERROR: No transcripts or introns were given. "
+             << "Use --transcripts FILE and/or --introns FILE." << endl;
         return 1;       
     }
 
@@ -257,7 +269,8 @@ int32_t main_rna(int32_t argc, char** argv) {
             // taken from https://stackoverflow.com/a/20446239/
             if (ends_with(filename, vg::GZ_SUFFIX)) {
 
-                cerr << "[vg rna] ERROR: Annotation file " << filename << " appears to be gzipped. Decompress it before use." << endl;    
+                cerr << "[vg rna] ERROR: Annotation file " << filename 
+                     << " appears to be gzipped. Decompress it before use." << endl;    
                 return 1;
             }
         }
@@ -265,18 +278,22 @@ int32_t main_rna(int32_t argc, char** argv) {
 
     if (!haplotypes_filename.empty() && gbz_format) {
 
-        cerr << "[vg rna] ERROR: Only one set of haplotypes can be provided (GBZ file contains both a graph and haplotypes). Use either --haplotypes or --gbz-format." << endl;
+        cerr << "[vg rna] ERROR: Only one set of haplotypes can be provided "
+             << "(GBZ file contains both a graph and haplotypes). "
+             << "Use either --haplotypes or --gbz-format." << endl;
         return 1;       
     }
 
     if (remove_non_transcribed_nodes && !add_reference_transcript_paths && !add_projected_transcript_paths) {
 
-        cerr << "[vg rna] WARNING: Reference paths are deleted when removing intergenic and intronic regions. Consider adding transcripts as embedded paths using --add-ref-paths and/or --add-hap-paths." << endl;
+        cerr << "[vg rna] WARNING: Reference paths are deleted when removing intergenic and intronic regions. "
+             << "Consider adding transcripts as embedded paths using --add-ref-paths and/or --add-hap-paths." << endl;
     }
 
     if (path_collapse_type != "no" && path_collapse_type != "haplotype" && path_collapse_type != "all") {
 
-        cerr << "[vg rna] ERROR: Path collapse type (--path-collapse) provided not supported. Options: no, haplotype or all." << endl;
+        cerr << "[vg rna] ERROR: Path collapse type (--path-collapse) provided not supported. "
+             << "Options: no, haplotype or all." << endl;
         return 1;
     }
 
@@ -320,7 +337,8 @@ int32_t main_rna(int32_t argc, char** argv) {
         handlealgs::copy_handle_graph(&(gbz->graph), graph.get());
 
         // Copy reference and generic paths to new graph.
-        gbz->graph.for_each_path_matching({PathSense::GENERIC, PathSense::REFERENCE}, {}, {}, [&](const path_handle_t& path) {
+        gbz->graph.for_each_path_matching({PathSense::GENERIC, PathSense::REFERENCE}, {}, {},
+            [&](const path_handle_t& path) {
             
             handlegraph::algorithms::copy_path(&(gbz->graph), path, graph.get());
         });
@@ -343,7 +361,11 @@ int32_t main_rna(int32_t argc, char** argv) {
     transcriptome.transcript_tag = transcript_tag;
     transcriptome.path_collapse_type = path_collapse_type;
     
-    if (show_progress) { cerr << "[vg rna] Graph " << ((!haplotype_index->empty()) ? "and GBWT index " : "") << "parsed in " << gcsa::readTimer() - time_parsing_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
+    if (show_progress) {
+        cerr << "[vg rna] Graph " << ((!haplotype_index->empty()) ? "and GBWT index " : "")
+             << "parsed in " << gcsa::readTimer() - time_parsing_start << " seconds, "
+             << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
+    };
 
 
     if (!intron_filenames.empty()) {
@@ -372,7 +394,11 @@ int32_t main_rna(int32_t argc, char** argv) {
             delete intron_stream;
         }
 
-        if (show_progress) { cerr << "[vg rna] Introns parsed and graph updated in " << gcsa::readTimer() - time_intron_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
+        if (show_progress) {
+            cerr << "[vg rna] Introns parsed and graph updated in "
+                 << gcsa::readTimer() - time_intron_start << " seconds, "
+                 << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
+        };
     }
 
     vector<istream *> transcript_streams;
@@ -397,7 +423,11 @@ int32_t main_rna(int32_t argc, char** argv) {
         // Add transcripts as novel exon boundaries and splice-junctions to graph.
         transcriptome.add_reference_transcripts(transcript_streams, haplotype_index, use_hap_ref, !use_hap_ref);
 
-        if (show_progress) { cerr << "[vg rna] Transcripts parsed and graph updated in " << gcsa::readTimer() - time_transcript_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
+        if (show_progress) {
+            cerr << "[vg rna] Transcripts parsed and graph updated in "
+                 << gcsa::readTimer() - time_transcript_start << " seconds, "
+                 << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
+        };
     }
 
     if (!transcript_streams.empty() && (!haplotype_index->empty() || proj_emded_paths) && !use_hap_ref) {
@@ -416,7 +446,11 @@ int32_t main_rna(int32_t argc, char** argv) {
         // in a graph and/or haplotypes in a GBWT index.
         transcriptome.add_haplotype_transcripts(transcript_streams, *haplotype_index, proj_emded_paths);
 
-        if (show_progress) { cerr << "[vg rna] Haplotype-specific transcripts constructed in " << gcsa::readTimer() - time_project_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
+        if (show_progress) {
+            cerr << "[vg rna] Haplotype-specific transcripts constructed in "
+                 << gcsa::readTimer() - time_project_start << " seconds, "
+                 << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
+        };
     }
 
     for (auto & transcript_stream: transcript_streams) {
@@ -432,7 +466,10 @@ int32_t main_rna(int32_t argc, char** argv) {
 
         transcriptome.remove_non_transcribed_nodes();
 
-        if (show_progress) { cerr << "[vg rna] Regions removed in " << gcsa::readTimer() - time_remove_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
+        if (show_progress) {
+            cerr << "[vg rna] Regions removed in " << gcsa::readTimer() - time_remove_start
+                 << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
+        };
     }
 
 
@@ -443,7 +480,10 @@ int32_t main_rna(int32_t argc, char** argv) {
 
         transcriptome.chop_nodes(max_node_length);
 
-        if (show_progress) { cerr << "[vg rna] Nodes chopped in " << gcsa::readTimer() - time_chop_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
+        if (show_progress) {
+            cerr << "[vg rna] Nodes chopped in " << gcsa::readTimer() - time_chop_start 
+                 << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
+        };
     }
 
 
@@ -454,11 +494,18 @@ int32_t main_rna(int32_t argc, char** argv) {
         
         if (transcriptome.sort_compact_nodes()) {
 
-            if (show_progress) { cerr << "[vg rna] Graph sorted and compacted in " << gcsa::readTimer() - time_sort_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
+            if (show_progress) { 
+                cerr << "[vg rna] Graph sorted and compacted in " 
+                     << gcsa::readTimer() - time_sort_start << " seconds, " 
+                     << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
+            };
 
         } else {
 
-            if (show_progress) { cerr << "[vg rna] WARNING: Can only sort and compact node ids for a graph in the PackedGraph format" << endl; };            
+            if (show_progress) {
+                cerr << "[vg rna] WARNING: Can only sort and compact node ids " 
+                     << "for a graph in the PackedGraph format" << endl;
+            };            
         }        
     }
 
@@ -469,16 +516,22 @@ int32_t main_rna(int32_t argc, char** argv) {
 
         if (add_reference_transcript_paths && add_projected_transcript_paths) {
 
-            if (show_progress) { cerr << "[vg rna] Adding reference and projected transcripts as embedded paths in the graph ..." << endl; }
+            if (show_progress) {
+                cerr << "[vg rna] Adding reference and projected transcripts as embedded paths in the graph ..." << endl;
+            }
 
         } else {
 
-            if (show_progress) { cerr << "[vg rna] Adding " << ((add_reference_transcript_paths) ? "reference" : "projected") << " transcripts as embedded paths in the graph ..." << endl; }
+            if (show_progress) { 
+                cerr << "[vg rna] Adding " << ((add_reference_transcript_paths) ? "reference" : "projected")
+                     << " transcripts as embedded paths in the graph ..." << endl;
+            }
         }
 
         transcriptome.embed_transcript_paths(add_reference_transcript_paths, add_projected_transcript_paths);
 
-        if (show_progress) { cerr << "[vg rna] Transcript paths added in " << gcsa::readTimer() - time_add_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
+        if (show_progress) { cerr << "[vg rna] Transcript paths added in " << gcsa::readTimer() - time_add_start 
+                                  << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
     }
 
 
@@ -496,7 +549,8 @@ int32_t main_rna(int32_t argc, char** argv) {
 
         // Silence GBWT index construction. 
         gbwt::Verbosity::set(gbwt::Verbosity::SILENT); 
-        gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(transcriptome.graph().max_node_id(), true)), gbwt::DynamicGBWT::INSERT_BATCH_SIZE, gbwt::DynamicGBWT::SAMPLE_INTERVAL);
+        gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(transcriptome.graph().max_node_id(), true)),
+                                       gbwt::DynamicGBWT::INSERT_BATCH_SIZE, gbwt::DynamicGBWT::SAMPLE_INTERVAL);
 
         transcriptome.add_transcripts_to_gbwt(&gbwt_builder, gbwt_add_bidirectional, exclude_reference_transcripts);
 
@@ -510,7 +564,8 @@ int32_t main_rna(int32_t argc, char** argv) {
     // Write a haplotype GBWT with node IDs updated to match the spliced graph.
     if (!hap_gbwt_out_filename.empty()) {
         if (!haplotype_index.get()) {
-            cerr << "[vg rna] Warning: not saving updated haplotypes to " << hap_gbwt_out_filename << " because haplotypes were not provided as input" << endl;
+            cerr << "[vg rna] Warning: not saving updated haplotypes to " << hap_gbwt_out_filename 
+                 << " because haplotypes were not provided as input" << endl;
         }
         else {
             ofstream hap_gbwt_ostream;
@@ -547,7 +602,11 @@ int32_t main_rna(int32_t argc, char** argv) {
     // Write splicing graph to stdout 
     transcriptome.write_graph(&cout);
 
-    if (show_progress) { cerr << "[vg rna] Graph " << (write_pantranscriptome ? "and pantranscriptome " : "") << "written in " << gcsa::readTimer() - time_writing_start << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
+    if (show_progress) {
+        cerr << "[vg rna] Graph " << (write_pantranscriptome ? "and pantranscriptome " : "")
+             << "written in " << gcsa::readTimer() - time_writing_start << " seconds, " 
+             << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
+    };
 
     return 0;
 }

--- a/src/subcommand/sift_main.cpp
+++ b/src/subcommand/sift_main.cpp
@@ -28,28 +28,23 @@ void help_sift(char** argv){
     cerr << "Usage: " << argv[0] << " sift [options] <alignments.gam>" << endl
         << "Sift through a GAM and select / remove reads with particular properties." << endl
         << "General Options: " << endl
-        << "    -t / --threads  <MTHRDS>    number of OMP threads (not all algorithms are parallelized)." << endl
-        //<< "    -v / --inverse      return the inverse of a query (like grep -v)"   << endl
-        << "    -p / --paired       input reads are paired-end" << endl
-        << "    -R / --remap        remap (locally) any soft-clipped, split, or discordant read pairs." << endl
-        << "    -o / --output <PREFIX>" << endl
+        << "    -t, --threads N                 number of OMP threads (not all algorithms are parallelized)." << endl
+        << "    -p, --paired                    input reads are paired-end" << endl
+        << "    -R, --remap                     remap (locally) any soft-clipped, split, or discordant read pairs." << endl
         << "Paired-end options:" << endl
-        << "    -I / --insert-size <INSRTSZ>        insert size mean. Flag reads where ((I - insrtsz) / W) > 2.95" << endl
-        << "    -W / --insert-size-sigma <SIGMA>    standard deviation of insert size." << endl
-        << "    -O / --one-end-anchored             flag reads where one read of the pair is mapped and the other is unmapped." << endl
-        << "    -C / --interchromosomal             flag reads mapping to two distinct Paths" << endl
-        << "    -D / --discordant-orientation       flag reads that do not have the expected --> <-- orientation." << endl
+        << "    -I, --insert-size DOUBLE        insert size mean. Flag reads where ((I - insrtsz) / W) > 2.95" << endl
+        << "    -W, --insert-size-sigma DOUBLE  standard deviation of insert size." << endl
+        << "    -O, --one-end-anchored          flag reads where one read of the pair is mapped and the other is unmapped." << endl
+        << "    -C, --interchromosomal          flag reads mapping to two distinct Paths" << endl
+        << "    -D, --discordant-orientation    flag reads that do not have the expected --> <-- orientation." << endl
         << "Single-end / individual read options:" << endl
-        << "    -c / --softclip <MAXCLIPLEN>        flag reads with softclipped sections longer than MAXCLIPLEN" << endl
-        << "    -s / --split-read <SPLITLEN>        flag reads with softclips that map independently of the anchored portion (requires -x, -g)." << endl
-        //<< "    -q / --quality <QUAL>               flag reads with a single base quality below <QUAL>" << endl
-        //<< "    -d / --depth <DEPTH>                flag reads which have a low-depth Pos+Edit combo." << endl
-        //<< "    -i / --percent-identity <PCTID>     flag reads with percent identity to their primary path beliw <PCTID>" << endl
-        //<< "    -a / --average" << endl
-        //<< "    -w / --window <WINDOWLEN>" << endl
-        << "    -r / --reversing                    flag reads with sections that reverse within the read, as with small inversions ( --->|<-|-->  or ---->||<-- )" << endl
+        << "    -c, --softclip INT              flag reads with softclipped sections longer than an INT" << endl
+        << "    -s, --split-read INT            flag reads with softclips that map independently of the anchored portion (requires -x, -g)." << endl
+        //<< "    -q, --quality DOUBLE            flag reads with a single base quality below <QUAL>" << endl
+        //<< "    -d, --depth DOUBLE              flag reads which have a low-depth Pos+Edit combo." << endl
+        << "    -r, --reversing                 flag reads with sections that reverse within the read, as with small inversions ( --->|<-|-->  or ---->||<-- )" << endl
         << "Helpful helpers: " << endl
-        << "    -1 / --calc-insert                  calculate and print the insert size mean / sd every 1000 reads." << endl
+        << "    -1, --calc-insert               calculate and print the insert size mean / sd every 1000 reads." << endl
         << endl;
 }
 
@@ -112,11 +107,27 @@ int main_sift(int argc, char** argv){
         static struct option long_options[] =
         {
             {"help", no_argument, 0, 'h'},
+            {"do-unmapped", no_argument, 0, 'u'},
+            {"graph", required_argument, 0, 'G'},
+            {"threads", required_argument, 0, 't'},
+            {"paired", no_argument, 0, 'p'},
+            {"remap", no_argument, 0, 'R'},
+            {"insert-size", required_argument, 0, 'I'},
+            {"insert-size-sigma", required_argument, 0, 'W'},
+            {"one-end-anchored", no_argument, 0, 'O'},
+            {"interchromosomal", no_argument, 0, 'C'},
+            {"discordant-orientation", no_argument, 0, 'D'},
+            {"softclip", required_argument, 0, 'c'},
+            {"split-read", required_argument, 0, 's'},
+            {"quality", required_argument, 0, 'q'},
+            {"depth", required_argument, 0, 'd'},
+            {"reversing", no_argument, 0, 'r'},
+            {"calc-insert", no_argument, 0, '1'},
             {0, 0, 0, 0}
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hut:vgG:pRo:I:W:OCDc:s:q:d:i:aw:r1",
+        c = getopt_long (argc, argv, "h?ut:G:pRI:W:OCDc:s:q:d:r1",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/sift_main.cpp
+++ b/src/subcommand/sift_main.cpp
@@ -24,28 +24,36 @@ using namespace vg::subcommand;
 //Max path len should be TODO s > avg_p_len + 3*sigma
 //and there should be min path len, essentially discordant path lengths
 
-void help_sift(char** argv){
-    cerr << "Usage: " << argv[0] << " sift [options] <alignments.gam>" << endl
-        << "Sift through a GAM and select / remove reads with particular properties." << endl
-        << "General Options: " << endl
-        << "    -t, --threads N                 number of OMP threads (not all algorithms are parallelized)." << endl
-        << "    -p, --paired                    input reads are paired-end" << endl
-        << "    -R, --remap                     remap (locally) any soft-clipped, split, or discordant read pairs." << endl
-        << "Paired-end options:" << endl
-        << "    -I, --insert-size DOUBLE        insert size mean. Flag reads where ((I - insrtsz) / W) > 2.95" << endl
-        << "    -W, --insert-size-sigma DOUBLE  standard deviation of insert size." << endl
-        << "    -O, --one-end-anchored          flag reads where one read of the pair is mapped and the other is unmapped." << endl
-        << "    -C, --interchromosomal          flag reads mapping to two distinct Paths" << endl
-        << "    -D, --discordant-orientation    flag reads that do not have the expected --> <-- orientation." << endl
-        << "Single-end / individual read options:" << endl
-        << "    -c, --softclip INT              flag reads with softclipped sections longer than an INT" << endl
-        << "    -s, --split-read INT            flag reads with softclips that map independently of the anchored portion (requires -x, -g)." << endl
-        //<< "    -q, --quality DOUBLE            flag reads with a single base quality below <QUAL>" << endl
-        //<< "    -d, --depth DOUBLE              flag reads which have a low-depth Pos+Edit combo." << endl
-        << "    -r, --reversing                 flag reads with sections that reverse within the read, as with small inversions ( --->|<-|-->  or ---->||<-- )" << endl
-        << "Helpful helpers: " << endl
-        << "    -1, --calc-insert               calculate and print the insert size mean / sd every 1000 reads." << endl
-        << endl;
+void help_sift(char** argv) {
+    cerr << "usage: " << argv[0] << " sift [options] <alignments.gam>" << endl
+         << "Sift through a GAM and select / remove reads with particular properties." << endl
+         << "General Options: " << endl
+         << "  -t, --threads N                number of OMP threads for parallel algorithms" << endl
+         << "  -p, --paired                   input reads are paired-end" << endl
+         << "  -R, --remap                    remap (locally) any soft-clipped, split, or" << endl
+         << "                                 discordant read pairs" << endl
+         << "Paired-end options:" << endl
+         << "  -I, --insert-size FLOAT        insert size mean. Flag reads where" << endl
+         << "                                 ((I - insrtsz) / W) > 2.95" << endl
+         << "  -W, --insert-size-sigma FLOAT  standard deviation of insert size" << endl
+         << "  -O, --one-end-anchored         flag reads where one read of the pair is mapped" << endl
+         << "                                 and the other is unmapped" << endl
+         << "  -C, --interchromosomal         flag reads mapping to two distinct Paths" << endl
+         << "  -D, --discordant-orientation   flag reads that do not have the" << endl
+         << "                                 expected --> <-- orientation" << endl
+         << "Single-end / individual read options:" << endl
+         << "  -c, --softclip INT             flag reads with softclips longer than INT" << endl
+         << "  -s, --split-read               flag reads with softclips mapping independently" << endl
+         << "                                 of the anchored portion (requires -x, -g)" << endl
+       //<< "  -q, --quality FLOAT            flag reads with a single base quality < QUAL" << endl
+       //<< "  -d, --depth FLOAT              flag reads with a low-depth Pos+Edit combo" << endl
+         << "  -r, --reversing                flag reads with sections that reverse within" << endl
+         << "                                 the read, as with small inversions" << endl
+         << "                                 ( --->|<-|-->  or ---->||<-- )" << endl
+         << "Helpful helpers: " << endl
+         << "  -1, --calc-insert              calculate and print the insert size" << endl
+         << "                                 mean / sd every 1000 reads." << endl
+         << "  -h, --help                     print this help message to stderr and exit" << endl;
 }
 
 
@@ -89,7 +97,6 @@ int main_sift(int argc, char** argv){
     int softclip_max = 15;
     int max_path_length = 200;
 
-    int split_read_limit = 15;
     double depth = -1;
 
 
@@ -118,7 +125,7 @@ int main_sift(int argc, char** argv){
             {"interchromosomal", no_argument, 0, 'C'},
             {"discordant-orientation", no_argument, 0, 'D'},
             {"softclip", required_argument, 0, 'c'},
-            {"split-read", required_argument, 0, 's'},
+            {"split-read", no_argument, 0, 's'},
             {"quality", required_argument, 0, 'q'},
             {"depth", required_argument, 0, 'd'},
             {"reversing", no_argument, 0, 'r'},
@@ -127,8 +134,8 @@ int main_sift(int argc, char** argv){
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "h?ut:G:pRI:W:OCDc:s:q:d:r1",
-                long_options, &option_index);
+        c = getopt_long (argc, argv, "h?ut:G:pRI:W:OCDc:sq:d:r1",
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -158,7 +165,6 @@ int main_sift(int argc, char** argv){
                 break;
             case 's':
                 do_split_read = true;
-                split_read_limit = parse<int>(optarg);
                 if (softclip_max < 0){
                     softclip_max = 15;
                     ff.set_soft_clip_limit(15);

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -46,7 +46,9 @@ vector<pair<string, double>> parse_rsem_expression_file(istream& rsem_in) {
             token.clear();
         }
         if (tokens.size() != 8) {
-            cerr << "[vg sim] error: Cannot parse transcription file. Expected 8-column TSV file as produced by RSEM, got " << tokens.size() << " columns." << endl;
+            cerr << "[vg sim] error: Cannot parse transcription file. "
+                 << "Expected 8-column TSV file as produced by RSEM, got "
+                 << tokens.size() << " columns." << endl;
             exit(1);
         }
         return_val.emplace_back(tokens[0], parse<double>(tokens[5]));
@@ -71,7 +73,9 @@ vector<tuple<string, string, size_t>> parse_haplotype_transcript_file(istream& h
             token.clear();
         }
         if (tokens.size() != 5) {
-            cerr << "[vg sim] error: Cannot parse haplotype transcript file. Expected 5-column TSV file as produced by vg rna -i, got " << tokens.size() << " columns." << endl;
+            cerr << "[vg sim] error: Cannot parse haplotype transcript file. "
+                 << "Expected 5-column TSV file as produced by vg rna -i, got "
+                 << tokens.size() << " columns." << endl;
             exit(1);
         }
         // contributing haplotypes are separeted by commas
@@ -87,41 +91,51 @@ void help_sim(char** argv) {
          << "Samples sequences from the xg-indexed graph." << endl
          << endl
          << "basic options:" << endl
-         << "    -x, --xg-name FILE          use the graph in FILE (required)" << endl
-         << "    -n, --num-reads N           simulate N reads or read pairs" << endl
-         << "    -l, --read-length N         simulate reads of length N" << endl
-         << "    -r, --progress              show progress information" << endl
+         << "  -h, --help                  print this help message to stderr and exit" << endl
+         << "  -x, --xg-name FILE          use the graph in FILE (required)" << endl
+         << "  -n, --num-reads N           simulate N reads or read pairs" << endl
+         << "  -l, --read-length N         simulate reads of length N" << endl
+         << "  -r, --progress              show progress information" << endl
          << "output options:" << endl
-         << "    -a, --align-out             write alignments in GAM-format" << endl
-         << "    -q, --fastq-out             write reads in FASTQ format" << endl
-         << "    -J, --json-out              write alignments in JSON-format GAM (implies --align-out)" << endl
-         << "    --multi-position            annotate alignments with multiple reference positions" << endl
+         << "  -a, --align-out             write alignments in GAM-format" << endl
+         << "  -q, --fastq-out             write reads in FASTQ format" << endl
+         << "  -J, --json-out              write alignments in JSON-format GAM (implies -a)" << endl
+         << "      --multi-position        annotate with multiple reference positions" << endl
          << "simulation parameters:" << endl
-         << "    -F, --fastq FILE            match the error profile of NGS reads in FILE, repeat for paired reads (ignores -l,-f)" << endl
-         << "    -I, --interleaved           reads in FASTQ (-F) are interleaved read pairs" << endl
-         << "    -s, --random-seed N         use this specific seed for the PRNG" << endl
-         << "    -e, --sub-rate FLOAT        base substitution rate (default 0.0)" << endl
-         << "    -i, --indel-rate FLOAT      indel rate (default 0.0)" << endl
-         << "    -d, --indel-err-prop FLOAT  proportion of trained errors from -F that are indels (default 0.01)" << endl
-         << "    -S, --scale-err FLOAT       scale trained error probabilities from -F by this much (default 1.0)" << endl
-         << "    -f, --forward-only          don't simulate from the reverse strand" << endl
-         << "    -p, --frag-len N            make paired end reads with given fragment length N" << endl
-         << "    -v, --frag-std-dev FLOAT    use this standard deviation for fragment length estimation" << endl
-         << "    -N, --allow-Ns              allow reads to be sampled from the graph with Ns in them" << endl
-         << "    --max-tries N               attempt sampling operations up to N times before giving up [100]" << endl
-         << "    -t, --threads N             number of compute threads (only when using FASTQ with -F) [1]" << endl
+         << "  -F, --fastq FILE            match the error profile of NGS reads in FILE," << endl
+         << "                              repeat for paired reads (ignores -l,-f)" << endl
+         << "  -I, --interleaved           reads in FASTQ (-F) are interleaved read pairs" << endl
+         << "  -s, --random-seed N         use this specific seed for the PRNG" << endl
+         << "  -e, --sub-rate FLOAT        base substitution rate [0.0]" << endl
+         << "  -i, --indel-rate FLOAT      indel rate [0.0]" << endl
+         << "  -d, --indel-err-prop FLOAT  proportion of trained errors from -F" << endl
+         << "                              that are indels [0.01]" << endl
+         << "  -S, --scale-err FLOAT       scale trained error probs from -F by FLOAT [1.0]" << endl
+         << "  -f, --forward-only          don't simulate from the reverse strand" << endl
+         << "  -p, --frag-len N            make paired end reads with fragment length N" << endl
+         << "  -v, --frag-std-dev FLOAT    use this standard deviation" << endl
+         << "                              for fragment length estimation" << endl
+         << "  -N, --allow-Ns              allow reads to be sampled with Ns in them" << endl
+         << "      --max-tries N           attempt sampling operations up to N times [100]" << endl
+         << "  -t, --threads N             number of compute threads (only when using -F) [1]" << endl
          << "simulate from paths:" << endl
-         << "    -P, --path PATH             simulate from this path (may repeat; cannot also give -T)" << endl
-         << "    -A, --any-path              simulate from any path (overrides -P)" << endl
-         << "    -m, --sample-name NAME      simulate from this sample (may repeat; requires -g)" << endl
-         << "    -R, --ploidy-regex RULES    use the given comma-separated list of colon-delimited REGEX:PLOIDY rules to assign" << endl
-         << "                                ploidies to contigs not visited by the selected samples, or to all contigs simulated" << endl
-         << "                                from if no samples are used. Unmatched contigs get ploidy 2." << endl
-         << "    -g, --gbwt-name FILE        use samples from this GBWT index" << endl
-         << "    -T, --tx-expr-file FILE     simulate from an expression profile formatted as RSEM output (cannot also give -P)" << endl
-         << "    -H, --haplo-tx-file FILE    transcript origin info table from vg rna -i (required for -T on haplotype transcripts)" << endl
-         << "    -u, --unsheared             sample from unsheared fragments" << endl
-         << "    -E, --path-pos-file FILE    output a TSV with sampled position on path of each read (requires -F)" << endl;
+         << "  -P, --path NAME             simulate from this path" << endl
+         << "                              (may repeat; cannot also give -T)" << endl
+         << "  -A, --any-path              simulate from any path (overrides -P)" << endl
+         << "  -m, --sample-name NAME      simulate from this sample (may repeat/requires -g)" << endl
+         << "  -R, --ploidy-regex RULES    use this comma-separated list of colon-delimited" << endl
+         << "                              REGEX:PLOIDY rules to assign ploidies to contigs" << endl
+         << "                              not visited by the selected samples, or to all" << endl
+         << "                              contigs simulated from if no samples are used." << endl
+         << "                              Unmatched contigs get ploidy 2" << endl
+         << "  -g, --gbwt-name FILE        use samples from this GBWT index" << endl
+         << "  -T, --tx-expr-file FILE     simulate from an expression profile formatted as" << endl
+         << "                              RSEM output (cannot also give -P)" << endl
+         << "  -H, --haplo-tx-file FILE    transcript origin info table from vg rna -i" << endl
+         << "                              (required for -T on haplotype transcripts)" << endl
+         << "  -u, --unsheared             sample from unsheared fragments" << endl
+         << "  -E, --path-pos-file FILE    output a TSV with sampled position on path" << endl
+         << "                              of each read (requires -F)" << endl;
 }
 
 int main_sim(int argc, char** argv) {
@@ -317,7 +331,8 @@ int main_sim(int argc, char** argv) {
             seed_val = parse<int>(optarg);
             if (seed_val == 0) {
                 // Don't let the user specify seed 0 as we will confuse it with no deterministic seed.
-                cerr << "error[vg sim]: seed 0 cannot be used. Omit the seed option if you want nondeterministic results." << endl;
+                cerr << "error[vg sim]: seed 0 cannot be used. "
+                     << "Omit the seed option if you want nondeterministic results." << endl;
                 exit(1);
             }
             break;
@@ -441,7 +456,8 @@ int main_sim(int argc, char** argv) {
         return 1;
     }
     if (!gbwt_name.empty() && !rsem_file_name.empty() && !haplotype_transcript_file_name.empty()) {
-        cerr << "[vg sim] error: using --gbwt-name requires that HSTs be included --tx-expr-file, combination with --haplo-tx-file is not implemented" << endl;
+        cerr << "[vg sim] error: using --gbwt-name requires that HSTs be included --tx-expr-file, "
+             << "combination with --haplo-tx-file is not implemented" << endl;
         return 1;
     }
 
@@ -463,7 +479,8 @@ int main_sim(int argc, char** argv) {
         }
         ifstream haplo_tx_in(haplotype_transcript_file_name);
         if (!haplo_tx_in) {
-            cerr << "[vg sim] error: could not open haplotype transcript file " << haplotype_transcript_file_name << endl;
+            cerr << "[vg sim] error: could not open haplotype transcript file "
+                 << haplotype_transcript_file_name << endl;
             return 1;
         }
         haplotype_transcripts = parse_haplotype_transcript_file(haplo_tx_in);
@@ -480,7 +497,8 @@ int main_sim(int argc, char** argv) {
     }
     
     if (fastq_name.empty() && unsheared_fragments) {
-        cerr << "[vg sim] error: unsheared fragment option only available when simulating from FASTQ-trained errors" << endl;
+        cerr << "[vg sim] error: unsheared fragment option only available "
+             << "when simulating from FASTQ-trained errors" << endl;
         exit(1);
     }
     
@@ -530,7 +548,8 @@ int main_sim(int argc, char** argv) {
             std::cerr << "Loading GBWT index " << gbwt_name << std::endl;
         }
         std::unique_ptr<gbwt::GBWT> gbwt_index = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_name);
-        if (!(gbwt_index->hasMetadata()) || !(gbwt_index->metadata.hasSampleNames()) || !(gbwt_index->metadata.hasPathNames())) {
+        if (!(gbwt_index->hasMetadata()) || !(gbwt_index->metadata.hasSampleNames()) 
+                                              || !(gbwt_index->metadata.hasPathNames())) {
             std::cerr << "[vg sim] error: GBWT index does not contain sufficient metadata" << std::endl;
             return 1;
         }
@@ -552,7 +571,8 @@ int main_sim(int argc, char** argv) {
                     auto name = path_handle_graph->get_path_name(handle);
                     if (!Paths::is_alt(name)) {
                         // TODO: We assume that if it isn't an alt path it represents a contig!
-                        // TODO: We may need to change this when working with graphs with multiple sets of primary paths, or other extra paths.
+                        // TODO: We may need to change this when working with graphs with
+                        // multiple sets of primary paths, or other extra paths.
                         unvisited_contigs.insert(name);
                     }
                 });
@@ -565,7 +585,8 @@ int main_sim(int argc, char** argv) {
             for (std::string& sample_name : sample_names) {
                 gbwt::size_type id = gbwt_index->metadata.sample(sample_name);
                 if (id >= gbwt_index->metadata.samples()) {
-                    std::cerr << "[vg sim] error: sample \"" << sample_name << "\" not found in the GBWT index" << std::endl;
+                    std::cerr << "[vg sim] error: sample \"" << sample_name 
+                              << "\" not found in the GBWT index" << std::endl;
                     return 1;
                 }
                 auto idx = sample_id_to_idx.size();
@@ -577,7 +598,8 @@ int main_sim(int argc, char** argv) {
             for (const auto& transcript_expression  : transcript_expressions) {
                 gbwt::size_type id = gbwt_index->metadata.sample(transcript_expression.first);
                 if (id >= gbwt_index->metadata.samples()) {
-                    std::cerr << "[vg sim] error: haplotype-specific transcript \"" << transcript_expression.first << "\" not found in the GBWT index" << std::endl;
+                    std::cerr << "[vg sim] error: haplotype-specific transcript \"" << transcript_expression.first
+                              << "\" not found in the GBWT index" << std::endl;
                     return 1;
                 }
                 auto idx = sample_id_to_idx.size();
@@ -585,7 +607,8 @@ int main_sim(int argc, char** argv) {
             }
         }
         
-        MutablePathMutableHandleGraph* mutable_graph = dynamic_cast<MutablePathMutableHandleGraph*>(path_handle_graph.get());
+        MutablePathMutableHandleGraph* mutable_graph \
+            = dynamic_cast<MutablePathMutableHandleGraph*>(path_handle_graph.get());
         if (mutable_graph == nullptr) {
             if (progress) {
                 std::cerr << "Converting the graph into HashGraph" << std::endl;
@@ -641,7 +664,8 @@ int main_sim(int argc, char** argv) {
                 path_ploidies.push_back(consult_ploidy_rules(name));
             }
             if (progress) {
-                std::cerr << "Also sampling from " << unvisited_contigs.size() << " paths representing unvisited contigs" << std::endl;
+                std::cerr << "Also sampling from " << unvisited_contigs.size()
+                          << " paths representing unvisited contigs" << std::endl;
             }
         }
     }
@@ -653,8 +677,10 @@ int main_sim(int argc, char** argv) {
             }
             for (auto& transcript_expression : transcript_expressions) {
                 if (!path_handle_graph->has_path(transcript_expression.first)) {
-                    cerr << "[vg sim] error: transcript path for \""<< transcript_expression.first << "\" not found in index" << endl;
-                    cerr << "if you embedded haplotype-specific transcripts in the graph, you may need the haplotype transcript file from vg rna -i" << endl;
+                    cerr << "[vg sim] error: transcript path for \""<< transcript_expression.first 
+                         << "\" not found in index" << endl;
+                    cerr << "if you embedded haplotype-specific transcripts in the graph, "
+                         << "you may need the haplotype transcript file from vg rna -i" << endl;
                     return 1;
                 }
             }
@@ -666,7 +692,8 @@ int main_sim(int argc, char** argv) {
         }
         for (auto& haplotype_transcript : haplotype_transcripts) {
             if (!path_handle_graph->has_path(get<0>(haplotype_transcript))) {
-                cerr << "[vg sim] error: transcript path for \""<< get<0>(haplotype_transcript) << "\" not found in index" << endl;
+                cerr << "[vg sim] error: transcript path for \""<< get<0>(haplotype_transcript) 
+                     << "\" not found in index" << endl;
                 return 1;
             }
         }
@@ -677,7 +704,8 @@ int main_sim(int argc, char** argv) {
     }
     
     bdsg::ReferencePathVectorizableOverlayHelper overlay_helper;
-    PathPositionHandleGraph* xgidx = dynamic_cast<PathPositionHandleGraph*>(overlay_helper.apply(path_handle_graph.get()));
+    PathPositionHandleGraph* xgidx = dynamic_cast<PathPositionHandleGraph*>(
+        overlay_helper.apply(path_handle_graph.get()));
     
     // We want to store the inserted paths as a set of handles, which are
     // easier to hash than strings for lookup.
@@ -761,7 +789,8 @@ int main_sim(int argc, char** argv) {
             cerr << "warning: Unsheared fragment option only available when simulating from FASTQ-trained errors" << endl;
         }
         
-        sampler.reset(new Sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns, path_names, path_ploidies, transcript_expressions, haplotype_transcripts));
+        sampler.reset(new Sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns, path_names,
+                                  path_ploidies, transcript_expressions, haplotype_transcripts));
     } else {
         // Use the FASTQ-trained sampler
         sampler.reset(new NGSSimulator(*xgidx,
@@ -775,8 +804,10 @@ int main_sim(int argc, char** argv) {
                                        base_error,
                                        indel_error,
                                        indel_prop,
-                                       fragment_length ? fragment_length : std::numeric_limits<double>::max(), // suppresses warnings about fragment length
-                                       fragment_std_dev ? fragment_std_dev : 0.000001, // eliminates errors from having 0 as stddev without substantial difference
+                                       // suppresses warnings about fragment length
+                                       fragment_length ? fragment_length : std::numeric_limits<double>::max(), 
+                                       // eliminates errors from having 0 as stddev without substantial difference
+                                       fragment_std_dev ? fragment_std_dev : 0.000001,
                                        error_scale_factor,
                                        !reads_may_contain_Ns,
                                        unsheared_fragments,

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -109,7 +109,7 @@ void help_sim(char** argv) {
          << "    -v, --frag-std-dev FLOAT    use this standard deviation for fragment length estimation" << endl
          << "    -N, --allow-Ns              allow reads to be sampled from the graph with Ns in them" << endl
          << "    --max-tries N               attempt sampling operations up to N times before giving up [100]" << endl
-         << "    -t, --threads               number of compute threads (only when using FASTQ with -F) [1]" << endl
+         << "    -t, --threads N             number of compute threads (only when using FASTQ with -F) [1]" << endl
          << "simulate from paths:" << endl
          << "    -P, --path PATH             simulate from this path (may repeat; cannot also give -T)" << endl
          << "    -A, --any-path              simulate from any path (overrides -P)" << endl
@@ -219,13 +219,13 @@ int main_sim(int argc, char** argv) {
             {"frag-len", required_argument, 0, 'p'},
             {"frag-std-dev", required_argument, 0, 'v'},
             {"threads", required_argument, 0, 't'},
-            {"path-usage", required_argument, 0, 'E'},
+            {"path-pos-file", required_argument, 0, 'E'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hrl:n:s:e:i:fax:qJp:v:Nud:F:P:Am:R:g:T:H:S:It:E:",
-                long_options, &option_index);
+        c = getopt_long (argc, argv, "h?rl:n:s:e:i:fax:qJp:v:Nud:F:P:Am:R:g:T:H:S:It:E:",
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -145,8 +145,8 @@ int main_sim(int argc, char** argv) {
         return 1;
     }
 
-    #define OPT_MULTI_POSITION 1000
-    #define OPT_MAX_TRIES 1001
+    constexpr int OPT_MULTI_POSITION = 1000;
+    constexpr int OPT_MAX_TRIES = 1001;
 
     string xg_name;
     int num_reads = 1;

--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -27,8 +27,8 @@ void help_simplify(char** argv) {
          << "    -a, --algorithm NAME   simplify using the given algorithm (small, rare; default: small)" << endl
          << "    -t, --threads N        use N threads to construct graph (defaults to numCPUs)" << endl
          << "    -p, --progress         show progress" << endl
-         << "    -b, --bed-in           read in the given BED file in the cordinates of the original paths" << endl
-         << "    -B, --bed-out          output transformed features in the coordinates of the new paths" << endl
+         << "    -b, --bed-in FILE      read in the given BED file in the cordinates of the original paths" << endl
+         << "    -B, --bed-out FILE     output transformed features in the coordinates of the new paths" << endl
          << "path snarl simplifier options:" << endl
          << "    -P, --path-prefix S    [NECESSARY TO SCALE PAST TINY GRAPHS] all paths whose names begins with S selected as reference paths (default: all reference-sense paths)" << endl
          << "small snarl simplifier options:" << endl       

--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -24,22 +24,29 @@ using namespace vg::subcommand;
 void help_simplify(char** argv) {
     cerr << "usage: " << argv[0] << " simplify [options] old.vg >new.vg" << endl
          << "general options:" << endl
-         << "    -a, --algorithm NAME   simplify using the given algorithm (small, rare; default: small)" << endl
-         << "    -t, --threads N        use N threads to construct graph (defaults to numCPUs)" << endl
-         << "    -p, --progress         show progress" << endl
-         << "    -b, --bed-in FILE      read in the given BED file in the cordinates of the original paths" << endl
-         << "    -B, --bed-out FILE     output transformed features in the coordinates of the new paths" << endl
+         << "  -h, --help              print this help message to stderr and exit" << endl
+         << "  -a, --algorithm NAME    simplification algorithm (small, rare) [small]" << endl
+         << "  -t, --threads N         use N threads to construct graph [numCPUs]" << endl
+         << "  -p, --progress          show progress" << endl
+         << "  -b, --bed-in FILE       BED file with the cordinates of the original paths" << endl
+         << "  -B, --bed-out FILE      output transformed features with new path coordinates" << endl
          << "path snarl simplifier options:" << endl
-         << "    -P, --path-prefix S    [NECESSARY TO SCALE PAST TINY GRAPHS] all paths whose names begins with S selected as reference paths (default: all reference-sense paths)" << endl
+         << "  -P, --path-prefix STR   [NECESSARY TO SCALE PAST TINY GRAPHS]" << endl
+         << "                          all paths with this prefix selected as reference paths" << endl
+         << "                          (default: all reference-sense paths)" << endl
          << "small snarl simplifier options:" << endl       
-         << "    -m, --min-size N       remove leaf sites with fewer than N bases (with -P, uses max allele length) involved (default: 10)" << endl
-         << "    -i, --max-iterations N perform up to N iterations of simplification (default: 10)" << endl
-         << "    -L, --cluster F        cluster traversals whose (handle) Jaccard coefficient is >= F together (default: 1.0)" << endl
-         << "    -k, --keep-paths       non-reference (as specified with -P) paths are removed by default. use this flag to keep them (but note that the resulting graph will be more complex and possibly more difficult to load)" << endl
+         << "  -m, --min-size N        remove leaf sites with fewer than N bases" << endl
+         << "                          (with -P, uses max allele length) involved [10]" << endl
+         << "  -i, --max-iterations N  perform up to N iterations of simplification [10]" << endl
+         << "  -L, --cluster F         cluster traversals whose (handle) Jaccard coefficient" << endl
+         << "                          is >= F together [1.0]" << endl
+         << "  -k, --keep-paths        non-reference (-P) paths are removed by default." << endl
+         << "                          use this flag to keep them (the resulting graph will" << endl
+         << "                          be more complex and possibly more difficult to load)" << endl
          << "rare variant simplifier options:" << endl
-         << "    -v, --vcf FILE         use the given VCF file to determine variant frequency (required)" << endl
-         << "    -f, --min-freq FLOAT   remove variants with total alt frequency under FLOAT (default: 0)" << endl
-         << "    -c, --min-count N      remove variants with total alt occurrence count under N (default: 0)" << endl;
+         << "  -v, --vcf FILE          use this VCF to determine variant frequency (required)" << endl
+         << "  -f, --min-freq FLOAT    remove variants with total alt frequency <FLOAT [0]" << endl
+         << "  -c, --min-count N       remove variants with total alt occurrence count <N [0]" << endl;
 }
 
 int main_simplify(int argc, char** argv) {

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -31,21 +31,27 @@ void help_snarl(char** argv) {
     cerr << "usage: " << argv[0] << " snarls [options] graph > snarls.pb" << endl
          << "       By default, a list of protobuf Snarls is written" << endl
          << "options:" << endl
-         << "    -A, --algorithm NAME       compute snarls using 'cactus' or 'integrated' algorithms (default: integrated)" << endl
-         << "    -p, --pathnames            output variant paths as SnarlTraversals to STDOUT" << endl
-         << "    -r, --traversals FILE      output SnarlTraversals for ultrabubbles." << endl
-         << "    -e, --path-traversals      only consider traversals that correspond to paths in the graph. (-m ignored)" << endl
-         << "    -l, --leaf-only            restrict traversals to leaf ultrabubbles." << endl
-         << "    -o, --top-level            restrict traversals to top level ultrabubbles" << endl
-         << "    -a, --any-snarl-type       compute traversals for any snarl type (not limiting to ultrabubbles)" << endl
-         << "    -m, --max-nodes N          only compute traversals for snarls with <= N nodes (with degree > 1) [10]" << endl
-         << "    -n, --named-coordinates    produce snarl and traversal outputs in named-segment (GFA) space" << endl
-         << "    -T, --include-trivial      report snarls that consist of a single edge" << endl
-         << "    -s, --sort-snarls          return snarls in sorted order by node ID (for topologically ordered graphs)" << endl
-         << "    -v, --vcf FILE             use vcf-based instead of exhaustive traversal finder with -r" << endl
-         << "    -f, --fasta FILE           reference in FASTA format (required for SVs by -v)" << endl
-         << "    -i, --ins-fasta FILE       insertion sequences in FASTA format (required for SVs by -v)" << endl
-         << "    -t, --threads N            number of threads to use [all available]" << endl;
+         << "  -A, --algorithm NAME      snarl algorithm {cactus/integrated} [integrated]" << endl
+         << "  -p, --pathnames           output variant paths as SnarlTraversals to stdout" << endl
+         << "  -r, --traversals FILE     output SnarlTraversals for ultrabubbles" << endl
+         << "  -e, --path-traversals     only consider traversals that correspond to paths in" << endl
+         << "                            the graph (-m ignored)" << endl
+         << "  -l, --leaf-only           restrict traversals to leaf ultrabubbles" << endl
+         << "  -o, --top-level           restrict traversals to top level ultrabubbles" << endl
+         << "  -a, --any-snarl-type      compute traversals for any snarl type" << endl
+         << "                            (not limiting to ultrabubbles)" << endl
+         << "  -m, --max-nodes N         only compute traversals for snarls with <= N nodes" << endl
+         << "                            (with degree > 1) [10]" << endl
+         << "  -n, --named-coordinates   produce all outputs in named-segment (GFA) space" << endl
+         << "  -T, --include-trivial     report snarls that consist of a single edge" << endl
+         << "  -s, --sort-snarls         return snarls in sorted order by node ID" << endl
+         << "                            (for topologically ordered graphs)" << endl
+         << "  -v, --vcf FILE            for -r, use VCF-based traversal finder instead of" << endl
+         << "                            exhaustive traversal finder with -r" << endl
+         << "  -f, --fasta FILE          reference as FASTA (required for SVs by -v)" << endl
+         << "  -i, --ins-fasta FILE      insertions as FASTA (required for SVs by -v)" << endl
+         << "  -t, --threads N           number of threads to use [all available]" << endl
+         << "  -h, --help                print this help message to stderr and exit" << endl;
 }
 
 int main_snarl(int argc, char** argv) {
@@ -202,7 +208,8 @@ int main_snarl(int argc, char** argv) {
     if (named_coordinates) {
         translation = vg::algorithms::find_translation(graph.get());
         if (!translation) {
-            cerr << "error:[vg snarls] Named coordinate output (-n) was requested, but the graph does not come with a named coordinate space." << endl;
+            cerr << "error:[vg snarls] Named coordinate output (-n) was requested, "
+                 << "but the graph does not come with a named coordinate space." << endl;
             return 1;
         }
     }

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -43,8 +43,8 @@ void help_snarl(char** argv) {
          << "    -T, --include-trivial      report snarls that consist of a single edge" << endl
          << "    -s, --sort-snarls          return snarls in sorted order by node ID (for topologically ordered graphs)" << endl
          << "    -v, --vcf FILE             use vcf-based instead of exhaustive traversal finder with -r" << endl
-         << "    -f  --fasta FILE           reference in FASTA format (required for SVs by -v)" << endl
-         << "    -i  --ins-fasta FILE       insertion sequences in FASTA format (required for SVs by -v)" << endl
+         << "    -f, --fasta FILE           reference in FASTA format (required for SVs by -v)" << endl
+         << "    -i, --ins-fasta FILE       insertion sequences in FASTA format (required for SVs by -v)" << endl
          << "    -t, --threads N            number of threads to use [all available]" << endl;
 }
 
@@ -90,8 +90,9 @@ int main_snarl(int argc, char** argv) {
                 {"vcf", required_argument, 0, 'v'},
                 {"fasta", required_argument, 0, 'f'},
                 {"ins-fasta", required_argument, 0, 'i'},
-                {"path-traversals", no_argument, 0, 'e'},                
+                {"path-traversals", no_argument, 0, 'e'},
                 {"threads", required_argument, 0, 't'},
+                {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}
             };
 

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -23,15 +23,16 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
-void help_sort(char** argv){
+void help_sort(char** argv) {
     cerr << "usage: " << argv[0] << " sort [options] > sorted.vg " << endl
          << "options: " << endl
-         << "    -a, --algorithm NAME   sort by the given algorithm (eades, max-flow, id, or topo; default id)" << endl
-         << "    -g, --gfa              input in GFA format" << endl
-         << "    -r, --ref NAME         reference name, for eades and max-flow algorithms; makes -a default to max-flow" << endl
-         << "    -w, --without-grooming no grooming mode for eades" << endl
-         << "    -I, --index-to FILE    produce an index of an id-sorted vg file to the given filename" << endl
-         << endl;
+         << "  -a, --algorithm NAME    sort algorithm {eades, max-flow, id, or topo} [id]" << endl
+         << "  -g, --gfa               input in GFA format" << endl
+         << "  -r, --ref NAME          reference name, for eades and max-flow algorithms;" << endl
+         << "                          makes -a default to max-flow" << endl
+         << "  -w, --without-grooming  no grooming mode for eades" << endl
+         << "  -I, --index-to FILE     save index of an ID-sorted vg file to the given file" << endl
+         << "  -h, --help              print this help message to stderr and exit" << endl;
 }
 
 int main_sort(int argc, char *argv[]) {

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -28,7 +28,7 @@ void help_sort(char** argv){
          << "options: " << endl
          << "    -a, --algorithm NAME   sort by the given algorithm (eades, max-flow, id, or topo; default id)" << endl
          << "    -g, --gfa              input in GFA format" << endl
-         << "    -r, --ref              reference name, for eades and max-flow algorithms; makes -a default to max-flow" << endl
+         << "    -r, --ref NAME         reference name, for eades and max-flow algorithms; makes -a default to max-flow" << endl
          << "    -w, --without-grooming no grooming mode for eades" << endl
          << "    -I, --index-to FILE    produce an index of an id-sorted vg file to the given filename" << endl
          << endl;
@@ -55,12 +55,13 @@ int main_sort(int argc, char *argv[]) {
                 {"gfa", no_argument, 0, 'g'},
                 {"ref", required_argument, 0, 'r'},
                 {"without-grooming", no_argument, 0, 'w'},
-                {"index-to", no_argument, 0, 'I'},
+                {"index-to", required_argument, 0, 'I'},
+                {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "a:gr:wI:",
+        c = getopt_long (argc, argv, "a:gr:wI:h?",
                          long_options, &option_index);
 
         /* Detect the end of the options. */

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -44,38 +44,39 @@ using namespace vg::algorithms;
 void help_stats(char** argv) {
     cerr << "usage: " << argv[0] << " stats [options] [<graph file>]" << endl
          << "options:" << endl
-         << "    -z, --size             size of graph" << endl
-         << "    -N, --node-count       number of nodes in graph" << endl
-         << "    -E, --edge-count       number of edges in graph" << endl
-         << "    -l, --length           length of sequences in graph" << endl
-         << "    -L, --self-loops       number of self-loops" << endl
-         << "    -s, --subgraphs        describe subgraphs of graph" << endl
-         << "    -H, --heads            list the head nodes of the graph" << endl
-         << "    -T, --tails            list the tail nodes of the graph" << endl
-         << "    -e, --nondeterm        list the nondeterministic edge sets" << endl
-         << "    -c, --components       print the strongly connected components of the graph" << endl
-         << "    -A, --is-acyclic       print if the graph is acyclic or not" << endl
-         << "    -n, --node ID          consider node with the given id" << endl
-         << "    -d, --to-head          show distance to head for each provided node" << endl
-         << "    -t, --to-tail          show distance to head for each provided node" << endl
-         << "    -a, --alignments FILE  compute stats for reads aligned to the graph" << endl
-         << "    -r, --node-id-range    X:Y where X and Y are the smallest and largest "
-        "node id in the graph, respectively" << endl
-         << "    -o, --overlap PATH    for each overlapping path mapping in the graph write a table:" << endl
+         << "  -z, --size               size of graph" << endl
+         << "  -N, --node-count         number of nodes in graph" << endl
+         << "  -E, --edge-count         number of edges in graph" << endl
+         << "  -l, --length             length of sequences in graph" << endl
+         << "  -L, --self-loops         number of self-loops" << endl
+         << "  -s, --subgraphs          describe subgraphs of graph" << endl
+         << "  -H, --heads              list the head nodes of the graph" << endl
+         << "  -T, --tails              list the tail nodes of the graph" << endl
+         << "  -e, --nondeterm          list the nondeterministic edge sets" << endl
+         << "  -c, --components         print the strongly connected components of the graph" << endl
+         << "  -A, --is-acyclic         print if the graph is acyclic or not" << endl
+         << "  -n, --node ID            consider node with the given id" << endl
+         << "  -d, --to-head            show distance to head for each provided node" << endl
+         << "  -t, --to-tail            show distance to head for each provided node" << endl
+         << "  -a, --alignments FILE    compute stats for reads aligned to the graph" << endl
+         << "  -r, --node-id-range      X:Y where X and Y are the smallest and largest" << endl
+         << "                           node id in the graph, respectively" << endl
+         << "  -o, --overlap PATH       for each overlapping path mapping in the graph write:" << endl
          << "                              PATH, other_path, rank1, rank2" << endl
-         << "                          multiple allowed; limit comparison to those provided" << endl
-         << "    -O, --overlap-all     print overlap table for the cartesian product of paths" << endl
-         << "    -R, --snarls          print statistics for each snarl" << endl
-         << "        --snarl-contents  print out a table of <snarl, depth, parent, contained node ids>" << endl
-         << "        --snarl-sample NAME  print out reference coordinates on given sample" << endl
-         << "    -C, --chains          print statistics for each chain" << endl
-         << "    -F, --format          graph format from {VG-Protobuf, PackedGraph, HashGraph, XG}. " <<
-        "Can't detect Protobuf if graph read from stdin" << endl
-         << "    -D, --degree-dist     print degree distribution of the graph." << endl
-         << "    -b, --dist-snarls FILE print the sizes and depths of the snarls in a given distance index." << endl
-         << "    -p, --threads N       number of threads to use [all available]" << endl
-         << "    -v, --verbose         output longer reports" << endl
-         << "    -P, --progress        show progress" << endl;
+         << "                           multiple allowed; limit comparison to those provided" << endl
+         << "  -O, --overlap-all        print overlap table for cartesian product of paths" << endl
+         << "  -R, --snarls             print statistics for each snarl" << endl
+         << "      --snarl-contents     print table of <snarl, depth, parent, node ids>" << endl
+         << "      --snarl-sample NAME  print out reference coordinates on given sample" << endl
+         << "  -C, --chains             print statistics for each chain" << endl
+         << "  -F, --format             graph type {VG-Protobuf, PackedGraph, HashGraph, XG}" << endl
+         << "                           Can't detect Protobuf if graph read from stdin" << endl
+         << "  -D, --degree-dist        print degree distribution of the graph." << endl
+         << "  -b, --dist-snarls FILE   print sizes/depths of the snarls in distance index" << endl
+         << "  -p, --threads N          number of threads to use [all available]" << endl
+         << "  -v, --verbose            output longer reports" << endl
+         << "  -P, --progress           show progress" << endl
+         << "  -h, --help               print this help message to stderr and exit" << endl;
 }
 
 int main_stats(int argc, char** argv) {
@@ -161,7 +162,7 @@ int main_stats(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?zlLsHTeScdtn:NEa:vPAro:ORCFDb:p:",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -283,7 +284,8 @@ int main_stats(int argc, char** argv) {
         {
             int num_threads = parse<int>(optarg);
             if (num_threads <= 0) {
-                cerr << "error:[vg stats] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                cerr << "error:[vg stats] Thread count (-t) set to " << num_threads
+                     << ", must set to a positive integer." << endl;
                 exit(1);
             }
             omp_set_num_threads(num_threads);
@@ -533,7 +535,8 @@ int main_stats(int argc, char** argv) {
         // print degrees
         cout << "Degree\tSides\tNodes(min)\tNodes(max)\tNodes(total)" << endl;
         for (const auto& dg : degree_to_count) {
-            cout << dg.first << "\t" << get<0>(dg.second) << "\t" <<get<1>(dg.second) << "\t" << get<2>(dg.second) << "\t" << get<3>(dg.second) << endl;
+            cout << dg.first << "\t" << get<0>(dg.second) << "\t" <<get<1>(dg.second) << "\t"
+                 << get<2>(dg.second) << "\t" << get<3>(dg.second) << endl;
         }
     }
 
@@ -952,13 +955,15 @@ int main_stats(int argc, char** argv) {
         get_input_file(alignments_filename, [&](istream& alignment_stream) {
             // Read in the given GAM
             // Actually go through all the reads and count stuff up.
-            vg::Progressive::with_progress(show_progress, "Read reads", [&](const std::function<void(size_t, size_t)>& progress) {
+            vg::Progressive::with_progress(show_progress, "Read reads", 
+                [&](const std::function<void(size_t, size_t)>& progress) {
                 vg::io::for_each_parallel(alignment_stream, lambda, 256, progress);
             });
         });
 
         // Now combine into a single ReadStats object (for which we pre-populated reads_on_allele with 0s).
-        vg::Progressive::with_progress(show_progress, "Combine thread results", [&](const std::function<void(size_t, size_t)>& progress) {
+        vg::Progressive::with_progress(show_progress, "Combine thread results", 
+            [&](const std::function<void(size_t, size_t)>& progress) {
             progress(0, read_stats.size());
             for(size_t i = 0; i < read_stats.size(); i++) {
                 combined += read_stats[i];
@@ -1109,7 +1114,8 @@ int main_stats(int argc, char** argv) {
                     << " on " << id_and_edit.first << endl;
             }
         }
-        cout << "Substitutions: " << combined.total_substituted_bases << " bp in " << combined.total_substitutions << " read events" << endl;
+        cout << "Substitutions: " << combined.total_substituted_bases << " bp in " << combined.total_substitutions 
+             << " read events" << endl;
         if(verbose) {
             for(auto& id_and_edit : combined.substitutions) {
                 cout << "\t" << id_and_edit.second.from_length() << " -> " << id_and_edit.second.sequence()
@@ -1121,7 +1127,8 @@ int main_stats(int argc, char** argv) {
             cout << " (" << combined.total_matched_bases / static_cast<double>(combined.total_alignments) << " bp/alignment)";
         }
         cout << endl;
-        cout << "Softclips: " << combined.total_softclipped_bases << " bp in " << combined.total_softclips << " read events" << endl;
+        cout << "Softclips: " << combined.total_softclipped_bases << " bp in "
+             << combined.total_softclips << " read events" << endl;
         if(verbose) {
             for(auto& id_and_edit : combined.softclips) {
                 cout << "\t" << id_and_edit.second.from_length() << " -> " << id_and_edit.second.sequence()
@@ -1198,7 +1205,9 @@ int main_stats(int argc, char** argv) {
                 }
                 path_trav_finder = unique_ptr<PathTraversalFinder>(new PathTraversalFinder(*pp_graph, ref_path_names));
             }
-            cout << "Start\tStart-Reversed\tEnd\tEnd-Reversed\tUltrabubble\tUnary\tShallow-Nodes\tShallow-Edges\tShallow-bases\tDeep-Nodes\tDeep-Edges\tDeep-Bases\tDepth\tChildren\tChains\tChains-Children\tNet-Graph-Size\n";
+            cout << "Start\tStart-Reversed\tEnd\tEnd-Reversed\tUltrabubble\tUnary\tShallow-Nodes"
+                 << "\tShallow-Edges\tShallow-bases\tDeep-Nodes\tDeep-Edges\tDeep-Bases\tDepth"
+                 << "\tChildren\tChains\tChains-Children\tNet-Graph-Size\n";
         }
         
         manager.for_each_snarl_preorder([&](const Snarl* snarl) {
@@ -1218,7 +1227,8 @@ int main_stats(int argc, char** argv) {
                         // search toward the reference path
                         unordered_map<path_handle_t, vector<step_handle_t>> start_steps;
                         unordered_map<path_handle_t, vector<step_handle_t>> end_steps;
-                        handlegraph::algorithms::dijkstra(pp_graph, pp_graph->get_handle(snarl->start().node_id(), snarl->start().backward()),
+                        handlegraph::algorithms::dijkstra(pp_graph, pp_graph->get_handle(snarl->start().node_id(),
+                                                                                         snarl->start().backward()),
                                  [&](const handle_t& found_handle, size_t dist) {
                                      graph->for_each_step_on_handle(found_handle, [&](step_handle_t step) {
                                          if (graph->get_sample_name(graph->get_path_handle_of_step(step)) == snarl_sample) {
@@ -1227,7 +1237,8 @@ int main_stats(int argc, char** argv) {
                                      });
                                      return start_steps.empty() && dist < snarl_search_context;
                                  }, true);
-                        handlegraph::algorithms::dijkstra(pp_graph, pp_graph->get_handle(snarl->end().node_id(), snarl->end().backward()),
+                        handlegraph::algorithms::dijkstra(pp_graph, pp_graph->get_handle(snarl->end().node_id(), 
+                                                                                         snarl->end().backward()),
                                  [&](const handle_t& found_handle, size_t dist) {
                                      graph->for_each_step_on_handle(found_handle, [&](step_handle_t step) {
                                          if (graph->get_sample_name(graph->get_path_handle_of_step(step)) == snarl_sample) {
@@ -1410,7 +1421,9 @@ int main_stats(int argc, char** argv) {
         
 
         // TSV header
-        cout << "Snarl1-Start\tSSnarl1-Start-Reversed\tSnarl1-End\tSnarl1-End-Reversed\tSnarl1-Reversed\tSnarl2-Start\tSSnarl2-Start-Reversed\tSnarl2-End\tSnarl2-End-Reversed\tSnarl2-Reversed\tSnarl-Count\tMax-Depth\tChild-Snarls\tChild-Chains\n";
+        cout << "Snarl1-Start\tSSnarl1-Start-Reversed\tSnarl1-End\tSnarl1-End-Reversed\tSnarl1-Reversed"
+             << "\tSnarl2-Start\tSSnarl2-Start-Reversed\tSnarl2-End\tSnarl2-End-Reversed\tSnarl2-Reversed"
+             << "\tSnarl-Count\tMax-Depth\tChild-Snarls\tChild-Chains\n";
         
         manager.for_each_chain([&](const Chain* chain) {
             // Loop over all the snarls and print stats.

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -118,8 +118,8 @@ int main_stats(int argc, char** argv) {
     string distance_index_filename;
 
     // Long options with no corresponding short options.
-    #define OPT_SNARL_CONTENTS 1000
-    #define OPT_SNARL_SAMPLE 1001
+    constexpr int OPT_SNARL_CONTENTS = 1000;
+    constexpr int OPT_SNARL_SAMPLE = 1001;
     constexpr int64_t snarl_search_context = 100;
 
     int c;

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -67,7 +67,7 @@ void help_stats(char** argv) {
          << "    -O, --overlap-all     print overlap table for the cartesian product of paths" << endl
          << "    -R, --snarls          print statistics for each snarl" << endl
          << "        --snarl-contents  print out a table of <snarl, depth, parent, contained node ids>" << endl
-         << "        --snarl-sample    print out reference coordinates on given sample" << endl
+         << "        --snarl-sample NAME  print out reference coordinates on given sample" << endl
          << "    -C, --chains          print statistics for each chain" << endl
          << "    -F, --format          graph format from {VG-Protobuf, PackedGraph, HashGraph, XG}. " <<
         "Can't detect Protobuf if graph read from stdin" << endl
@@ -117,8 +117,8 @@ int main_stats(int argc, char** argv) {
     string distance_index_filename;
 
     // Long options with no corresponding short options.
-    constexpr int OPT_SNARL_CONTENTS = 1000;
-    constexpr int OPT_SNARL_SAMPLE = 1001;
+    #define OPT_SNARL_CONTENTS 1000
+    #define OPT_SNARL_SAMPLE 1001
     constexpr int64_t snarl_search_context = 100;
 
     int c;
@@ -135,6 +135,7 @@ int main_stats(int argc, char** argv) {
             {"heads", no_argument, 0, 'H'},
             {"tails", no_argument, 0, 'T'},
             {"nondeterm", no_argument, 0, 'e'},
+            {"show-siblings", no_argument, 0, 'S'},
             {"help", no_argument, 0, 'h'},
             {"components", no_argument, 0, 'c'},
             {"to-head", no_argument, 0, 'd'},
@@ -144,7 +145,7 @@ int main_stats(int argc, char** argv) {
             {"is-acyclic", no_argument, 0, 'A'},
             {"node-id-range", no_argument, 0, 'r'},
             {"verbose", no_argument, 0, 'v'},
-            {"overlap", no_argument, 0, 'o'},
+            {"overlap", required_argument, 0, 'o'},
             {"overlap-all", no_argument, 0, 'O'},
             {"snarls", no_argument, 0, 'R'},
             {"snarl-contents", no_argument, 0, OPT_SNARL_CONTENTS},
@@ -159,7 +160,7 @@ int main_stats(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hzlLsHTecdtn:NEa:vPAro:ORCFDb:p:",
+        c = getopt_long (argc, argv, "h?zlLsHTeScdtn:NEa:vPAro:ORCFDb:p:",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -37,36 +37,53 @@ void help_surject(char** argv) {
          << "Transforms alignments to be relative to particular paths." << endl
          << endl
          << "options:" << endl
-         << "  -x, --xg-name FILE       use this graph or xg index (required)" << endl
-         << "  -t, --threads N          number of threads to use" << endl
-         << "  -p, --into-path NAME     surject into this path or its subpaths (many allowed, default: reference, then non-alt generic)" << endl
-         << "  -F, --into-paths FILE    surject into path names listed in HTSlib sequence dictionary or path list FILE" << endl
-         << "  -n, --into-ref NAME      surject into this reference assembly" << endl 
-         << "  -i, --interleaved        GAM is interleaved paired-ended, so when outputting HTS formats, pair reads" << endl
-         << "  -M, --multimap           include secondary alignments to all overlapping paths instead of just primary" << endl
-         << "  -G, --gaf-input          input file is GAF instead of GAM" << endl
-         << "  -m, --gamp-input         input file is GAMP instead of GAM" << endl
-         << "  -c, --cram-output        write CRAM to stdout" << endl
-         << "  -b, --bam-output         write BAM to stdout" << endl
-         << "  -s, --sam-output         write SAM to stdout" << endl
-         << "  -l, --subpath-local      let the multipath mapping surjection produce local (rather than global) alignments" << endl
-         << "  -T, --max-tail-len N     only align up to N bases of read tails (default: 10000)" << endl
-         << "  -g, --max-graph-scale X  make reads unmapped if alignment target subgraph size exceeds read length by a factor of X (default: " << Surjector::DEFAULT_SUBGRAPH_LIMIT << " or " << Surjector::SPLICED_DEFAULT_SUBGRAPH_LIMIT << " with -S)" << endl
-         << "  -P, --prune-low-cplx     prune short and low complexity anchors during realignment" << endl
-         << "  -I, --max-slide N        look for offset duplicates of anchors up to N bp away when pruning (default: " << Surjector::DEFAULT_MAX_SLIDE << ")" << endl
-         << "  -a, --max-anchors N      use no more than N anchors per target path (default: unlimited)" << endl
-         << "  -S, --spliced            interpret long deletions against paths as spliced alignments" << endl
-         << "  -A, --qual-adj           adjust scoring for base qualities, if they are available" << endl
-         << "  -E, --extra-gap-cost N   for dynamic programming, add this to the gap open cost of the 10x-scaled scoring parameters" << endl 
-         << "  -N, --sample NAME        set this sample name for all reads" << endl
-         << "  -R, --read-group NAME    set this read group for all reads" << endl
-         << "  -f, --max-frag-len N     reads with fragment lengths greater than N will not be marked properly paired in SAM/BAM/CRAM" << endl
-         << "  -L, --list-all-paths     annotate SAM records with a list of all attempted re-alignments to paths in SS tag" << endl
-         << "  -H, --graph-aln          annotate SAM records with cs-style difference string of the pre-surjected graph alignment in GR tag" << endl
-         << "  -C, --compression N      level for compression [0-9]" << endl
-         << "  -V, --no-validate        skip checking whether alignments plausibly are against the provided graph" << endl
-         << "  -w, --watchdog-timeout N warn when reads take more than the given number of seconds to surject" << endl
-         << "  -r, --progress           show progress" << endl;
+         << "  -x, --xg-name FILE        use this graph or xg index (required)" << endl
+         << "  -t, --threads N           number of threads to use" << endl
+         << "  -p, --into-path NAME      surject into this path or its subpaths (may repeat)" << endl
+         << "                            default: reference, then non-alt generic" << endl
+         << "  -F, --into-paths FILE     surject into path names listed in" << endl
+         << "                            HTSlib sequence dictionary or path list FILE" << endl
+         << "  -n, --into-ref NAME       surject into this reference assembly" << endl 
+         << "  -i, --interleaved         GAM is interleaved paired-ended, so pair reads" << endl
+         << "                            when outputting HTS formats" << endl
+         << "  -M, --multimap            include secondary alignments to all" << endl
+         << "                            overlapping paths instead of just primary" << endl
+         << "  -G, --gaf-input           input file is GAF instead of GAM" << endl
+         << "  -m, --gamp-input          input file is GAMP instead of GAM" << endl
+         << "  -c, --cram-output         write CRAM to stdout" << endl
+         << "  -b, --bam-output          write BAM to stdout" << endl
+         << "  -s, --sam-output          write SAM to stdout" << endl
+         << "  -l, --subpath-local       let the multipath mapping surjection produce local" << endl
+         << "                            (rather than global) alignments" << endl
+         << "  -T, --max-tail-len N      only align up to N bases of read tails [10000]" << endl
+         << "  -g, --max-graph-scale X   make reads unmapped if alignment target subgraph" << endl
+         << "                            size exceeds read length by a factor of X " << endl
+                                         << "(default: " << Surjector::DEFAULT_SUBGRAPH_LIMIT
+                                         << " or " << Surjector::SPLICED_DEFAULT_SUBGRAPH_LIMIT << " with -S)" << endl
+         << "  -P, --prune-low-cplx      prune short/low complexity anchors in realignment" << endl
+         << "  -I, --max-slide N         look for offset duplicates of anchors up to N bp" << endl
+         << "                            away when pruning "
+                                     << "(default: " << Surjector::DEFAULT_MAX_SLIDE << ")" << endl
+         << "  -a, --max-anchors N       use <= N anchors per target path [unlimited]" << endl
+         << "  -S, --spliced             interpret long deletions against paths" << endl
+         << "                            as spliced alignments" << endl
+         << "  -A, --qual-adj            adjust scoring for base qualities, if available" << endl
+         << "  -E, --extra-gap-cost N    for dynamic programming, add N to the gap open cost" << endl
+         << "                            of the 10x-scaled scoring parameters" << endl 
+         << "  -N, --sample NAME         set this sample name for all reads" << endl
+         << "  -R, --read-group NAME     set this read group for all reads" << endl
+         << "  -f, --max-frag-len N      reads with fragment lengths greater than N won't be" << endl
+         << "                            marked properly paired in SAM/BAM/CRAM" << endl
+         << "  -L, --list-all-paths      annotate SAM records with a list of all attempted" << endl
+         << "                            re-alignments to paths in SS tag" << endl
+         << "  -H, --graph-aln           annotate SAM records with cs-style difference string" << endl
+         << "                            of the pre-surjected graph alignment in GR tag" << endl
+         << "  -C, --compression N       level for compression [0-9]" << endl
+         << "  -V, --no-validate         skip checking whether alignments plausibly are" << endl
+         << "                            against the provided graph" << endl
+         << "  -w, --watchdog-timeout N  warn when reads take more than N seconds to surject" << endl
+         << "  -r, --progress            show progress" << endl
+         << "  -h, --help                print this help message to stderr and exit" << endl;
 }
 
 /// If the given alignment doesn't make sense against the given graph (i.e.
@@ -77,7 +94,8 @@ static void ensure_alignment_is_for_graph(const Alignment& aln, const HandleGrap
     if (!validity) {
         #pragma omp critical (cerr)
         {
-            std::cerr << "error:[vg surject] Alignment " << aln.name() << " cannot be interpreted against this graph: " << validity.message << std::endl;
+            std::cerr << "error:[vg surject] Alignment " << aln.name() << " cannot be interpreted against this graph: "
+                      << validity.message << std::endl;
             std::cerr << "Make sure that you are using the same graph that the reads were mapped to!" << std::endl;
         }
         exit(1);
@@ -96,7 +114,9 @@ static void ensure_alignment_is_for_graph(const MultipathAlignment& aln, const H
                 // Something is wrong with this alignment.
                 #pragma omp critical (cerr)
                 {
-                    std::cerr << "error:[vg surject] MultipathAlignment " << aln.name() << " cannot be interpreted against this graph: node " << node_id << " does not exist!" << std::endl;
+                    std::cerr << "error:[vg surject] MultipathAlignment " << aln.name() 
+                              << " cannot be interpreted against this graph: node "
+                              << node_id << " does not exist!" << std::endl;
                     std::cerr << "Make sure that you are using the same graph that the reads were mapped to!" << std::endl;
                 }
                 exit(1);
@@ -187,7 +207,7 @@ int main_surject(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsN:R:f:C:t:SPI:a:AE:LHMVw:r",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -438,7 +458,11 @@ int main_surject(int argc, char** argv) {
             if (src.has_path() && src.sequence().empty()) {
 #pragma omp critical
                 {
-                    cerr << "error:[surject] Read " << src.name() << " is aligned but does not have a sequence and therefore cannot be surjected. Was it derived from a GAF without a base-level alignment? Or a GAF with a CIGAR string in the 'cg' tag (which does not provide enough information to reconstruct the sequence)?" << endl;
+                    cerr << "error:[surject] Read " << src.name() << " is aligned but "
+                         << "does not have a sequence and therefore cannot be surjected. "
+                         << "Was it derived from a GAF without a base-level alignment? "
+                         << "Or a GAF with a CIGAR string in the 'cg' tag "
+                         << "(which does not provide enough information to reconstruct the sequence)?" << endl;
                     exit(1);
                 }
             }
@@ -531,7 +555,8 @@ int main_surject(int argc, char** argv) {
                             auto it = strand_idx2.find(make_pair(pos.name(), !pos.is_reverse()));
                             if (it != strand_idx2.end()) {
                                 // the alignments are paired on this strand
-                                alignment_emitter->emit_pair(std::move(surjected1[i]), std::move(surjected2[it->second]), max_frag_len);
+                                alignment_emitter->emit_pair(std::move(surjected1[i]), 
+                                                            std::move(surjected2[it->second]), max_frag_len);
                             }
                             else {
                                 // this strand's surjection is unpaired
@@ -631,7 +656,8 @@ int main_surject(int argc, char** argv) {
                 
                 // GAMP input is paired, and for HTS output reads need to know their pair partners' mapping locations.
                 // TODO: We don't preserve order relationships (like primary/secondary) beyond the interleaving.
-                vg::io::for_each_interleaved_pair_parallel<MultipathAlignment>(in, [&](MultipathAlignment& src1, MultipathAlignment& src2) {
+                vg::io::for_each_interleaved_pair_parallel<MultipathAlignment>(in, 
+                    [&](MultipathAlignment& src1, MultipathAlignment& src2) {
                     try {
                         set_crash_context(src1.name() + ", " + src2.name());
                         size_t thread_num = omp_get_thread_num();
@@ -741,10 +767,12 @@ int main_surject(int argc, char** argv) {
                             // FIXME: these aren't required to be on the same path...
                             positions.emplace_back();
                             surjected.emplace_back(surjector.surject(mp_src1, paths, get<0>(positions.front().first),
-                                                                     get<2>(positions.front().first), get<1>(positions.front().first),
+                                                                     get<2>(positions.front().first),
+                                                                     get<1>(positions.front().first),
                                                                      subpath_global, spliced),
                                                    surjector.surject(mp_src2, paths, get<0>(positions.front().second),
-                                                                     get<2>(positions.front().second), get<1>(positions.front().second),
+                                                                     get<2>(positions.front().second),
+                                                                     get<1>(positions.front().second),
                                                                      subpath_global, spliced));
                         }
                                             

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -178,15 +178,15 @@ int main_surject(int argc, char** argv) {
             {"max-frag-len", required_argument, 0, 'f'},
             {"list-all-paths", no_argument, 0, 'L'},
             {"graph-aln", no_argument, 0, 'H'},
-            {"compress", required_argument, 0, 'C'},
-            {"no-validate", required_argument, 0, 'V'},
+            {"compression", required_argument, 0, 'C'},
+            {"no-validate", no_argument, 0, 'V'},
             {"watchdog-timeout", required_argument, 0, 'w'},
             {"progress", no_argument, 0, 'r'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:p:F:n:lT:g:iGmcbsN:R:f:C:t:SPI:a:AE:LHMVw:r",
+        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsN:R:f:C:t:SPI:a:AE:LHMVw:r",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/trace_main.cpp
+++ b/src/subcommand/trace_main.cpp
@@ -57,12 +57,13 @@ int main_trace(int argc, char** argv) {
             {"start-node", required_argument, 0, 'n'},
             {"extend-distance", required_argument, 0, 'd'},
             {"json", no_argument, 0, 'j'},
+            {"help", no_argument, 0, 'h'},
             //{"backwards", no_argument, 0, 'b'},
             {0, 0, 0, 0}
         };
 
     int option_index = 0;
-    c = getopt_long (argc, argv, "x:G:a:n:d:jh",
+    c = getopt_long (argc, argv, "x:G:a:n:d:jh?",
                      long_options, &option_index);
 
     /* Detect the end of the options. */

--- a/src/subcommand/trace_main.cpp
+++ b/src/subcommand/trace_main.cpp
@@ -20,14 +20,15 @@ void help_trace(char** argv) {
          << "Trace and extract haplotypes from an index" << endl
          << endl
          << "options:" << endl
-         << "    -x, --index FILE           use this xg index or graph" << endl
-         << "    -G, --gbwt-name FILE       use this GBWT haplotype index instead of any in the graph" << endl
-         << "    -n, --start-node INT       start at this node" << endl
+         << "  -x, --index FILE            use this xg index or graph" << endl
+         << "  -G, --gbwt-name FILE        use GBWT haplotype index instead of any in graph" << endl
+         << "  -n, --start-node INT        start at this node ID" << endl
         //TODO: implement backwards iteration over graph
-        // << "    -b, --backwards            iterate backwards over graph" << endl
-         << "    -d, --extend-distance INT  extend search this many nodes [default=50]" << endl
-         << "    -a, --annotation-path FILE output file for haplotype frequency annotations" << endl
-         << "    -j, --json                 output subgraph in json instead of protobuf" << endl;
+        // << "  -b, --backwards             iterate backwards over graph" << endl
+         << "  -d, --extend-distance INT   extend search this many nodes [50]" << endl
+         << "  -a, --annotation-path FILE  output file for haplotype frequency annotations" << endl
+         << "  -j, --json                  output subgraph in json instead of protobuf" << endl
+         << "  -h, --help                  print this help message to stderr and exit" << endl;
 }
 
 int main_trace(int argc, char** argv) {

--- a/src/subcommand/translate_main.cpp
+++ b/src/subcommand/translate_main.cpp
@@ -25,12 +25,13 @@ void help_translate(char** argv) {
          << "Translate alignments or paths using the translation map." << endl
          << endl
          << "options:" << endl
-         << "    -p, --paths FILE      project the input paths into the from-graph" << endl
-         << "    -a, --alns FILE       project the input alignments into the from-graph" << endl
-         << "    -l, --loci FILE       project the input locus descriptions into the from-graph" << endl
-         << "    -m, --mapping JSON    print the from-mapping corresponding to the given JSON mapping" << endl
-         << "    -P, --position JSON   print the from-position corresponding to the given JSON position" << endl
-         << "    -o, --overlay FILE    overlay this translation on top of the one we are given" << endl;
+         << "  -p, --paths FILE      project the input paths into the from-graph" << endl
+         << "  -a, --alns FILE       project the input alignments into the from-graph" << endl
+         << "  -l, --loci FILE       project the input locus descriptions into the from-graph" << endl
+         << "  -m, --mapping JSON    print the from-mapping corresponding to a JSON mapping" << endl
+         << "  -P, --position JSON   print the from-position corresponding to a JSON position" << endl
+         << "  -o, --overlay FILE    overlay this translation on top of the one we are given" << endl
+         << "  -h, --help            print this help message to stderr and exit" << endl;
 }
 
 int main_translate(int argc, char** argv) {
@@ -64,7 +65,7 @@ int main_translate(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?p:m:P:a:o:l:",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)

--- a/src/subcommand/translate_main.cpp
+++ b/src/subcommand/translate_main.cpp
@@ -63,7 +63,7 @@ int main_translate(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hp:m:P:a:o:l:",
+        c = getopt_long (argc, argv, "h?p:m:P:a:o:l:",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -25,11 +25,12 @@ void help_validate(char** argv) {
          << "Validate the graph." << endl
          << endl
          << "options:" << endl
-         << "    default: check all aspects of the graph, if options are specified do only those" << endl
-         << "    -o, --orphans    verify that all nodes have edges" << endl
-         << "    -a, --gam FILE   verify that edits in the alignment fit on nodes in the graph" << endl
-         << "    -A, --gam-only   do not verify the graph itself, only the alignment" << endl
-         << "    -c, --check-seq  check that the edits in the alignment correctly report matches" << endl;
+         << "default: check all aspects of the graph; if options are specified do only those" << endl
+         << "  -o, --orphans    verify that all nodes have edges" << endl
+         << "  -a, --gam FILE   verify that edits in the alignment fit on nodes in the graph" << endl
+         << "  -A, --gam-only   do not verify the graph itself, only the alignment" << endl
+         << "  -c, --check-seq  check that the edits in alignment correctly report matches" << endl
+         << "  -h, --help       print this help message to stderr and exit" << endl;
 }
 
 int main_validate(int argc, char** argv) {
@@ -59,7 +60,7 @@ int main_validate(int argc, char** argv) {
 
         int option_index = 0;
         c = getopt_long (argc, argv, "h?oa:Ac",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -116,12 +117,18 @@ int main_validate(int argc, char** argv) {
                                 // If a node is too short, report the whole mapping again.
                                 cerr << ":" << std::endl << pb2json(aln.path().mapping(validity.bad_mapping_index));
                             }
-                            if (validity.problem == AlignmentValidity::READ_TOO_SHORT || validity.problem == AlignmentValidity::BAD_EDIT || validity.problem == AlignmentValidity::SEQ_DOES_NOT_MATCH) {
-                                // If there's something wrong with an edit or the read, report the edit and the position in the read
-                                if (validity.bad_mapping_index < aln.path().mapping_size() && validity.bad_edit_index < aln.path().mapping(validity.bad_mapping_index).edit_size()) {
-                                    cerr << ":" << std::endl << pb2json(aln.path().mapping(validity.bad_mapping_index).edit(validity.bad_edit_index));
+                            if (validity.problem == AlignmentValidity::READ_TOO_SHORT ||
+                                validity.problem == AlignmentValidity::BAD_EDIT ||
+                                validity.problem == AlignmentValidity::SEQ_DOES_NOT_MATCH) {
+                                // If there's something wrong with an edit or the read,
+                                // report the edit and the position in the read
+                                if (validity.bad_mapping_index < aln.path().mapping_size() &&
+                                    validity.bad_edit_index < aln.path().mapping(validity.bad_mapping_index).edit_size()) {
+                                    cerr << ":" << std::endl << pb2json(aln.path().mapping(
+                                        validity.bad_mapping_index).edit(validity.bad_edit_index));
                                 }
-                                cerr << ": at mapping " << validity.bad_mapping_index << " edit " << validity.bad_edit_index << " vs. read base " << validity.bad_read_position;
+                                cerr << ": at mapping " << validity.bad_mapping_index << " edit " 
+                                     << validity.bad_edit_index << " vs. read base " << validity.bad_read_position;
                             }
                             cerr << endl;
                             valid_aln = false;

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -58,7 +58,7 @@ int main_validate(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hoa:Ac",
+        c = getopt_long (argc, argv, "h?oa:Ac",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/vectorize_main.cpp
+++ b/src/subcommand/vectorize_main.cpp
@@ -30,18 +30,18 @@ void help_vectorize(char** argv){
          << "Vectorize a set of alignments to a variety of vector formats." << endl
          << endl
          << "options: " << endl
-         << "  -x --xg FILE       an xg index or graph of interest" << endl
-         << "  -g --gcsa FILE     a gcsa2 index to use if generating MEM sketches" << endl
-         << "  -l --aln-label LABEL   rename every alignment to LABEL when outputting alignment name." << endl
-         << "  -f --format        tab-delimit output so it can be used in R." << endl
-         << "  -A --annotate      create a header with each node/edge's name and a column with alignment names." << endl
-         << "  -a --a-hot         instead of a 1-hot, output a vector of {0|1|2} for covered, reference, or alt." << endl
-         << "  -w --wabbit        output a format that's friendly to vowpal wabbit" << endl
-         << "  -M --wabbit-mapping <FILE> output the mappings used for vowpal wabbit classes (default: print to stderr)" << endl
-         << "  -m --mem-sketch    generate a MEM sketch of a given read based on the GCSA" << endl
-         << "  -p --mem-positions add the positions to the MEM sketch of a given read based on the GCSA" << endl
-         << "  -H --mem-hit-max N ignore MEMs with this many hits when extracting poisitions" << endl
-         << "  -i --identity-hot  output a score vector based on percent identity and coverage" << endl
+         << "  -x, --xg FILE       an xg index or graph of interest" << endl
+         << "  -g, --gcsa FILE     a gcsa2 index to use if generating MEM sketches" << endl
+         << "  -l, --aln-label LABEL   rename every alignment to LABEL when outputting alignment name." << endl
+         << "  -f, --format        tab-delimit output so it can be used in R." << endl
+         << "  -A, --annotate      create a header with each node/edge's name and a column with alignment names." << endl
+         << "  -a, --a-hot         instead of a 1-hot, output a vector of {0|1|2} for covered, reference, or alt." << endl
+         << "  -w, --wabbit        output a format that's friendly to vowpal wabbit" << endl
+         << "  -M, --wabbit-mapping FILE  output the mappings used for vowpal wabbit classes (default: print to stderr)" << endl
+         << "  -m, --mem-sketch    generate a MEM sketch of a given read based on the GCSA" << endl
+         << "  -p, --mem-positions add the positions to the MEM sketch of a given read based on the GCSA" << endl
+         << "  -H, --mem-hit-max N ignore MEMs with this many hits when extracting poisitions" << endl
+         << "  -i, --identity-hot  output a score vector based on percent identity and coverage" << endl
          << endl;
 }
 
@@ -78,7 +78,6 @@ int main_vectorize(int argc, char** argv){
             {"annotate", no_argument, 0, 'A'},
             {"xg", required_argument,0, 'x'},
             {"gcsa", required_argument,0, 'g'},
-            {"threads", required_argument, 0, 't'},
             {"format", no_argument, 0, 'f'},
             {"a-hot", no_argument, 0, 'a'},
             {"wabbit", no_argument, 0, 'w'},
@@ -93,7 +92,7 @@ int main_vectorize(int argc, char** argv){
 
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "AaihwM:fmpx:g:l:H:",
+        c = getopt_long (argc, argv, "Aaih?wM:fmpx:g:l:H:r:",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/vectorize_main.cpp
+++ b/src/subcommand/vectorize_main.cpp
@@ -24,25 +24,30 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
-void help_vectorize(char** argv){
+void help_vectorize(char** argv) {
     cerr << "usage: " << argv[0] << " vectorize [options] -x <index.xg> <alignments.gam>" << endl
-
          << "Vectorize a set of alignments to a variety of vector formats." << endl
          << endl
          << "options: " << endl
-         << "  -x, --xg FILE       an xg index or graph of interest" << endl
-         << "  -g, --gcsa FILE     a gcsa2 index to use if generating MEM sketches" << endl
-         << "  -l, --aln-label LABEL   rename every alignment to LABEL when outputting alignment name." << endl
-         << "  -f, --format        tab-delimit output so it can be used in R." << endl
-         << "  -A, --annotate      create a header with each node/edge's name and a column with alignment names." << endl
-         << "  -a, --a-hot         instead of a 1-hot, output a vector of {0|1|2} for covered, reference, or alt." << endl
-         << "  -w, --wabbit        output a format that's friendly to vowpal wabbit" << endl
-         << "  -M, --wabbit-mapping FILE  output the mappings used for vowpal wabbit classes (default: print to stderr)" << endl
-         << "  -m, --mem-sketch    generate a MEM sketch of a given read based on the GCSA" << endl
-         << "  -p, --mem-positions add the positions to the MEM sketch of a given read based on the GCSA" << endl
-         << "  -H, --mem-hit-max N ignore MEMs with this many hits when extracting poisitions" << endl
-         << "  -i, --identity-hot  output a score vector based on percent identity and coverage" << endl
-         << endl;
+         << "  -x, --xg FILE              an xg index or graph of interest" << endl
+         << "  -g, --gcsa FILE            a GCSA2 index to use if generating MEM sketches" << endl
+         << "  -l, --aln-label LABEL      output all alignments with name LABEL" << endl
+         << "  -f, --format               tab-delimit output so it can be used in R." << endl
+         << "  -A, --annotate             create a header with each node/edge's name" << endl
+         << "                             and a column with alignment names." << endl
+         << "  -a, --a-hot                instead of a 1-hot, output a vector of {0|1|2}" << endl
+         << "                             for covered, reference, or alt." << endl
+         << "  -w, --wabbit               output a format that's friendly to vowpal wabbit" << endl
+         << "  -M, --wabbit-mapping FILE  output the mappings used for vowpal wabbit classes" << endl
+         << "                             (default: print to stderr)" << endl
+         << "  -m, --mem-sketch           generate a MEM sketch of a given read based on GCSA" << endl
+         << "  -p, --mem-positions        add the positions to the MEM sketch of a given read" << endl
+         << "                             based on the GCSA" << endl
+         << "  -H, --mem-hit-max N        ignore MEMs with more than this many hits when" << endl
+         << "                             extracting poisitions" << endl
+         << "  -i, --identity-hot         output a score vector for each alignment based on" << endl
+         << "                             percent identity and coverage" << endl
+         << "  -h, --help                 print this help message to stderr and exit" << endl;
 }
 
 int main_vectorize(int argc, char** argv){
@@ -93,7 +98,7 @@ int main_vectorize(int argc, char** argv){
         };
         int option_index = 0;
         c = getopt_long (argc, argv, "Aaih?wM:fmpx:g:l:H:r:",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -200,7 +205,8 @@ int main_vectorize(int argc, char** argv){
     }
 
     //Generate a 1-hot coverage vector for graph entities.
-    function<void(Alignment&)> lambda = [&vz, &mapper, use_identity_hot, output_wabbit, aln_label, mem_sketch, mem_positions, format, a_hot, max_mem_length](Alignment& a){
+    function<void(Alignment&)> lambda = [&vz, &mapper, use_identity_hot, output_wabbit, aln_label, mem_sketch, 
+                                         mem_positions, format, a_hot, max_mem_length](Alignment& a){
         //vz.add_bv(vz.alignment_to_onehot(a));
         //vz.add_name(a.name());
         if (a_hot) {

--- a/src/subcommand/vectorize_main.cpp
+++ b/src/subcommand/vectorize_main.cpp
@@ -101,28 +101,37 @@ int main_vectorize(int argc, char** argv){
 
         switch (c)
         {
-
- /*           case '?':
-            case 'h':
-                help_vectorize(argv);
-                return 1;
-            case 'x':
-                xg_name = optarg;
-                break;
-            case 'a':
-                a_hot = true;
-                break;
-            case 'w':
-                output_wabbit = true;
-                break; */
             case 'l':
                 aln_label = optarg;
                 break;
             case 'r':
                 read_file = optarg;
                 break;
-                /*
-
+            case '?':
+            case 'h':
+                help_vectorize(argv);
+                return 1;
+            case 'x':
+                xg_name = optarg;
+                break;
+            case 'g':
+                gcsa_name = optarg;
+                break;
+            case 'm':
+                mem_sketch = true;
+                break;
+            case 'p':
+                mem_positions = true;
+                break;
+            case 'H':
+                mem_hit_max = parse<int>(optarg);
+                break;
+            case 'a':
+                a_hot = true;
+                break;
+            case 'w':
+                output_wabbit = true;
+                break;
             case 'i':
                 use_identity_hot = true;
                 break;
@@ -133,50 +142,11 @@ int main_vectorize(int argc, char** argv){
                 annotate = true;
                 format = true;
                 break;
+            case 'M':
+                wabbit_mapping_file = optarg;
+                break;
             default:
                 abort();
-*/
-
-        case '?':
-        case 'h':
-            help_vectorize(argv);
-            return 1;
-        case 'x':
-            xg_name = optarg;
-            break;
-        case 'g':
-            gcsa_name = optarg;
-            break;
-        case 'm':
-            mem_sketch = true;
-            break;
-        case 'p':
-            mem_positions = true;
-            break;
-        case 'H':
-            mem_hit_max = parse<int>(optarg);
-            break;
-        case 'a':
-            a_hot = true;
-            break;
-        case 'w':
-            output_wabbit = true;
-            break;
-        case 'i':
-            use_identity_hot = true;
-            break;
-        case 'f':
-            format = true;
-            break;
-        case 'A':
-            annotate = true;
-            format = true;
-            break;
-        case 'M':
-            wabbit_mapping_file = optarg;
-            break;
-        default:
-            abort();
         }
     }
 

--- a/src/subcommand/version_main.cpp
+++ b/src/subcommand/version_main.cpp
@@ -21,8 +21,8 @@ using namespace vg::subcommand;
 void help_version(char** argv){
     cerr << "usage: " << argv[0] << " version" << endl
          << "options: " << endl
-         << "  -s / --slug           print only the one-line, whitespace-free version string" << endl
-         << "  -h / --help           print this help" << endl
+         << "  -s, --slug           print only the one-line, whitespace-free version string" << endl
+         << "  -h, --help           print this help" << endl
          << endl;
 }
 
@@ -39,7 +39,7 @@ int main_version(int argc, char** argv){
                 {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}};
         int option_index = 0;
-        c = getopt_long(argc, argv, "sh",
+        c = getopt_long(argc, argv, "sh?",
                         long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/version_main.cpp
+++ b/src/subcommand/version_main.cpp
@@ -18,11 +18,11 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
-void help_version(char** argv){
+void help_version(char** argv) {
     cerr << "usage: " << argv[0] << " version" << endl
          << "options: " << endl
          << "  -s, --slug           print only the one-line, whitespace-free version string" << endl
-         << "  -h, --help           print this help" << endl
+         << "  -h, --help           print this help message to stderr and exit" << endl
          << endl;
 }
 

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -151,8 +151,8 @@ int main_view(int argc, char** argv) {
     bool ascii_labels = false;
     omp_set_num_threads(1); // default to 1 thread
     
-    #define OPT_FIRST 1000
-    #define OPT_VERBOSE 1001
+    constexpr int OPT_FIRST = 1000;
+    constexpr int OPT_VERBOSE = 1001;
 
     int c;
     optind = 2; // force optind past "view" argument

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -95,7 +95,7 @@ void help_view(char** argv) {
          << "  -x, --extract-tag TAG     extract and concatenate messages with the given tag" << endl
          << "      --first               only extract first message with the requested tag" << endl
          << "      --verbose             explain the file being read with --extract-tag" << endl
-         << "      --threads N           for parallel operations use this many threads [1]" << endl
+         << "  -7,  --threads N          for parallel operations use this many threads [1]" << endl
          << "  -h, --help                print this help message to stderr and exit" << endl;
     
     // TODO: Can we regularize the option names for input and output types?

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -50,7 +50,7 @@ void help_view(char** argv) {
 
          << "    -t, --turtle               output RDF/turtle format (can not be loaded by VG)" << endl
          << "    -T, --turtle-in            input turtle format." << endl
-         << "    -r, --rdf_base_uri         set base uri for the RDF output" << endl
+         << "    -r, --rdf-base-uri URI     set base uri for the RDF output" << endl
 
          << "    -a, --align-in             input GAM format, or JSON version of GAM format" << endl
          << "    -A, --aln-graph GAM        add alignments from GAM to the graph" << endl
@@ -190,7 +190,7 @@ int main_view(int argc, char** argv) {
                 {"ultra-label", no_argument, 0, 'Y'},
                 {"skip-missing", no_argument, 0, 'm'},
                 {"locus-in", no_argument, 0, 'q'},
-                {"loci", no_argument, 0, 'Q'},
+                {"loci", required_argument, 0, 'Q'},
                 {"locus-out", no_argument, 0, 'z'},
                 {"distance-in", no_argument, 0, 'B'},
                 {"snarl-in", no_argument, 0, 'R'},
@@ -203,11 +203,12 @@ int main_view(int argc, char** argv) {
                 {"multipath-in", no_argument, 0, 'K'},
                 {"ascii-labels", no_argument, 0, 'e'},
                 {"threads", required_argument, 0, '7'},
+                {"help", no_argument, 0, 'h'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "dgFjJhvVpaGbifA:s:wnlLIMcTtr:SuCZYmqQ:zXBREDx:kKe7:",
+        c = getopt_long (argc, argv, "dgFjJh?vVpaGbifA:s:wnlLIMcTtr:SuCZYmqQ:zXBREDx:kKe7:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -34,65 +34,69 @@ using namespace vg::io;
 void help_view(char** argv) {
     cerr << "usage: " << argv[0] << " view [options] [ <graph.vg> | <graph.json> | <aln.gam> | <read1.fq> [<read2.fq>] ]" << endl
          << "options:" << endl
-         << "    -g, --gfa                  output GFA format (default)" << endl
-         << "    -F, --gfa-in               input GFA format, reducing overlaps if they occur" << endl
+         << "  -g, --gfa                 output GFA format (default)" << endl
+         << "  -F, --gfa-in              input GFA format, reducing overlaps if they occur" << endl
 
-         << "    -v, --vg                   output VG format [DEPRECATED, use vg convert instead]" << endl
-         << "    -V, --vg-in                input VG format only" << endl
+         << "  -v, --vg                  output VG format [DEPRECATED, use vg convert]" << endl
+         << "  -V, --vg-in               input VG format only" << endl
 
-         << "    -j, --json                 output JSON format" << endl
-         << "    -J, --json-in              input JSON format (use with e.g. -a as necessary)" << endl
-         << "    -c, --json-stream          streaming conversion of a VG format graph in line delimited JSON format" << endl
-         << "                               (this cannot be loaded directly via -J)" << endl
+         << "  -j, --json                output JSON format" << endl
+         << "  -J, --json-in             input JSON format (use with e.g. -a as necessary)" << endl
+         << "  -c, --json-stream         streaming conversion of a VG format graph" << endl
+         << "                            in line delimited JSON format" << endl
+         << "                            (this cannot be loaded directly via -J)" << endl
 
-         << "    -G, --gam                  output GAM format (vg alignment format: Graph Alignment/Map)" << endl
-         << "    -Z, --translation-in       input is a graph translation description" << endl
+         << "  -G, --gam                 output GAM format (vg alignment format)" << endl
+         << "  -Z, --translation-in      input is a graph translation description" << endl
 
-         << "    -t, --turtle               output RDF/turtle format (can not be loaded by VG)" << endl
-         << "    -T, --turtle-in            input turtle format." << endl
-         << "    -r, --rdf-base-uri URI     set base uri for the RDF output" << endl
+         << "  -t, --turtle              output RDF/turtle format (can not be loaded by VG)" << endl
+         << "  -T, --turtle-in           input turtle format." << endl
+         << "  -r, --rdf-base-uri URI    set base uri for the RDF output" << endl
 
-         << "    -a, --align-in             input GAM format, or JSON version of GAM format" << endl
-         << "    -A, --aln-graph GAM        add alignments from GAM to the graph" << endl
+         << "  -a, --align-in            input GAM format, or JSON version of GAM format" << endl
+         << "  -A, --aln-graph GAM       add alignments from GAM to the graph" << endl
 
-         << "    -q, --locus-in             input is Locus format, or JSON version of Locus format" << endl
-         << "    -z, --locus-out            output is Locus format" << endl
-         << "    -Q, --loci FILE            input is Locus format for use by dot output" << endl
+         << "  -q, --locus-in            input is Locus format, or JSON version of it" << endl
+         << "  -z, --locus-out           output is Locus format" << endl
+         << "  -Q, --loci FILE           input is Locus format for use by dot output" << endl
 
-         << "    -d, --dot                  output dot format" << endl
-         << "    -S, --simple-dot           simplify the dot output; remove node labels, simplify alignments" << endl
-         << "    -u, --noseq-dot            shows size information instead of sequence in the dot output" << endl
-         << "    -e, --ascii-labels         use labels for paths or superbubbles with char/colors rather than emoji" << endl
-         << "    -Y, --ultra-label          label nodes with emoji/colors that correspond to ultrabubbles" << endl
-         << "    -m, --skip-missing         skip mappings to nodes not in the graph when drawing alignments" << endl
-         << "    -C, --color                color nodes that are not in the reference path (DOT OUTPUT ONLY)" << endl
-         << "    -p, --show-paths           show paths in dot output" << endl
-         << "    -w, --walk-paths           add labeled edges to represent paths in dot output" << endl
-         << "    -n, --annotate-paths       add labels to normal edges to represent paths in dot output" << endl
-         << "    -M, --show-mappings        with -p print the mappings in each path in JSON" << endl
-         << "    -I, --invert-ports         invert the edge ports in dot so that ne->nw is reversed" << endl
-         << "    -s, --random-seed N        use this seed when assigning path symbols in dot output" << endl
+         << "  -d, --dot                 output dot format" << endl
+         << "  -S, --simple-dot          simple alignments & no node labels in dot output" << endl
+         << "  -u, --noseq-dot           show size instead of sequence in dot output" << endl
+         << "  -e, --ascii-labels        label paths/superbubbles with char/colors vs. emoji" << endl
+         << "  -Y, --ultra-label         label nodes with emoji/colors for ultrabubbles" << endl
+         << "  -m, --skip-missing        skip mappings to nodes not in the graph" << endl
+         << "                            when drawing alignments" << endl
+         << "  -C, --color               color nodes not in reference path (DOT OUTPUT ONLY)" << endl
+         << "  -p, --show-paths          show paths in dot output" << endl
+         << "  -w, --walk-paths          add labeled edges to represent paths in dot output" << endl
+         << "  -n, --annotate-paths      add labels to edges to represent paths in dot output" << endl
+         << "  -M, --show-mappings       with -p, print the mappings in each path in JSON" << endl
+         << "  -I, --invert-ports        invert edge ports in dot so that ne->nw is reversed" << endl
+         << "  -s, --random-seed N       use this seed for path symbols in dot output" << endl
 
-         << "    -b, --bam                  input BAM or other htslib-parseable alignments" << endl
+         << "  -b, --bam                 input BAM or other htslib-parseable alignments" << endl
 
-         << "    -f, --fastq-in             input fastq (output defaults to GAM). Takes two " << endl
-         << "                               positional file arguments if paired" << endl
-         << "    -X, --fastq-out            output fastq (input defaults to GAM)" << endl
-         << "    -i, --interleaved          fastq is interleaved paired-ended" << endl
+         << "  -f, --fastq-in            input fastq (output defaults to GAM). Takes two" << endl
+         << "                            positional file arguments if paired" << endl
+         << "  -X, --fastq-out           output fastq (input defaults to GAM)" << endl
+         << "  -i, --interleaved         fastq is interleaved paired-ended" << endl
 
-         << "    -L, --pileup               output VG Pileup format" << endl
-         << "    -l, --pileup-in            input VG Pileup format, or JSON version of VG Pileup format" << endl
+         << "  -L, --pileup              output VG Pileup format" << endl
+         << "  -l, --pileup-in           input VG Pileup format, or JSON version of it" << endl
 
-         << "    -B, --distance-in          input distance index" << endl
-         << "    -R, --snarl-in             input VG Snarl format" << endl
-         << "    -E, --snarl-traversal-in   input VG SnarlTraversal format" << endl
-         << "    -K, --multipath-in         input VG MultipathAlignment format (GAMP), or JSON version of GAMP format" << endl
-         << "    -k, --multipath            output VG MultipathAlignment format (GAMP)" << endl
-         << "    -D, --expect-duplicates    don't warn if encountering the same node or edge multiple times" << endl
-         << "    -x, --extract-tag TAG      extract and concatenate messages with the given tag" << endl
-         << "    --first                    only extract the first message with the requested tag" << endl
-         << "    --verbose                  explain the file being read with --extract-tag" << endl
-         << "    --threads N                for parallel operations use this many threads [1]" << endl;
+         << "  -B, --distance-in         input distance index" << endl
+         << "  -R, --snarl-in            input VG Snarl format" << endl
+         << "  -E, --snarl-traversal-in  input VG SnarlTraversal format" << endl
+         << "  -K, --multipath-in        input VG MultipathAlignment format (GAMP)," << endl
+         << "                            or JSON version of it" << endl
+         << "  -k, --multipath           output VG MultipathAlignment format (GAMP)" << endl
+         << "  -D, --expect-duplicates   don't warn about duplicate nodes or edges" << endl
+         << "  -x, --extract-tag TAG     extract and concatenate messages with the given tag" << endl
+         << "      --first               only extract first message with the requested tag" << endl
+         << "      --verbose             explain the file being read with --extract-tag" << endl
+         << "      --threads N           for parallel operations use this many threads [1]" << endl
+         << "  -h, --help                print this help message to stderr and exit" << endl;
     
     // TODO: Can we regularize the option names for input and output types?
 

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -57,13 +57,13 @@ int main_viz(int argc, char** argv) {
             {"height", required_argument, 0, 'Y'},
             {"out", required_argument, 0, 'o'},
             {"scale", required_argument, 0, 's'},
-            {"hide-cnv", no_argument, 0, 'C'},
+            {"show-cnv", no_argument, 0, 'C'},
             {"hide-dna", no_argument, 0, 'D'},
             {"hide-paths", no_argument, 0, 'P'},
             {0, 0, 0, 0}
         };
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:i:n:o:X:Y:s:CDP",
+        c = getopt_long (argc, argv, "h?x:i:n:o:X:Y:s:CDP",
                 long_options, &option_index);
 
         // Detect the end of the options.

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -15,15 +15,16 @@ using namespace vg::subcommand;
 void help_viz(char** argv) {
     cerr << "usage: " << argv[0] << " viz [options]" << endl
          << "options:" << endl
-         << "    -x, --xg FILE         use this basis graph" << endl
-         << "    -i, --pack-in FILE    use this compressed coverage format (multiple allowed)" << endl
-         << "    -n, --name NAME       apply name to the previous .pack (multiple allowed)" << endl
-         << "    -o, --out FILE        write to file (could be .png or .svg)" << endl
-         << "    -X, --width N         write an image N pixels wide (default 1024)" << endl
-         << "    -Y, --height N        write an image N pixels high (default 1024)" << endl
-         << "    -C, --show-cnv        visualize CNVs in paths on new rows (default uses text)" << endl
-         << "    -P, --hide-paths      hide reference paths in the graph" << endl
-         << "    -D, --hide-dna        suppress the visualization of DNA sequences" << endl;
+         << "  -x, --xg FILE         use this basis graph" << endl
+         << "  -i, --pack-in FILE    use this compressed coverage format (may repeat)" << endl
+         << "  -n, --name NAME       apply name to the previous .pack (may repeat)" << endl
+         << "  -o, --out FILE        write to file (could be .png or .svg)" << endl
+         << "  -X, --width N         write an image N pixels wide [1024]" << endl
+         << "  -Y, --height N        write an image N pixels high [1024]" << endl
+         << "  -C, --show-cnv        visualize CNVs in paths on new rows (default uses text)" << endl
+         << "  -P, --hide-paths      hide reference paths in the graph" << endl
+         << "  -D, --hide-dna        suppress the visualization of DNA sequences" << endl
+         << "  -h, --help            print this help message to stderr and exit" << endl;
 }
 
 int main_viz(int argc, char** argv) {
@@ -64,7 +65,7 @@ int main_viz(int argc, char** argv) {
         };
         int option_index = 0;
         c = getopt_long (argc, argv, "h?x:i:n:o:X:Y:s:CDP",
-                long_options, &option_index);
+                         long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -120,7 +121,8 @@ int main_viz(int argc, char** argv) {
         exit(1);
     } else {
         path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
-        // We know the PathPositionVectorizableOverlayHelper produces a PathPositionVectorizableOverlay which implements PathPositionHandleGraph.
+        // We know the PathPositionVectorizableOverlayHelper produces a PathPositionVectorizableOverlay
+        // which implements PathPositionHandleGraph.
         // TODO: Make the types actually work out here.
         xgidx = dynamic_cast<PathPositionHandleGraph*>(overlay_helper.apply(path_handle_graph.get()));
         assert(xgidx != nullptr);

--- a/src/subcommand/zipcode_main.cpp
+++ b/src/subcommand/zipcode_main.cpp
@@ -39,10 +39,11 @@ void help_zipcode(char** argv) {
     << "usage: " << argv[0] << " test zipcodes on minimizers from reads [options] input.gam > output.gam" << endl
     << endl
     << "basic options:" << endl
+    << "  -h, --help                    print this help message to stderr and exit" << endl
     << "  -x, --xg-name FILE            use this xg index or graph (required)" << endl
     << "  -m, --minimizer-name FILE     use this minimizer index" << endl
     << "  -d, --dist-name FILE          use this distance index (required)" << endl
-    << "  -c, --hit-cap INT             ignore minimizers with more than this many locations [10]" << endl
+    << "  -c, --hit-cap INT             ignore minimizers with >INT locations [10]" << endl
     << "computational parameters:" << endl
     << "  -t, --threads INT             number of compute threads to use" << endl;
 }
@@ -127,7 +128,8 @@ int main_zipcode(int argc, char** argv) {
             {
                 int num_threads = parse<int>(optarg);
                 if (num_threads <= 0) {
-                    cerr << "error:[vg zipcode] Thread count (-t) set to " << num_threads << ", must set to a positive integer." << endl;
+                    cerr << "error:[vg zipcode] Thread count (-t) set to " << num_threads 
+                         << ", must set to a positive integer." << endl;
                     exit(1);
                 }
                 omp_set_num_threads(num_threads);

--- a/src/subcommand/zipcode_main.cpp
+++ b/src/subcommand/zipcode_main.cpp
@@ -77,7 +77,7 @@ int main_zipcode(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "hx:g:m:d:c:t:",
+        c = getopt_long (argc, argv, "h?x:g:m:d:c:t:",
                          long_options, &option_index);
 
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Register command line options correctly & put them under test (`scripts/check_options.py`). This involved a _lot_ of minor bugfixes and helptext modifications, collected in a [Google Doc](https://docs.google.com/document/d/1V4wj4c7OPFfcZ4nsd5hnRWgR_lfSzfMXvVHjEhodAZo/edit?usp=sharing).
 * Manually wrap option helptext lines after 80 characters
 
## Description

This is what I've been working on during the week since I left on vacation. I had to deal with minor option errors one too many times (see #4648, #4649, etc.) and decided I would fix them once and for all. In addition, I've been minorly miffed at when too-long helptext exceeded the width of my (perfectly normal) terminal, and ended up wrapping around to under the list of options instead of staying in the description column. Thus, my quality-of-life PR to end all quality-of-life PRs.

The script itself explains what it does, so I'll just quote that here:

https://github.com/vgteam/vg/blob/a94eea53c2b1be4ae5142babf0052bd3c26429d4/scripts/check_options.py#L1-L61

To bring the subcommand files into compliance with `scripts/check_options.py`, I ended up editing—I wish this were a joke—literally every single file in `src/subcommand/*_main.cpp` except for the two I manually excepted (`test_main.cpp` & `help_main.cpp`) on account of them being exceptions. I don't _think_ I did anything with functional consequences except bugfixes. The majority of the edits were purely whitespace/formatting. However, as my six-page (abridged) changelog Google Doc attests, I did change an awful lot. For what it's worth the current commit passes all of the `vg test` suite.

Most of the commits here are just messing with the option-checking script itself. Only a few touch the subcommand files:
- Commit https://github.com/vgteam/vg/commit/9986d94b232c7c0164390ddff04a11af9914bb0c, which fixes bugs with command-line options (i.e. the original impetus for this project)
- Commit https://github.com/vgteam/vg/commit/5fcd40dbc962e4d52c7c236a73b690fede8ddb1a, which removes a duplicate options and deletes useless comments (this commit wasn't really supposed to be its own thing; it's an accident)
- Commit https://github.com/vgteam/vg/commit/1cbee96ec2f637979479d4dbc3d04fcc9f2c952b, which does whitespace/formatting elements to make the helptext line up in neat 80-char columns. Also breaks up some non-helptext lines (no functional changes, just extra newlines) to keep them from being too obscenely long.

I have taken pains to make sure that the script is well-documented. Ideally it should be accessible to other people. That includes both that they can understand what the script is complaining about, and that they can understand how the script works in case they need to update it themselves. Yet, no matter how long my docstrings are, this is indeed a 750-line script developed by a single hyperfocused person over a week. I've definitely missed something. Y'all are free to ping me about it.

@adamnovak I'd appreciate help figuring out how to add my option-checking script to the automated tests that run on PRs. Currently, it expects to be run from within the vg directory as `python scripts/check_options.py`. If it finds a problem it prints a summary; on a success it prints nothing. I'm open to changing any of that functionality because it's all just a wrapper for the all-important `check_file()` function.