### PR TITLE
Add make mimalloc=on to allow building with mimalloc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -130,3 +130,6 @@
 [submodule "deps/kff-cpp-api"]
 	path = deps/kff-cpp-api
 	url = https://github.com/Kmer-File-Format/kff-cpp-api.git
+[submodule "deps/mimalloc"]
+	path = deps/mimalloc
+	url = https://github.com/microsoft/mimalloc.git

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ UNITTEST_EXE = $(patsubst $(UNITTEST_SRC_DIR)/%.cpp,$(UNITTEST_BIN_DIR)/%,$(wild
 
 RAPTOR_DIR:=deps/raptor
 JEMALLOC_DIR:=deps/jemalloc
-LOCKFREE_MALLOC_DIR:=deps/lockfree-malloc
+MIMALLOC_DIR:=deps/mimalloc
 SDSL_DIR:=deps/sdsl-lite
 SNAPPY_DIR:=deps/snappy
 GCSA2_DIR:=deps/gcsa2
@@ -422,35 +422,76 @@ ifeq ($(asan),on)
 	CXXFLAGS += -fsanitize=address -fno-omit-frame-pointer
 endif
 
-# Control variable for allocator
+# Control variable for mimalloc allocator
+# On the command line, you can `make mimalloc=on` if you want mimalloc.
+mimalloc = off
+
+# Control variable for jemalloc allocator
 # On the command line, you can `make jemalloc=off` if you definitely don't want jemalloc.
 # Or you can `make jemalloc=debug` to use a version that tries to find memory errors.
 jemalloc = on
+ifeq ($(mimalloc),on)
+	jemalloc = off
+endif
 ifeq ($(shell uname -s),Darwin)
 	jemalloc = off
 endif
 
+# Sometimes I say jemalloc=yes and then make a face when that doesn't work. Put
+# a stop to this.
+ifneq ($(asan),on)
+	ifneq ($(asan),off)
+		unused := $(error "Error: asan must be on or off, not $(asan)")
+	endif
+endif
+ifneq ($(mimalloc),on)
+	ifneq ($(mimalloc),off)
+		unused := $(error "Error: mimalloc must be on or off, not $(mimalloc)")
+	endif
+endif
+ifneq ($(jemalloc),on)
+	ifneq ($(jemalloc),off)
+		ifneq ($(jemalloc),debug)
+			unused := $(error "Error: jemalloc must be on, off, or debug, not $(jemalloc)")
+		endif
+	endif
+endif
+ifeq ($(mimalloc),on)
+	ifneq ($(jemalloc),off)
+		unused := $(error "Error: mimalloc and jemalloc cannot be used together")
+	endif
+endif
+
+
 # Only depend on these files for the final linking stage.	
 # These libraries provide no headers to affect the vg build.	
 LINK_DEPS =
+# Only depend on these files for the final linking stage, but link them in
+# before all other files.
+PRE_LINK_DEPS =
 
-ifeq ($(jemalloc),on)
-    # Use jemalloc at link time
+ifeq ($(mimalloc),on)
+	# Use mimalloc at link time
+	PRE_LINK_DEPS += $(LIB_DIR)/mimalloc.o
+	# Use the config object for mimalloc
+	CONFIG_OBJ += $(CONFIG_OBJ_DIR)/allocator_config_mimalloc.o
+else ifeq ($(jemalloc),on)
+	# Use jemalloc at link time
 	LINK_DEPS += $(LIB_DIR)/libjemalloc.a
-    # We have to use it statically or we can't get at its secret symbols.
+	# We have to use it statically or we can't get at its secret symbols.
 	LD_EXE_LIB_FLAGS += $(LIB_DIR)/libjemalloc.a
 	# Use the config object for jemalloc
-    CONFIG_OBJ += $(CONFIG_OBJ_DIR)/allocator_config_jemalloc.o
+	CONFIG_OBJ += $(CONFIG_OBJ_DIR)/allocator_config_jemalloc.o
 else ifeq ($(jemalloc),debug)
-    # Use jemalloc at link time
+	# Use jemalloc at link time
 	LINK_DEPS += $(LIB_DIR)/libjemalloc_debug.a $(LIB_DIR)/libjemalloc_debug_pic.a
-    # We have to use it statically or we can't get at its secret symbols.
+	# We have to use it statically or we can't get at its secret symbols.
 	LD_EXE_LIB_FLAGS += $(LIB_DIR)/libjemalloc_debug.a
 	# Use the config object for jemalloc
-    CONFIG_OBJ += $(CONFIG_OBJ_DIR)/allocator_config_jemalloc_debug.o
+	CONFIG_OBJ += $(CONFIG_OBJ_DIR)/allocator_config_jemalloc_debug.o
 else
 	# Use the config object for the normal allocator
-    CONFIG_OBJ += $(CONFIG_OBJ_DIR)/allocator_config_system.o
+	CONFIG_OBJ += $(CONFIG_OBJ_DIR)/allocator_config_system.o
 endif
 
 # common dependencies to build before all vg src files
@@ -479,7 +520,7 @@ DEPS += $(INC_DIR)/atomic_queue.h
 # Aggregate all libvg deps, and exe deps other than libvg
 LIBVG_DEPS = $(OBJ) $(ALGORITHMS_OBJ) $(IO_OBJ) $(DEP_OBJ) $(DEPS)
 LIBVG_SHARED_DEPS = $(SHARED_OBJ) $(ALGORITHMS_SHARED_OBJ) $(IO_SHARED_OBJ) $(DEP_SHARED_OBJ) $(DEPS)
-EXE_DEPS = $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(DEPS) $(LINK_DEPS)
+EXE_DEPS = $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(DEPS) $(LINK_DEPS) $(PRE_LINK_DEPS)
 
 # We have a target we can build to do everything but link the library and executable
 objs: $(LIBVG_DEPS) $(EXE_DEPS)
@@ -499,11 +540,11 @@ $(UNITTEST_EXE): $(UNITTEST_BIN_DIR)/%: $(UNITTEST_OBJ_DIR)/%.o $(UNITTEST_SUPPO
 # For a normal dynamic build we remove the static build marker
 $(BIN_DIR)/$(EXE): $(LIB_DIR)/libvg.a $(EXE_DEPS)
 	-rm -f $(LIB_DIR)/vg_is_static
-	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(LD_LIB_DIR_FLAGS) $(LDFLAGS) $(LIB_DIR)/libvg.a $(LD_LIB_FLAGS) $(START_STATIC) $(LD_STATIC_LIB_FLAGS) $(END_STATIC) $(LD_STATIC_LIB_DEPS) $(LD_EXE_LIB_FLAGS)
+	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(PRE_LINK_DEPS) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(LD_LIB_DIR_FLAGS) $(LDFLAGS) $(LIB_DIR)/libvg.a $(LD_LIB_FLAGS) $(START_STATIC) $(LD_STATIC_LIB_FLAGS) $(END_STATIC) $(LD_STATIC_LIB_DEPS) $(LD_EXE_LIB_FLAGS)
 # We keep a file that we touch on the last static build.
 # If the vg linkables are newer than the last static build, we do a build
 $(LIB_DIR)/vg_is_static: $(OBJ_DIR)/main.o $(LIB_DIR)/libvg.a $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(DEPS) $(LINK_DEPS)
-	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(LD_LIB_DIR_FLAGS) $(LDFLAGS) $(LIB_DIR)/libvg.a $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(LD_STATIC_LIB_FLAGS) $(LD_STATIC_LIB_DEPS) $(LD_EXE_LIB_FLAGS)
+	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $(BIN_DIR)/$(EXE) $(PRE_LINK_DEPS) $(OBJ_DIR)/main.o $(UNITTEST_OBJ) $(SUBCOMMAND_OBJ) $(CONFIG_OBJ) $(LD_LIB_DIR_FLAGS) $(LDFLAGS) $(LIB_DIR)/libvg.a $(STATIC_FLAGS) $(LD_LIB_FLAGS) $(LD_STATIC_LIB_FLAGS) $(LD_STATIC_LIB_DEPS) $(LD_EXE_LIB_FLAGS)
 	-touch $(LIB_DIR)/vg_is_static
 
 # We don't want to always rebuild the static vg if no files have changed.
@@ -568,12 +609,15 @@ endif
 test/build_graph: test/build_graph.cpp $(LIB_DIR)/libvg.a $(SRC_DIR)/vg.hpp
 	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o test/build_graph test/build_graph.cpp $(LD_LIB_DIR_FLAGS) $(LDFLAGS) $(LIB_DIR)/libvg.a $(LD_LIB_FLAGS) $(START_STATIC) $(LD_STATIC_LIB_FLAGS) $(END_STATIC) $(FILTER)
 
+$(LIB_DIR)/mimalloc.o: $(MIMALLOC_DIR)/src/*.c $(MIMALLOC_DIR)/src/*/*.c $(MIMALLOC_DIR)/src/*/*/*.c $(MIMALLOC_DIR)/include/*.h $(MIMALLOC_DIR)/include/*/*.h $(MIMALLOC_DIR)/CMakeLists.txt
+	+rm -f $(LIB_DIR)/mimalloc.o && rm -Rf $(INC_DIR)/mimalloc $(INC_DIR)/mimalloc*.h && cd $(MIMALLOC_DIR) && rm -Rf build && mkdir build && cd build && cmake -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)" -DCMAKE_C_FLAGS="$(CFLAGS)" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)" ..  && $(MAKE) $(FILTER) &&  cp -r ../include/* $(CWD)/$(INC_DIR)/ && cp mimalloc.o $(CWD)/$(LIB_DIR)/
+
 # TODO: The normal and debug jemalloc builds can't safely be run at the same time.
 $(LIB_DIR)/libjemalloc.a: $(JEMALLOC_DIR)/src/*.c
-	+rm -f $(LIB_DIR)/libjemalloc*.* && rm -Rf $(CWD)/$(INC_DIR)/jemalloc && cd $(JEMALLOC_DIR) && ./autogen.sh && ./configure --enable-prof --disable-libdl --prefix=`pwd` $(FILTER) && $(MAKE) clean && $(MAKE) $(FILTER) && cp lib/libjemalloc.a $(CWD)/$(LIB_DIR)/ && cp -r include/* $(CWD)/$(INC_DIR)/
+	+rm -f $(LIB_DIR)/libjemalloc*.* && rm -Rf $(CWD)/$(INC_DIR)/jemalloc && cd $(JEMALLOC_DIR) && ./autogen.sh && ./configure --enable-prof --disable-libdl --prefix=`pwd` $(FILTER) && $(MAKE) clean && $(MAKE) $(FILTER) && cp -r include/* $(CWD)/$(INC_DIR)/ && cp lib/libjemalloc.a $(CWD)/$(LIB_DIR)/
 
 $(LIB_DIR)/libjemalloc_debug.a: $(JEMALLOC_DIR)/src/*.c
-	+rm -f $(LIB_DIR)/libjemalloc*.* && rm -Rf $(CWD)/$(INC_DIR)/jemalloc && cd $(JEMALLOC_DIR) && ./autogen.sh && ./configure --enable-prof --disable-libdl --enable-debug --enable-fill --prefix=`pwd` $(FILTER) && $(MAKE) clean && $(MAKE) $(FILTER) && cp lib/libjemalloc.a $(CWD)/$(LIB_DIR)/libjemalloc_debug.a && cp -r include/* $(CWD)/$(INC_DIR)/
+	+rm -f $(LIB_DIR)/libjemalloc*.* && rm -Rf $(CWD)/$(INC_DIR)/jemalloc && cd $(JEMALLOC_DIR) && ./autogen.sh && ./configure --enable-prof --disable-libdl --enable-debug --enable-fill --prefix=`pwd` $(FILTER) && $(MAKE) clean && $(MAKE) $(FILTER) && cp -r include/* $(CWD)/$(INC_DIR)/ && cp lib/libjemalloc.a $(CWD)/$(LIB_DIR)/libjemalloc_debug.a
 
 # Use fake patterns to tell Make that this rule generates all these files when run once.
 # Here % should always match "lib" which is a common substring.
@@ -955,6 +999,9 @@ $(UNITTEST_SUPPORT_OBJ): $(UNITTEST_SUPPORT_OBJ_DIR)/%.o : $(UNITTEST_SUPPORT_SR
 	@touch $@
 	
 # Config objects get individual rules
+$(CONFIG_OBJ_DIR)/allocator_config_mimalloc.o: $(CONFIG_SRC_DIR)/allocator_config_mimalloc.cpp $(CONFIG_OBJ_DIR)/allocator_config_mimalloc.d $(DEPS) $(LIB_DIR)/mimalloc.o
+	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) $(DEPGEN_FLAGS) -c -o $@ $< $(FILTER)
+	@touch $@
 $(CONFIG_OBJ_DIR)/allocator_config_jemalloc.o: $(CONFIG_SRC_DIR)/allocator_config_jemalloc.cpp $(CONFIG_OBJ_DIR)/allocator_config_jemalloc.d $(DEPS) $(LIB_DIR)/libjemalloc.a
 	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) $(DEPGEN_FLAGS) -c -o $@ $< $(FILTER)
 	@touch $@
@@ -1078,6 +1125,7 @@ clean: clean-vcflib
 	cd $(DEP_DIR) && cd vcflib && $(MAKE) clean
 	cd $(DEP_DIR) && cd sha1 && $(MAKE) clean
 	cd $(DEP_DIR) && cd structures && $(MAKE) clean
+	cd $(DEP_DIR) && cd mimalloc && rm -Rf build CMakeCache.txt CMakeFiles
 	cd $(DEP_DIR) && cd jemalloc && $(MAKE) clean || true
 	cd $(DEP_DIR) && cd sublinear-Li-Stephens && $(MAKE) clean
 	cd $(DEP_DIR) && cd libhandlegraph && rm -Rf build CMakeCache.txt CMakeFiles

--- a/src/config/allocator_config_mimalloc.cpp
+++ b/src/config/allocator_config_mimalloc.cpp
@@ -1,0 +1,27 @@
+/**
+ * \file
+ * Allocator configuration procedure for mimalloc.
+ */
+
+#include "allocator_config.hpp"
+
+#include <mimalloc.h>
+
+namespace vg {
+
+using namespace std;
+
+void AllocatorConfig::configure() {
+    // mimalloc's default configuration is fine, so do nothing.
+}
+
+void AllocatorConfig::set_profiling(bool should_profile) {
+    // mimalloc doesn't have builton profiling, so do nothing.
+}
+
+void AllocatorConfig::snapshot() {
+    // mimalloc doesn't have builton profiling, so do nothing.
+}
+
+}
+ 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg can now be built with the [mimalloc allocator](https://github.com/microsoft/mimalloc) (v3 beta)

## Description

Since in #4645 it seems like part of the problem is bad behavior from jemalloc when overcommit is disabled by the kernel, and since jemalloc [has died](https://jasone.github.io/2025/06/12/jemalloc-postmortem/), this adds a new allocator option for vg of mimalloc.

You can `make -j15 mimalloc=on` and get a vg that is built with mimalloc as the allocator.

Unfortunately mimalloc can't do any of the fancy profiling jemalloc could do. Also, it hasn't yet been drag-raced against jemalloc or the system allocator in a real vg workload (rotation project???), so it's not used by default. But this should set us up for easily testing it.