### PR TITLE
vg paths helptext improvements

### DIFF
--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -337,6 +337,9 @@ int main_paths(int argc, char** argv) {
             path_senses.insert(PathSense::GENERIC);
         }
     } else {
+        if (!gbwt_file.empty()) {
+            std::cerr << "warning: [vg paths] path sense selection is not done by GBWT" << std::endl;
+        }
         // We asked for path senses specifically
         selection_criteria++;
     }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Added a warning that path selection options are not compatible with `vg paths -g`

## Description

Noticed some typos in the `vg paths` helptext (oops). Then noticed that my path sense selection wasn't working. Not sure it's possible on GBWTs so I just added a warning.