### PR TITLE
Add -w option to vg index to allow upweighting nodes in snarl finding

### DIFF
--- a/src/integrated_snarl_finder.hpp
+++ b/src/integrated_snarl_finder.hpp
@@ -45,6 +45,12 @@ private:
      * identified by a "head" handle.
      */
     class MergedAdjacencyGraph;
+
+    /**
+     * Stores extra weight to add to the effective length of graph nodes when
+     * rooting the snarl decomposition.
+     */
+    const std::unordered_map<nid_t, size_t> extra_node_weight;
     
     /**
      * Find all the snarls, given the Cactus graph, the bridge forest, the
@@ -59,12 +65,21 @@ private:
         unordered_map<handle_t, handle_t>& next_along_cycle,
         const function<void(handle_t)>& begin_chain, const function<void(handle_t)>& end_chain,
         const function<void(handle_t)>& begin_snarl, const function<void(handle_t)>& end_snarl) const;
-    
+
 public:
     /**
      * Make a new IntegratedSnarlFinder to find snarls in the given graph.
+     *
+     * Can optionally take a mapping of extra weight to assign to particular
+     * graph nodes, to control how the snarl tree is rooted. The snarl tree is
+     * rooted along the bridge edge path or cycle with the most fixes bases, so
+     * up-weighting nodes makes the rooting process prefer paths or cycles that
+     * include those nodes as fixed nodes, for rooting the snarl tree and
+     * defining top-level chains.
+     *
+     * The mapping is assumed to be small and cheap to copy.
      */
-    IntegratedSnarlFinder(const HandleGraph& graph);
+    IntegratedSnarlFinder(const HandleGraph& graph, const std::unordered_map<nid_t, size_t>& extra_node_weight = {});
     
     /**
      * Find all the snarls of weakly connected components in parallel.

--- a/src/primer_filter.hpp
+++ b/src/primer_filter.hpp
@@ -78,8 +78,6 @@ private:
 
 
 public:
-    PrimerFinder() = default;
-    
     /**
      * Construct Primer finder given PathPositionHandleGraph, reference graph name
      * and pointer to SnarlDistanceIndex

--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -67,7 +67,9 @@ void help_index(char** argv) {
          << "  -j, --dist-name FILE      use this file to store a snarl-based distance index" << endl
          << "      --snarl-limit N       don't store distances for snarls > N nodes [10000]" << endl
          << "                            if 0 then don't store distances, only the snarl tree" << endl
-         << "      --no-nested-distance  only store distances along the top-level chain" << endl;
+         << "      --no-nested-distance  only store distances along the top-level chain" << endl
+         << "  -w, --upweight-node N     upweight the node with ID N to push it to be part" << endl
+         << "                            of a top-level chain (may repeat)" << endl;
 }
 
 int main_index(int argc, char** argv) {
@@ -111,8 +113,13 @@ int main_index(int argc, char** argv) {
 
     //Distance index
     size_t snarl_limit = 50000;
-
     bool only_top_level_chain_distances = false;
+    std::unordered_map<nid_t, size_t> extra_node_weight;
+    // We will put this amount of extra weight on upweighted nodes. It should
+    // be longer than the maximum plausible distracting path or spurious bridge
+    // edge cycle, but small enough that several of it fit in a size_t.
+    // TODO: Expose to command line.
+    constexpr size_t EXTRA_WEIGHT = 10000000000;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -167,11 +174,12 @@ int main_index(int argc, char** argv) {
             {"snarl-limit", required_argument, 0, OPT_DISTANCE_SNARL_LIMIT},
             {"dist-name", required_argument, 0, 'j'},
             {"no-nested-distance", no_argument, 0, OPT_DISTANCE_NESTING},
+            {"upweight-node", no_argument, 0, 'w'},
             {0, 0, 0, 0}
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "b:t:px:Lv:WTM:F:G:zPoB:u:n:R:r:I:E:g:i:f:k:X:Z:Vlj:h?",
+        c = getopt_long (argc, argv, "b:t:px:Lv:WTM:F:G:zPoB:u:n:R:r:I:E:g:i:f:k:X:Z:Vlj:w:h?",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -265,9 +273,13 @@ int main_index(int argc, char** argv) {
         case OPT_DISTANCE_SNARL_LIMIT:
             snarl_limit = parse<int>(optarg);
             break;
-
         case OPT_DISTANCE_NESTING:
             only_top_level_chain_distances = true;
+            break;
+        case 'w':
+            // We use += so you can repeat a node and make it even more
+            // heavier.
+            extra_node_weight[parse<nid_t>(optarg)] += EXTRA_WEIGHT;
             break;
 
         case 'h':
@@ -315,6 +327,11 @@ int main_index(int argc, char** argv) {
     
     if (build_gcsa && kmer_size > gcsa::Key::MAX_LENGTH) {
         cerr << "error: [vg index] GCSA2 cannot index with kmer size greater than " << gcsa::Key::MAX_LENGTH << endl;
+        return 1;
+    }
+
+    if (!build_dist && !extra_node_weight.empty()) {
+        cerr << "error: [vg index] cannot up-weight nodes for snarl finding if not building distance index" << endl;
         return 1;
     }
     
@@ -542,7 +559,7 @@ int main_index(int argc, char** argv) {
                 
                 auto xg = vg::io::VPKG::load_one<xg::XG>(xg_name);
 
-                IntegratedSnarlFinder snarl_finder(*xg.get());
+                IntegratedSnarlFinder snarl_finder(*xg.get(), extra_node_weight);
                 // Create the SnarlDistanceIndex
                 SnarlDistanceIndex distance_index;
 
@@ -559,7 +576,7 @@ int main_index(int argc, char** argv) {
                     auto& gbz = get<0>(options);
                     
                     // Create the SnarlDistanceIndex
-                    IntegratedSnarlFinder snarl_finder(gbz->graph);
+                    IntegratedSnarlFinder snarl_finder(gbz->graph, extra_node_weight);
 
                     //Make a distance index and fill it in
                     SnarlDistanceIndex distance_index;
@@ -571,7 +588,7 @@ int main_index(int argc, char** argv) {
                     auto& graph = get<1>(options);
                     
                     // Create the SnarlDistanceIndex
-                    IntegratedSnarlFinder snarl_finder(*graph.get());
+                    IntegratedSnarlFinder snarl_finder(*graph.get(), extra_node_weight);
 
                     //Make a distance index and fill it in
                     SnarlDistanceIndex distance_index;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg index` now accepts a `-w` option to up-weight nodes to push the top-level chain through them when finding snarls

## Description

This gives you some control over snarl finding by letting you up-weight nodes during distance indexing. You can pass `-w` to `vg index -j` with a node ID and it will imagine it to be 10 billion bases longer than it actually is, which *should* force the top-level chain through it. You can repeat the option if you have multiple nodes you think should be on the top-level chain path (such as two known tip nodes you want at either end of the chain). If it somehow isn't working (maybe you have a *really* long genome), you can use it on the same node multiple times.

In the future we can make the weight amount configurable. Genuinely scripting the order of the snarl decomposition rooting process, rather than just up-weighting nodes, would require a lot more refactoring, so I didn't do it.
