### PR TITLE
Fix lookup of partial regions of subpaths

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -2610,7 +2610,16 @@ bool for_each_overlapping_subpath(const PathPositionHandleGraph& graph, Region& 
         last_path = candidate;
         
         if (iteratee_active) {
-            if ((region.start == -1 || candidate_subrange.second > region.start) && (region.end == -1 || candidate_subrange.first < region.end + 1)) {
+            size_t region_offset = 0;
+            if (graph.get_path_name(candidate) == region.seq && candidate_subrange.first > 0) {
+                // We found a path that exactly matches the region asked for, and it doesn't start at 0.
+                // The region's start and end need to be interpreted relative to the start of this path, not relative to the base path.
+                region_offset = candidate_subrange.first;
+#ifdef debug
+                std::cerr << "Subpath is what region is on" << std::endl;
+#endif
+            }
+            if ((region.start == -1 || candidate_subrange.second > region.start + region_offset) && (region.end == -1 || candidate_subrange.first < region.end + region_offset + 1)) {
                 // The subranges are 0-based exclusive and the regions are 0-based inclusive.
                 // This subrange intersects this region.
 #ifdef debug
@@ -2619,9 +2628,9 @@ bool for_each_overlapping_subpath(const PathPositionHandleGraph& graph, Region& 
                 
                 // If the region has a start other than -1 and starts after the subpath does, cut into the subpath on the left.
                 // We need the explicit comparison against -1 because we can't usefully compare a signed -1 to an unsigned number.
-                size_t intersection_start = (region.start != -1 && region.start > candidate_subrange.first) ? (region.start - candidate_subrange.first) : 0;
+                size_t intersection_start = (region.start != -1 && region.start + region_offset > candidate_subrange.first) ? (region.start + region_offset - candidate_subrange.first) : 0;
                 // If the region ends somewhere other than -1 and ends before the subpath does, cut into the subpath on the right.
-                size_t intersection_end = (region.end != -1 && region.end + 1 < candidate_subrange.second) ? region.end + 1 - candidate_subrange.first : candidate_subrange.second - candidate_subrange.first;
+                size_t intersection_end = (region.end != -1 && region.end + region_offset + 1 < candidate_subrange.second) ? region.end + region_offset + 1 - candidate_subrange.first : candidate_subrange.second - candidate_subrange.first;
                 
                 // Show the iteratee the intersecting part.
                 iteratee_active = iteratee(candidate, intersection_start, intersection_end);

--- a/src/unittest/path.cpp
+++ b/src/unittest/path.cpp
@@ -351,6 +351,22 @@ TEST_CASE("find_containing_subpath() works", "[path]") {
             REQUIRE(path == ref_ph3);
         }
 
+        SECTION("It finds a subpath when asked explicitly for part of a subpath") {
+            Region target_region {"GRCh38#0#chr1[4-7]", 0, 1};
+            bool result = find_containing_subpath(ref_graph, target_region, path);
+
+            REQUIRE(result == true);
+            REQUIRE(path == ref_ph3);
+        }
+
+        SECTION("It doesn't finds a subpath when asked explicitly for part of a subpath that goes off its end") {
+            // Because the region is 0-based, end-inclusive, this asks for a 2-base part of a 1-base subpath
+            Region target_region {"GRCh38#0#chr1[3-4]", 0, 1};
+            bool result = find_containing_subpath(ref_graph, target_region, path);
+
+            REQUIRE(result == false);
+        }
+
     }
 }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Lookup of regions within paths that are themselves subpaths (like `Stella_v1p1#0#Chr4__Stella_v1p1[11578420-11580540]:0-100`) should now work again.

## Description
This should fix https://github.com/vgteam/sequenceTubeMap/issues/486 by fixing the finding of intersections between subpaths and regions of themselves. That was apparently the one case for `find_containing_subpath()` that I didn't test.
