### PR TITLE
add "nodes" field to vg filter

### DIFF
--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -1581,6 +1581,10 @@ inline void ReadFilter<Alignment>::emit_tsv(Alignment& read, std::ostream& out) 
                 mapping_cigar(mapping, cigar, 'X');
             }
             out << cigar_string(cigar);
+        } else if (field == "nodes") {
+            for (const auto& mapping : read.path().mapping()) {
+                out << mapping.position().node_id() << (mapping.position().is_reverse() ? "-" : "+") << ",";
+            }
         } else if (field == "time_used") {
             out << read.time_used();
         } else if (field == "annotation") {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add `nodes` as a `vg filter --tsv-out` field option; prints a comma-separated list of nodes traversed by the read's path

## Description

This exposes something that's already in the GAM which might be useful to Julian Menendez.
