### PR TITLE
add --invert-keep-paths option to vg mod

### DIFF
--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -3343,11 +3343,11 @@ void VG::remove_orphan_edges(void) {
     }
 }
 
-void VG::keep_paths(const set<string>& path_names, set<string>& kept_names) {
+void VG::keep_paths(const set<string>& path_names, set<string>& kept_names, bool invert) {
 
     set<nid_t> to_keep;
     paths.for_each([&](const Path& path) {
-            if (path_names.count(path.name())) {
+            if (path_names.count(path.name()) != invert) {
                 kept_names.insert(path.name());
                 for (int i = 0; i < path.mapping_size(); ++i) {
                     to_keep.insert(path.mapping(i).position().node_id());
@@ -3370,7 +3370,7 @@ void VG::keep_paths(const set<string>& path_names, set<string>& kept_names) {
     remove_orphan_edges();
 
     // Throw out all the paths data for paths we don't want to keep.
-    paths.keep_paths(path_names);
+    paths.keep_paths(kept_names);
 }
 
 void VG::keep_path(const string& path_name) {

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -859,7 +859,8 @@ public:
 
     /// Keep paths in the given set of path names. Populates kept_names with the names of the paths it actually found to keep.
     /// The paths specified may not overlap. Removes all nodes and edges not used by one of the specified paths.
-    void keep_paths(const set<string>& path_names, set<string>& kept_names);
+    /// If invert is true, instead keeps all paths *not* in the given set of path names.
+    void keep_paths(const set<string>& path_names, set<string>& kept_names, bool invert = false);
     void keep_path(const string& path_name);
 
     /// Path stats.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg mod` now has an `--invert-keep-paths` option to save the complement of path names passed to `--keep-paths`

## Description

Another "I wanted it so I tweaked a thing" feature. I have a graph with over a hundred paths and I wanted to remove a single one. Technically I could've generated the >100 `--keep-path` options and tacked them all on, but this way is easier.