### PR TITLE
Use htslib tag accessors as much as possible to avoid BAM surgery in tag stringification

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1657,108 +1657,87 @@ int32_t sam_flag(const Alignment& alignment, bool on_reverse_strand, bool paired
     return flag;
 }
 
-template<typename T>
-string aux_array_to_string(const uint8_t*& aux_arr, int32_t arr_len) {
-    
-    const T* t_arr = (const T*) aux_arr;
-    
-    stringstream strm;
-    strm << setprecision(8); // lossless for 32-bit float
-    for (int32_t i = 0; i < arr_len; ++i) {
-        strm << ',' << t_arr[i];
-    }
-    aux_arr = (const uint8_t*) (t_arr + arr_len);
-    return strm.str();
-}
-
-template<typename T>
-string aux_val_to_string(const uint8_t*& aux_arr) {
-    string str = to_string(*(const T*) aux_arr);
-    aux_arr += sizeof(T);
-    return str;
-}
-
 vector<string> bam_tag_strings(const bam1_t* b) {
     vector<string> tag_strings;
-    const uint8_t* aux = bam_get_aux(b);
-    const uint8_t* end = b->data + b->l_data;
-    while (aux != end) {
+    
+    for (uint8_t* aux = bam_aux_first(b); aux != NULL; aux = bam_aux_next(b, aux)) {
+        // For each aux field (i.e. tag)
         tag_strings.emplace_back();
         auto& tag_string = tag_strings.back();
         tag_string.reserve(6);
-        tag_string.push_back(aux[0]);
-        tag_string.push_back(aux[1]);
+        // We know that this returns a pointer to 2 characters in a row, with
+        // no null terminator.
+        // TODO: Work out how to get a const char tag[2] here even though you
+        // can't assign or initialize an array from a pointer. For now we just
+        // have to remember that this is 2 items and no more or less.
+        const char* tag = bam_aux_tag(aux);
+        char type = bam_aux_type(aux);
+        tag_string.push_back(tag[0]);
+        tag_string.push_back(tag[1]);
         tag_string.push_back(':');
-        tag_string.push_back(aux[2]);
+        tag_string.push_back(type);
         tag_string.push_back(':');
-        char type = aux[2];
-        aux += 3;
         switch (type) {
             case 'A':
-                tag_string.append(aux_val_to_string<char>(aux));
+                // Handle single characters
+                tag_string.append(std::string(1, bam_aux2A(aux)));
                 break;
             case 'c':
-                tag_string.append(aux_val_to_string<int8_t>(aux));
-                break;
             case 'C':
-                tag_string.append(aux_val_to_string<uint8_t>(aux));
-                break;
             case 's':
-                tag_string.append(aux_val_to_string<int16_t>(aux));
-                break;
             case 'S':
-                tag_string.append(aux_val_to_string<uint16_t>(aux));
-                break;
             case 'i':
-                tag_string.append(aux_val_to_string<int32_t>(aux));
-                break;
             case 'I':
-                tag_string.append(aux_val_to_string<uint32_t>(aux));
+                // Handle any integral number (with fall-through)
+                tag_string.append(std::to_string(bam_aux2i(aux)));
                 break;
             case 'f':
-                tag_string.append(aux_val_to_string<float>(aux));
+                // Handle a float
+                tag_string.append(std::to_string(bam_aux2f(aux)));
                 break;
             case 'H':
             case 'Z':
-                tag_string.append((const char*) aux);
-                aux += strlen((const char*) aux) + 1;
+                // Handle string data (with fall-through)
+                tag_string.append(bam_aux2Z(aux));
                 break;
             case 'B':
             {
-                char arr_type = *aux;
-                int32_t arr_len = bam_auxB_len(aux);
-                aux += 5;
+                // Handle arrays, which can actually only be of integral or float types.
+                uint32_t arr_len = bam_auxB_len(aux);
+                // Get the type of the items *in* the array. There's no
+                // dedicated accessor to do this, but the htslib example code
+                // does it this way. See
+                // <https://github.com/samtools/htslib/blob/d677f345fe35d451587319ca38ac611862a46e1b/samples/read_aux.c#L91>
+                char arr_type = bam_aux_type(aux + 1);
+                stringstream strm;
                 switch (arr_type) {
                     case 'c':
-                        tag_string.append(aux_array_to_string<int8_t>(aux, arr_len));
-                        break;
                     case 'C':
-                        tag_string.append(aux_array_to_string<uint8_t>(aux, arr_len));
-                        break;
                     case 's':
-                        tag_string.append(aux_array_to_string<int16_t>(aux, arr_len));
-                        break;
                     case 'S':
-                        tag_string.append(aux_array_to_string<uint16_t>(aux, arr_len));
-                        break;
                     case 'i':
-                        tag_string.append(aux_array_to_string<int32_t>(aux, arr_len));
-                        break;
                     case 'I':
-                        tag_string.append(aux_array_to_string<uint32_t>(aux, arr_len));
+                        for (uint32_t i = 0; i < arr_len; i++) {
+                            strm << "," << bam_auxB2i(aux, i);
+                        }
+                        tag_string.append(strm.str());
                         break;
                     case 'f':
-                        tag_string.append(aux_array_to_string<float>(aux, arr_len));
+                        strm << setprecision(8); // lossless for 32-bit float
+                        for (uint32_t i = 0; i < arr_len; i++) {
+                            strm << "," << bam_auxB2f(aux, i);
+                        }
+                        tag_string.append(strm.str());
                         break;
                     default:
-                        cerr << "error: unrecognized array type " << arr_type << " for 'B' type SAM tag" << endl;
+                        cerr << "error: invalid BAM array type '" << arr_type << "' (" << (int)arr_type << ") for 'B' type tag '" << tag[0] << tag[1] << "'" << endl;
                         exit(1);
                         break;
                 }
                 break;
             }
             default:
-                cerr << "error: invalid BAM tag " << type << '\n';
+                cerr << "error: invalid BAM tag type '" << type << "' (" << (int)type << ") for tag '" << tag[0] << tag[1] << "'" << endl;
                 exit(1);
                 break;
         }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * BAM tags are now manipulated using HTSlib accessor functions and not by wandering through the BAM record's memory

## Description

It was reported that `vg inject` could sometimes crash with an `error: invalid BAM tag` message. That message is *supposed* to include the type character for the supposedly-invalid BAM tag. It seems it was trying to complain about a BAM tag with a non-printable-character type, which moreover wasn't actually in the provided reproduction BAM file.

I noticed that the code that processes BAM tags and could try to print that message was handling the tags by scanning over a memory range inside HTSlib's BAM record type and processing the tag data byte by byte. That's not actually how HTSlib wants you to do it; their [example code](https://github.com/samtools/htslib/blob/d677f345fe35d451587319ca38ac611862a46e1b/samples/read_aux.c#L91) uses [a bunch of `bam_aux*` functions](https://github.com/samtools/htslib/blob/d677f345fe35d451587319ca38ac611862a46e1b/htslib/sam.h#L1637-L1770) and only has to dip down into pointer math for grabbing the interior types of arrays.

So I reimplemented the relevant vg code using the actual accessors instead of byte-wise manual traversal of htslib's memory, and the problem seems to have gone away. I've also improved the invalid-type messages so they should blame a particular BAM tag name and to make it more obvious if they are reporting garbage where printable characters are expected.