### PR TITLE
Set HiFi max min chain score to 100

### DIFF
--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1467,6 +1467,8 @@ int main_giraffe(int argc, char** argv) {
                         exit(1);
                     } else {
                         // Apply the preset values.
+                        // Order of processing doesn't matter; preset values
+                        // sit under any actually-parsed values.
                         found->second.apply(*parser);
                     }
                 }

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1005,7 +1005,7 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<int>("min-chains", 2)
         .add_entry<double>("min-chain-score-per-base", 0.1)
         .add_entry<size_t>("max-chains-per-tree", 3)
-        .add_entry<int>("max-min-chain-score", 1100)
+        .add_entry<int>("max-min-chain-score", 100)
         .add_entry<size_t>("max-skipped-bases", 1000)
         .add_entry<size_t>("max-alignments", 3)
         .add_entry<size_t>("max-chain-connection", 233)


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe -b hifi` preset now uses a `--max-min-chain-score` of 100

## Description
This adopts a parameter change to the default `hifi` preset mapping parameters for Giraffe that, in our testing, seems to dramatically reduce unmapped reads, while making it somewhat slower and very slightly worse at SNP calling in the high-confidence regions we evaluate.