### PR TITLE
Utility functions for option parsing, validity checks, and pretty printing errors/warnings

### DIFF
--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -142,6 +142,8 @@ ANNOTATE_EXCEPTIONS = {'xg-name', 'bed-name'}
 """annotate_main.cpp lets these appear twice in helptext."""
 NON_WORK_WORDS = {'exit', 'return', 'deprecated', 'abort', 'throw'}
 """Keywords that indicate something is meant to not work in the switch block."""
+FILENAME_VAR_ENDS = {'file', 'filename', 'file_name', 'filepath', 'file_path'}
+"""Suffixes that indicate a variable is definitely a filename"""
 
 @dataclass
 class OptionInfo:
@@ -672,13 +674,13 @@ def extract_switch_optarg(text: str) -> Dict[str, OptionInfo]:
 
         # This won't catch all file variables (e.g. if called `xg_name`),
         # but it'll catch some at least
-        if ('file = optarg;' in stripped 
-            or 'filename = optarg;' in stripped
-            or 'file_name = optarg;' in stripped):
-            # Extra check for file-existance functions
-            extra_errors.append("Use error_if_file_does_not_exist() or "
-                                "error_if_file_cannot_be_written() for "
-                                "standardized file checks: " + stripped)
+        for suffix in FILENAME_VAR_ENDS:
+            if f'{suffix} = optarg;' in stripped:
+                # Extra check for file-existance functions
+                extra_errors.append("Use error_if_file_does_not_exist() or "
+                                    "error_if_file_cannot_be_written() for "
+                                    "standardized file checks: " + stripped)
+                break
 
         # Detect new case
         case_match = re.match(r'case\s+(.+)\s*:', stripped)

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -667,11 +667,6 @@ def extract_switch_optarg(text: str) -> Dict[str, OptionInfo]:
             extra_errors.append("Parse thread count using parse_thread_count() "
                                 "for standardized error messages")
     
-        if '"error' in stripped or '"warning' in stripped:
-            # Extra check for error/warning messages
-            extra_errors.append("Use error_and_exit() or emit_warning() "
-                                "for standardized error messages: " + stripped)
-
         # This won't catch all file variables (e.g. if called `xg_name`),
         # but it'll catch some at least
         for suffix in FILENAME_VAR_ENDS:

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -127,7 +127,7 @@ Some GitHub Copilot autocompletions were used.
 import os
 import re
 import sys
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 from dataclasses import dataclass
 
 SUBCOMMAND_DIR = 'src/subcommand'

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -672,7 +672,9 @@ def extract_switch_optarg(text: str) -> Dict[str, OptionInfo]:
 
         # This won't catch all file variables (e.g. if called `xg_name`),
         # but it'll catch some at least
-        if 'file = optarg;' in stripped or 'filename = optarg;' in stripped:
+        if ('file = optarg;' in stripped 
+            or 'filename = optarg;' in stripped
+            or 'file_name = optarg;' in stripped):
             # Extra check for file-existance functions
             extra_errors.append("Use error_if_file_does_not_exist() or "
                                 "error_if_file_cannot_be_written() for "

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -659,6 +659,11 @@ def extract_switch_optarg(text: str) -> Tuple[Dict[str, Optional[bool]],
             # Extra check for thread count options
             extra_errors.append("Parse thread count using parse_thread_count() "
                                 "for standardized error messages")
+    
+        if '"error' in stripped or '"warning' in stripped:
+            # Extra check for error/warning messages
+            extra_errors.append("Use error_and_exit() or emit_warning() "
+                                "for standardized error messages: " + stripped)
 
         # Detect new case
         case_match = re.match(r'case\s+(.+)\s*:', stripped)

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -672,7 +672,7 @@ def extract_switch_optarg(text: str) -> Dict[str, OptionInfo]:
 
         # This won't catch all file variables (e.g. if called `xg_name`),
         # but it'll catch some at least
-        if 'file = optarg;' in stripped:
+        if 'file = optarg;' in stripped or 'filename = optarg;' in stripped:
             # Extra check for file-existance functions
             extra_errors.append("Use error_if_file_does_not_exist() or "
                                 "error_if_file_cannot_be_written() for "

--- a/scripts/check_options.py
+++ b/scripts/check_options.py
@@ -665,6 +665,14 @@ def extract_switch_optarg(text: str) -> Tuple[Dict[str, Optional[bool]],
             extra_errors.append("Use error_and_exit() or emit_warning() "
                                 "for standardized error messages: " + stripped)
 
+        # This won't catch all file variables (e.g. if called `xg_name`),
+        # but it'll catch some at least
+        if 'file = optarg;' in stripped:
+            # Extra check for file-existance functions
+            extra_errors.append("Use error_if_file_does_not_exist() or "
+                                "error_if_file_cannot_be_written() for "
+                                "standardized file checks: " + stripped)
+
         # Detect new case
         case_match = re.match(r'case\s+(.+)\s*:', stripped)
         if case_match or stripped == 'default:':

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -87,6 +87,7 @@ static string to_string(const vg::IndexGroup& name) {
 
 namespace vg {
 
+const string context = "[IndexRegistry]";
 
 IndexingParameters::MutableGraphImplementation IndexingParameters::mut_graph_impl = PackedGraph;
 int IndexingParameters::max_node_size = 32;
@@ -5630,6 +5631,7 @@ void IndexFile::provide(const vector<string>& filenames) {
     // append all filenames
     // TODO: would it be better to sometimes error check that the file isn't a duplicate?
     for (const string& filename : filenames) {
+        error_if_file_does_not_exist(context, filename);
         this->filenames.emplace_back(filename);
     }
     provided_directly = true;

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -4573,11 +4573,15 @@ void IndexRegistry::provide(const IndexName& identifier, const string& filename)
 
 void IndexRegistry::provide(const IndexName& identifier, const vector<string>& filenames) {
     if (IndexingParameters::verbosity >= IndexingParameters::Debug) {
-        cerr << "[IndexRegistry]: Provided: " << identifier << endl;
+        cerr << context << ": Provided: " << identifier << endl;
     }
     if (!index_registry.count(identifier)) {
-        cerr << "error:[IndexRegistry] cannot provide unregistered index: " << identifier << endl;
-        exit(1);
+        error_and_exit(context, "cannot provide unregistered index: " + identifier);
+    }
+    if (this->check_files) {
+        for (const string& filename : filenames) {
+            error_if_file_does_not_exist(context, filename);
+        }
     }
     get_index(identifier)->provide(filenames);
 }
@@ -5631,7 +5635,6 @@ void IndexFile::provide(const vector<string>& filenames) {
     // append all filenames
     // TODO: would it be better to sometimes error check that the file isn't a duplicate?
     for (const string& filename : filenames) {
-        error_if_file_does_not_exist(context, filename);
         this->filenames.emplace_back(filename);
     }
     provided_directly = true;

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -211,6 +211,10 @@ public:
     // get_index, so it has to be a friend.
     friend class IndexingPlan;
 
+    // Whether files given to provide() should be checked for existence
+    // This should always be true except in unit tests
+    bool check_files = true;
+
     /// Constructor
     IndexRegistry() = default;
     

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -25,6 +25,9 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg call]";
+const string DEFAULT_SAMPLE_NAME = "SAMPLE";
+
 void help_call(char** argv) {
     cerr << "usage: " << argv[0] << " call [options] <graph> > output.vcf" << endl
          << "Call variants or genotype known variants" << endl
@@ -58,7 +61,7 @@ void help_call(char** argv) {
          << "  -f, --ref-fasta FILE      reference FASTA" << endl
          << "                            (required if VCF has symbolic deletions/inversions)" << endl
          << "  -i, --ins-fasta FILE      insertions (required if VCF has symbolic insertions)" << endl
-         << "  -s, --sample NAME         sample name [SAMPLE]" << endl
+         << "  -s, --sample NAME         sample name [" << DEFAULT_SAMPLE_NAME << "]" << endl
          << "  -r, --snarls FILE         snarls (from vg snarls) to avoid recomputing." << endl
          << "  -g, --gbwt FILE           only call genotypes present in given GBWT index" << endl
          << "  -z, --gbz                 only call genotypes present in GBZ index" << endl
@@ -89,7 +92,7 @@ int main_call(int argc, char** argv) {
 
     string pack_filename;
     string vcf_filename;
-    string sample_name = "SAMPLE";
+    string sample_name = DEFAULT_SAMPLE_NAME;
     string snarl_filename;
     string gbwt_filename;
     bool   gbz_paths = false;
@@ -189,7 +192,7 @@ int main_call(int argc, char** argv) {
         switch (c)
         {
         case 'k':
-            pack_filename = optarg;
+            pack_filename = error_if_file_does_not_exist(context, optarg);
             break;
         case 'B':
             ratio_caller = true;
@@ -204,7 +207,7 @@ int main_call(int argc, char** argv) {
             baseline_error_string = optarg;
             break;            
         case 'v':
-            vcf_filename = optarg;
+            vcf_filename = error_if_file_does_not_exist(context, optarg);
             break;
         case 'a':
             genotype_snarls = true;
@@ -219,25 +222,25 @@ int main_call(int argc, char** argv) {
             max_allele_len = parse<size_t>(optarg);
             break;
         case 'f':
-            ref_fasta_filename = optarg;
+            ref_fasta_filename = error_if_file_does_not_exist(context, optarg);
             break;
         case 'i':
-            ins_fasta_filename = optarg;
+            ins_fasta_filename = error_if_file_does_not_exist(context, optarg);
             break;
         case 's':
             sample_name = optarg;
             break;
         case 'r':
-            snarl_filename = optarg;
+            snarl_filename = error_if_file_does_not_exist(context, optarg);
             break;
         case 'g':
-            gbwt_filename = optarg;
+            gbwt_filename = error_if_file_does_not_exist(context, optarg);
             break;
         case 'z':
             gbz_paths = true;
             break;
         case 'N':
-            translation_file_name = optarg;
+            translation_file_name = error_if_file_does_not_exist(context, optarg);
             break;
         case 'O':
             gbz_translation = true;
@@ -262,8 +265,7 @@ int main_call(int argc, char** argv) {
                 // For each comma-separated rule
                 auto parts = split_delims(rule, ":");
                 if (parts.size() != 2) {
-                    cerr << "error: ploidy rules must be REGEX:PLOIDY" << endl;
-                    exit(1);
+                    error_and_exit(context, "ploidy rules must be REGEX:PLOIDY");
                 }
                 try {
                     // Parse the regex
@@ -273,8 +275,7 @@ int main_call(int argc, char** argv) {
                     ploidy_rules.emplace_back(match, weight);
                 } catch (const std::regex_error& e) {
                     // This is not a good regex
-                    cerr << "error: unacceptable regular expression \"" << parts[0] << "\": " << e.what() << endl;
-                    exit(1);
+                    error_and_exit(context, "unacceptable regular expression \"" + parts[0] + "\": " + e.what());
                 }
             }
             break;            
@@ -301,16 +302,8 @@ int main_call(int argc, char** argv) {
             show_progress = true;
             break;
         case 't':
-        {
-            int num_threads = parse<int>(optarg);
-            if (num_threads <= 0) {
-                cerr << "error:[vg call] Thread count (-t) set to " << num_threads 
-                     << ", must set to a positive integer." << endl;
-                exit(1);
-            }
-            omp_set_num_threads(num_threads);
+            omp_set_num_threads(parse_thread_count(context, optarg));
             break;
-        }
         case 'h':
         case '?':
             /* getopt_long already printed an error message. */
@@ -338,8 +331,7 @@ int main_call(int argc, char** argv) {
     if (support_toks.size() == 2) {
         min_site_support = parse<double>(support_toks[1]);
     } else if (support_toks.size() > 2) {
-        cerr << "error [vg call]: -m option expects at most two comma separated numbers M,N" << endl;
-        return 1;
+        error_and_exit(context, "-m option expects at most two comma separated numbers M,N");
     }
     // parse the biases
     vector<string> bias_toks = split_delims(bias_string, ",");
@@ -352,8 +344,7 @@ int main_call(int argc, char** argv) {
     if (bias_toks.size() == 2) {
         ref_het_bias = parse<double>(bias_toks[1]);
     } else if (bias_toks.size() > 2) {
-        cerr << "error [vg call]: -b option expects at most two comma separated numbers M,N" << endl;
-        return 1;
+        error_and_exit(context, "-b option expects at most two comma separated numbers M,N");
     }
     // parse the baseline errors (defaults are in snarl_caller.hpp)
     vector<string> error_toks = split_delims(baseline_error_string, ",");
@@ -363,32 +354,27 @@ int main_call(int argc, char** argv) {
         baseline_error_small = parse<double>(error_toks[0]);
         baseline_error_large = parse<double>(error_toks[1]);
         if (baseline_error_small > baseline_error_large) {
-            cerr << "warning [vg call]: with baseline error -e X,Y option, "
-                 << "small variant error (X) normally less than large (Y)" << endl;
+            emit_warning(context, "with baseline error -e X,Y option, "
+                                  "small variant error (X) normally less than large (Y)");
         }
     } else if (error_toks.size() != 0) {
-        cerr << "error [vg call]: -e option expects exactly two comma-separated numbers X,Y" << endl;
-        return 1;
+        error_and_exit(context, "-e option expects exactly two comma-separated numbers X,Y");
     }
 
     if (trav_padding > 0 && traversals_only == false) {
-        cerr << "error [vg call]: -M option can only be used in conjunction with -T" << endl;
-        return 1;
+        error_and_exit(context, "-M option can only be used in conjunction with -T");
     }
 
     if (!vcf_filename.empty() && genotype_snarls) {
-        cerr << "error [vg call]: -v and -a options cannot be used together" << endl;
-        return 1;
+        error_and_exit(context, "-v and -a options cannot be used together");
     }
 
     if ((min_allele_len > 0 || max_allele_len < numeric_limits<size_t>::max())
         && (legacy || !vcf_filename.empty() || nested)) {
-        cerr << "error [vg call]: -c/-C no supported with -v, -l or -n" << endl;
-        return 1;        
+        error_and_exit(context, "-c/-C no supported with -v, -l or -n");
     }
     if (!ref_paths.empty() && !ref_sample.empty()) {
-        cerr << "error [vg call]: -S cannot be used with -p" << endl;
-        return 1;
+        error_and_exit(context, "-S cannot be used with -p");
     }
 
     // Read the graph
@@ -397,34 +383,31 @@ int main_call(int argc, char** argv) {
     gbwt::GBWT* gbwt_index = nullptr;
     PathHandleGraph* graph = nullptr;
     string graph_filename = get_input_file_name(optind, argc, argv);
-    if (show_progress) cerr << "[vg call]: Loading graph " << graph_filename << endl;
+    if (show_progress) cerr << context << ": Loading graph " << graph_filename << endl;
     auto input = vg::io::VPKG::try_load_first<GBZGraph, PathHandleGraph>(graph_filename);
-    if (show_progress) cerr << "[vg call]: Loaded graph" << endl;
+    if (show_progress) cerr << context << ": Loaded graph" << endl;
     if (get<0>(input)) {        
         gbz_graph = std::move(get<0>(input));
         graph = gbz_graph.get();
-        if (show_progress) cerr << "[vg call]: GBZ input detected" << endl;
+        if (show_progress) cerr << context << ": GBZ input detected" << endl;
         if (gbz_paths) {
-            if (show_progress) cerr << "[vg call]: Restricting search to GBZ haplotypes" << endl;
+            if (show_progress) cerr << context << ": Restricting search to GBZ haplotypes" << endl;
             gbwt_index = &gbz_graph->gbz.index;
         } else {
-            cerr << "[vg call]: You can restrict the search to GBZ haplotypes, "
+            cerr << context << ": You can restrict the search to GBZ haplotypes, "
                  << "often to the benefict of speed and accuracy, with the -z option" << endl;
         }
     } else if (get<1>(input)) {
         path_handle_graph = std::move(get<1>(input));
         graph = path_handle_graph.get();
     } else {
-        cerr << "Error [vg call]: Input graph is not a GBZ or path handle graph" << endl;
-        return 1;
+        error_and_exit(context, "Input graph is not a GBZ or path handle graph");
     }
     if (gbz_paths && !gbz_graph) {
-        cerr << "Error [vg call]: -z can only be used when input graph is in GBZ format" << endl;
-        return 1;
+        error_and_exit(context, "-z can only be used when input graph is in GBZ format");
     }
     if (gbz_translation && !gbz_graph) {
-        cerr << "Error [vg call]: -O can only be used when input graph is in GBZ format" << endl;
-        return 1;
+        error_and_exit(context, "-O can only be used when input graph is in GBZ format");
     }
     
     // Read the translation
@@ -440,14 +423,10 @@ int main_call(int argc, char** argv) {
     }
     if (!translation_file_name.empty()) {
         if (!translation->empty()) {
-            cerr << "Warning [vg call]: Using translation from -N overrides that in input GBZ"
-                 << "(you probably don't want to use -N)" << endl;
+            emit_warning(context, "Using translation from -N overrides that in input GBZ "
+                                  "(you probably don't want to use -N)");
         }        
         ifstream translation_file(translation_file_name.c_str());
-        if (!translation_file) {
-            cerr << "Error [vg call]: Unable to load translation file: " << translation_file_name << endl;
-            return 1;
-        }
         translation = make_unique<unordered_map<nid_t, pair<string, size_t>>>();
         *translation = load_translation_back_map(*graph, translation_file);
     }    
@@ -458,7 +437,9 @@ int main_call(int argc, char** argv) {
     bdsg::ReferencePathOverlayHelper pp_overlay_helper;
     bdsg::ReferencePathVectorizableOverlayHelper ppv_overlay_helper;
     bdsg::PathVectorizableOverlayHelper pv_overlay_helper;
-    if (show_progress) cerr << "[vg call]: Applying overlays if necessary (ie input not in XG format)" << endl;
+    if (show_progress) {
+        cerr << context << ": Applying overlays if necessary (i.e. input not in XG format)" << endl;
+    }
     if (need_path_positions && need_vectorizable) {
         graph = dynamic_cast<PathHandleGraph*>(ppv_overlay_helper.apply(graph));
     } else if (need_path_positions && !need_vectorizable) {
@@ -466,51 +447,41 @@ int main_call(int argc, char** argv) {
     } else if (!need_path_positions && need_vectorizable) {
         graph = dynamic_cast<PathHandleGraph*>(pv_overlay_helper.apply(graph));
     }
-    if (show_progress) cerr << "[vg call]: Applied overlays" << endl;
+    if (show_progress) cerr << context << ": Applied overlays" << endl;
     
     // Check our offsets
     if (ref_path_offsets.size() != 0 && ref_path_offsets.size() != ref_paths.size()) {
-        cerr << "error [vg call]: when using -o, the same number paths must be given with -p" << endl;
-        return 1;
+        error_and_exit(context, "when using -o, the same number of paths must be given with -p");
     }
     if (!ref_path_offsets.empty() && !vcf_filename.empty()) {
-        cerr << "error [vg call]: -o cannot be used with -v" << endl;
-        return 1;
+        error_and_exit(context, "-o cannot be used with -v");
     }
     // Check our ref lengths
     if (ref_path_lengths.size() != 0 && ref_path_lengths.size() != ref_paths.size()) {
-        cerr << "error [vg call]: when using -l, the same number paths must be given with -p" << endl;
-        return 1;
+        error_and_exit(context, "when using -l, the same number of paths must be given with -p");
     }
     // Check bias option
     if (!bias_string.empty() && !ratio_caller) {
-        cerr << "error [vg call]: -b can only be used with -B" << endl;
-        return 1;
+        error_and_exit(context, "-b can only be used with -B");
     }
     // Check ploidy option
     if (ploidy < 1 || ploidy > 2) {
-        cerr << "error [vg call]: ploidy (-d) must be either 1 or 2" << endl;
-        return 1;
+        error_and_exit(context, "ploidy (-d) must be either 1 or 2");
     }
     if (ratio_caller == true && ploidy != 2) {
-        cerr << "error [vg call]: ploidy (-d) must be 2 when using ratio caller (-B)" << endl;
-        return 1;
+        error_and_exit(context, "ploidy (-d) must be 2 when using ratio caller (-B)");
     }
     if (legacy == true && ploidy != 2) {
-        cerr << "error [vg call]: ploidy (-d) must be 2 when using legacy caller (-L)" << endl;
-        return 1;
+        error_and_exit(context, "ploidy (-d) must be 2 when using legacy caller (-L)");
     }
     if (!vcf_filename.empty() && !gbwt_filename.empty()) {
-        cerr << "error [vg call]: gbwt (-g) cannot be used when genotyping VCF (-v)" << endl;
-        return 1;
+        error_and_exit(context, "gbwt (-g) cannot be used when genotyping VCF (-v)");
     }
     if (legacy == true && !gbwt_filename.empty()) {
-        cerr << "error [vg call]: gbwt (-g) cannot be used with legacy caller (-L)" << endl;
-        return 1;
+        error_and_exit(context, "gbwt (-g) cannot be used with legacy caller (-L)");
     }
     if (gbz_paths && !gbwt_filename.empty()) {
-        cerr << "error [vg call]: gbwt (-g) cannot be used with gbz graph (-z): choose one or the other" << endl;
-        return 1;
+        error_and_exit(context, "gbwt (-g) cannot be used with GBZ graph (-z): choose one or the other");
     }
 
     // in order to add subpath support, we let all ref_paths be subpaths and then convert coordinates
@@ -559,21 +530,22 @@ int main_call(int argc, char** argv) {
                 }
             });
         if (ref_sample_names.size() > 1 && ref_sample.empty()) {
-            cerr << "error [vg call]: Multiple reference samples detected: [";
+            stringstream ref_sample_ss;
             size_t count = 0;
             for (const string& n : ref_sample_names) {                
-                cerr << n;
+                ref_sample_ss << n;
                 if (++count >= std::min(ref_sample_names.size(), (size_t)5)) {
                     if (ref_sample_names.size() > 5) {
-                        cerr << ", ...";
+                        ref_sample_ss << ", ...";
                     }
                     break;
                 } else {
-                    cerr << ", ";
+                    ref_sample_ss << ", ";
                 }
             }
-            cerr << "]. Please use -S to specify a single reference sample or use -p to specify reference paths";
-            return 1;
+            error_and_exit(context, "Multiple reference samples detected: [" + ref_sample_ss.str()
+                                    + "]. Please use -S to specify a single reference sample "
+                                    + "or use -p to specify reference paths");
         }                
     } else {
         // if paths are given, we convert them to subpaths so that ref paths list corresponds
@@ -612,8 +584,7 @@ int main_call(int argc, char** argv) {
         // Check our paths
         for (const auto& ref_path_used : ref_path_set) {
             if (!ref_path_used.second) {
-                cerr << "error [vg call]: Reference path \"" << ref_path_used.first << "\" not found in graph" << endl;
-                return 1;
+                error_and_exit(context, "Reference path \"" + ref_path_used.first + "\" not found in graph");
             }
         }
         
@@ -623,12 +594,10 @@ int main_call(int argc, char** argv) {
     // make sure we have some ref paths
     if (ref_paths.empty()) {
         if (!ref_sample.empty()) {
-            cerr << "error [vg call]: No paths with selected reference sample \"" << ref_sample << "\" found. "
-                 << "Try using vg paths -M to see which samples are in your graph" << endl;
-            return 1;
+            error_and_exit(context, "No paths with selected reference sample \"" + ref_sample + "\" found." 
+                           "Try using vg paths -M to see which samples are in your graph");
         }
-        cerr << "error [vg call]: No reference paths found" << endl;
-        return 1;
+        error_and_exit(context, "No reference paths found");
     }
 
     // build table of ploidys
@@ -649,16 +618,15 @@ int main_call(int argc, char** argv) {
     if (!snarl_filename.empty()) {
         ifstream snarl_file(snarl_filename.c_str());
         if (!snarl_file) {
-            cerr << "Error [vg call]: Unable to load snarls file: " << snarl_filename << endl;
-            return 1;
+            error_and_exit(context, "Unable to open snarls file: " + snarl_filename);
         }
-        if (show_progress) cerr << "[vg call]: Loading snarls from " << snarl_filename << endl;
+        if (show_progress) cerr << context << ": Loading snarls from " << snarl_filename << endl;
         snarl_manager = vg::io::VPKG::load_one<SnarlManager>(snarl_file);
-        if (show_progress) cerr << "[vg call]: Loaded snarls" << endl;
+        if (show_progress) cerr << context << ": Loaded snarls" << endl;
     } else {
-        if (show_progress) cerr << "[vg call]: Computing snarls" << endl;
+        if (show_progress) cerr << context << ": Computing snarls" << endl;
         IntegratedSnarlFinder finder(*graph);
-        if (show_progress) cerr << "[vg call]: Computed snarls" << endl;
+        if (show_progress) cerr << context << ": Computed snarls" << endl;
         snarl_manager = unique_ptr<SnarlManager>(new SnarlManager(std::move(finder.find_snarls_parallel())));
     }
     
@@ -671,9 +639,9 @@ int main_call(int argc, char** argv) {
     if (!pack_filename.empty()) {        
         // Load our packed supports (they must have come from vg pack on graph)
         packer = unique_ptr<Packer>(new Packer(graph));
-        if (show_progress) cerr << "[vg call]: Loading pack file " << pack_filename << endl;
+        if (show_progress) cerr << context << ": Loading pack file " << pack_filename << endl;
         packer->load_from_file(pack_filename);
-        if (show_progress) cerr << "[vg call]: Loaded pack file" << endl;
+        if (show_progress) cerr << context << ": Loaded pack file" << endl;
         if (nested) {
             // Make a nested packed traversal support finder (using cached veresion important for poisson caller)
             support_finder.reset(new NestedCachedPackedTraversalSupportFinder(*packer, *snarl_manager));
@@ -695,10 +663,10 @@ int main_call(int argc, char** argv) {
 
         if (ratio_caller == false) {
             // Make a depth index
-            if (show_progress) cerr << "[vg call]: Computing coverage statistics" << endl;
+            if (show_progress) cerr << context << ": Computing coverage statistics" << endl;
             depth_index = algorithms::binned_packed_depth_index(*packer, ref_paths, min_depth_bin_width, max_depth_bin_width,
                                                                 depth_scale_fac, 0, true, true);
-            if (show_progress) cerr << "[vg call]: Computed coverage statistics" << endl;
+            if (show_progress) cerr << context << ": Computed coverage statistics" << endl;
             // Make a new-stype probablistic caller
             auto poisson_caller = new PoissonSupportSnarlCaller(*graph, *snarl_manager, *support_finder, depth_index,
                                                                 //todo: qualities need to be used better in conjunction with
@@ -726,8 +694,7 @@ int main_call(int argc, char** argv) {
     }
 
     if (!snarl_caller) {
-        cerr << "error [vg call]: pack file (-k) is required" << endl;
-        return 1;
+        error_and_exit(context, "pack file (-k) is required");
     }
 
     unique_ptr<AlignmentEmitter> alignment_emitter;
@@ -747,8 +714,7 @@ int main_call(int argc, char** argv) {
         variant_file.parseSamples = false;
         variant_file.open(vcf_filename);
         if (!variant_file.is_open()) {
-            cerr << "error: [vg call] could not open " << vcf_filename << endl;
-            return 1;
+            error_and_exit(context, "could not open " + vcf_filename);
         }
 
         // load up the fasta
@@ -787,8 +753,7 @@ int main_call(int argc, char** argv) {
                 gbwt_index_up = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_filename);
                 gbwt_index = gbwt_index_up.get();
                 if (gbwt_index == nullptr) {
-                    cerr << "error:[vg call] unable to load gbwt index file: " << gbwt_filename << endl;
-                    return 1;
+                    error_and_exit(context, "Unable to load GBWT index from file: " + gbwt_filename);
                 }
             }
             GBWTTraversalFinder* gbwt_traversal_finder = new GBWTTraversalFinder(*graph, *gbwt_index);
@@ -867,25 +832,25 @@ int main_call(int argc, char** argv) {
 
         // Call each snarl
         // (todo: try chains in normal mode)
-        if (show_progress) cerr << "[vg call]: Calling top-level snarls" << endl;
+        if (show_progress) cerr << context << ": Calling top-level snarls" << endl;
         graph_caller->call_top_level_snarls(*graph, all_snarls ? GraphCaller::RecurseAlways : GraphCaller::RecurseOnFail);
     } else {
         // Attempt to call chains instead of snarls so that the output traversals are longer
         // Todo: this could probably help in some cases when making VCFs too
-        if (show_progress) cerr << "[vg call]: Calling top-level chains" << endl;
+        if (show_progress) cerr << context << ": Calling top-level chains" << endl;
         graph_caller->call_top_level_chains(*graph,  max_chain_edges,  max_chain_trivial_travs,
                                             all_snarls ? GraphCaller::RecurseAlways : GraphCaller::RecurseOnFail);
     }
-    if (show_progress) cerr << "[vg call]: Calling complete" << endl;
+    if (show_progress) cerr << context << ": Calling complete" << endl;
 
     if (!gaf_output) {
         // Output VCF
         VCFOutputCaller* vcf_caller = dynamic_cast<VCFOutputCaller*>(graph_caller.get());
         assert(vcf_caller != nullptr);
         cout << header << flush;
-        if (show_progress) cerr << "[vg call]: Writing VCF Variants" << endl;
+        if (show_progress) cerr << context << ": Writing VCF Variants" << endl;
         vcf_caller->write_variants(cout, snarl_manager.get());
-        if (show_progress) cerr << "[vg call]: VCF complete" << endl;        
+        if (show_progress) cerr << context << ": VCF complete" << endl;        
     }
     
     return 0;

--- a/src/subcommand/circularize_main.cpp
+++ b/src/subcommand/circularize_main.cpp
@@ -22,6 +22,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg circularize]";
+
 void help_circularize(char** argv) {
     cerr << "usage: " << argv[0] << " circularize [options] <graph.vg> > [circularized.vg]" << endl
          << "Makes specific paths or nodes in a graph circular." << endl
@@ -51,7 +53,7 @@ int main_circularize(int argc, char** argv){
 
     int c;
     optind = 2;
-    while (true){
+    while (true) {
         static struct option long_options[] =
         {
             {"help", no_argument, 0, 'h'},
@@ -64,14 +66,14 @@ int main_circularize(int argc, char** argv){
         };
 
 
-    int option_index = 0;
-    c = getopt_long (argc, argv, "h?dp:P:a:z:",
-                     long_options, &option_index);
-    if (c == -1){
-        break;
-    }
+        int option_index = 0;
+        c = getopt_long (argc, argv, "h?dp:P:a:z:",
+                        long_options, &option_index);
+        if (c == -1) {
+            break;
+        }
 
-        switch(c){
+        switch(c) {
             case 'a':
                 head = parse<int>(optarg);
                 break;
@@ -82,7 +84,7 @@ int main_circularize(int argc, char** argv){
                 path = optarg;
                 break;
             case 'P':
-                pathfile = optarg;
+                pathfile = error_if_file_does_not_exist(context, optarg);
                 break;
             case 'd':
                 describe = true;
@@ -91,7 +93,6 @@ int main_circularize(int argc, char** argv){
             case '?':
                 help_circularize(argv);
                 exit(1);
-                break;
 
             default:
                 abort();
@@ -99,18 +100,17 @@ int main_circularize(int argc, char** argv){
     }
 
     vector<string> paths_to_circularize;
-    if (!((head * tail) > 0)){
-        cerr << "Both a head and tail node must be provided" << endl;
+    if (!((head * tail) > 0)) {
         help_circularize(argv);
-        exit(1);
+        error_and_exit(context, "Both a head and tail node must be provided");
     }
-    if  (pathfile != ""){
+    if  (pathfile != "") {
         string line;
         ifstream pfi;
         pfi.open(pathfile);
         if (!pfi.good()){
-            cerr << "There is an error with the input file." << endl;
             help_circularize(argv);
+            error_and_exit(context, "There is an error with the input file.");
         }
         while (getline(pfi, line)){
             paths_to_circularize.push_back(line);
@@ -118,7 +118,7 @@ int main_circularize(int argc, char** argv){
         pfi.close();
 
     }
-    else if (path != ""){
+    else if (path != "") {
         paths_to_circularize.push_back(path);
     }
 
@@ -129,10 +129,9 @@ int main_circularize(int argc, char** argv){
     });
 
     // Check if paths are in graph:
-    for (const string& p : paths_to_circularize){
-        if (!graph->has_path(p)){
-            cerr << "ERROR: PATH NOT IN GRAPH - " << p << endl;
-            exit(1);
+    for (const string& p : paths_to_circularize) {
+        if (!graph->has_path(p)) {
+            error_and_exit(context, "Path not in graph \"" + p + "\"");
         }
     }
 

--- a/src/subcommand/combine_main.cpp
+++ b/src/subcommand/combine_main.cpp
@@ -24,6 +24,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg combine]";
+
 void help_combine(char** argv) {
     cerr << "usage: " << argv[0] << " combine [options] <graph1.vg> [graph2.vg ...] >merged.vg" << endl
          << "Combines one or more graphs into a single file, regardless of input format." << endl
@@ -93,8 +95,8 @@ int main_combine(int argc, char** argv) {
 
     if (cat_proto) {
         if (connect_paths) 
-        cerr << "warning [vg combine]: --cat-proto/-c option is deprecated "
-             << "and will be removed in a future version of vg." << endl;
+        emit_warning(context, "--cat-proto/-c option is deprecated "
+                              "and will be removed in a future version of vg.");
         return cat_proto_graphs(argc, argv);
     }
     
@@ -122,10 +124,9 @@ int main_combine(int argc, char** argv) {
             graph->for_each_path_handle([&](path_handle_t path_handle) {
                     string path_name = graph->get_path_name(path_handle);
                     if (first_graph->has_path(path_name)) {
-                        cerr << "error [vg combine]: Paths with name \"" << path_name
-                             << "\" found in multiple input graphs. If they are consecutive subpath ranges, "
-                             << "they can be connected by using the -p option." << endl;
-                        exit(1);
+                        error_and_exit(context, "Paths with name \"" + path_name 
+                                                + "\" found in multiple input graphs. If they are consecutive"
+                                                + "subpath ranges, they can be connected by using the -p option.");
                     }
                 });
             handlealgs::copy_path_handle_graph(graph.get(), first_graph.get());
@@ -175,8 +176,7 @@ int cat_proto_graphs(int argc, char** argv) {
                         }
                         
                         if (!cout) {
-                            cerr << "error [vg combine]: Could not write decompressed data to output stream." << endl;
-                            exit(1);
+                            error_and_exit(context, "Could not write decompressed data to output stream.");
                         }
                         
                         // Do the next input file
@@ -197,8 +197,7 @@ int cat_proto_graphs(int argc, char** argv) {
                 cout << in.rdbuf();
                 
                 if (!cout) {
-                    cerr << "error [vg combine]: Could not write raw data to output stream." << endl;
-                    exit(1);
+                    error_and_exit(context, "Could not write raw data to output stream.");
                 }
                 
                 // Do the next input file
@@ -228,8 +227,7 @@ int cat_proto_graphs(int argc, char** argv) {
             }
             
             if (!cout) {
-                cerr << "error [vg combine]: Could not write converted graph to output stream." << endl;
-                exit(1);
+                error_and_exit(context, "Could not write converted graph to output stream.");
             }
             
         });

--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -18,6 +18,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg construct]";
+
 void help_construct(char** argv) {
     cerr << "usage: " << argv[0] << " construct [options] >new.vg" << endl
          << "options:" << endl
@@ -122,15 +124,15 @@ int main_construct(int argc, char** argv) {
         switch (c)
         {
         case 'v':
-            vcf_filenames.push_back(optarg);
+            vcf_filenames.push_back(error_if_file_does_not_exist(context, optarg));
             break;
 
         case 'M':
-            msa_filename = optarg;
+            msa_filename = error_if_file_does_not_exist(context, optarg);
             break;
             
         case 'F':
-            msa_format = optarg;
+            msa_format = error_if_file_does_not_exist(context, optarg);
             break;
             
         case 'd':
@@ -146,7 +148,7 @@ int main_construct(int argc, char** argv) {
             break;
 
         case 'r':
-            fasta_filenames.push_back(optarg);
+            fasta_filenames.push_back(error_if_file_does_not_exist(context, optarg));
             break;
 
         case 'S':
@@ -154,22 +156,14 @@ int main_construct(int argc, char** argv) {
             break;
 
         case 'I':
-            insertion_filenames.push_back(optarg);
+            insertion_filenames.push_back(error_if_file_does_not_exist(context, optarg));
             break;
 
             
         case 'n':
             {
-                // Parse the rename old=new
-                string key_value(optarg);
-                auto found = key_value.find('=');
-                if (found == string::npos || found == 0 || found + 1 == key_value.size()) {
-                    cerr << "error:[vg construct] could not parse rename " << key_value << endl;
-                    exit(1);
-                }
-                // Parse out the two parts
-                string vcf_contig = key_value.substr(0, found);
-                string fasta_contig = key_value.substr(found + 1);
+                string vcf_contig, fasta_contig;
+                tie(vcf_contig, fasta_contig) = parse_split_string(context, optarg, '=', "--rename");
                 // Add the name mapping
                 constructor.add_name_mapping(vcf_contig, fasta_contig);
             }
@@ -201,7 +195,7 @@ int main_construct(int argc, char** argv) {
             break;
 
         case 't':
-            omp_set_num_threads(parse<int>(optarg));
+            omp_set_num_threads(parse_thread_count(context, optarg));
             break;
 
         case 'm':
@@ -227,16 +221,14 @@ int main_construct(int argc, char** argv) {
             throw runtime_error("Not implemented: " + to_string(c));
         }
     }
-    
+
     if (max_node_size == 0) {
         // Make sure we can actually make nodes
-        cerr << "error:[vg construct] max node size cannot be 0" << endl;
-        exit(1);
+        error_and_exit(context, "max node size cannot be 0");
     }
     
     if (!msa_filename.empty() && !fasta_filenames.empty()) {
-        cerr << "error:[vg construct] cannot construct from a reference/VCF and an MSA simultaneously" << endl;
-        exit(1);
+        error_and_exit(context, "cannot construct from a reference/VCF and an MSA simultaneously");
     }
     
     if (!fasta_filenames.empty()) {
@@ -261,43 +253,39 @@ int main_construct(int argc, char** argv) {
                              stop_pos);
                              
                 if (used_region_contigs.count(seq_name)) {
-                    cerr << "error:[vg construct] cannot construct multiple regions of " << seq_name << endl;
-                    exit(1);
+                    error_and_exit(context, "cannot construct multiple regions of " + seq_name);
                 }
                 used_region_contigs.insert(seq_name);
                 
                 if (start_pos > 0 && stop_pos > 0) {
                     // These are 0-based, so if both are nonzero we got a real set of coordinates
                     if (constructor.show_progress) {
-                        cerr << "Restricting to " << seq_name << " from " << start_pos << " to " << stop_pos << endl;
+                        cerr << context << ": Restricting to " << seq_name << " from " << start_pos << " to " << stop_pos << endl;
                     }
                     constructor.allowed_vcf_names.insert(seq_name);
                     // Make sure to correct the coordinates to 0-based exclusive-end, from 1-based inclusive-end
                     constructor.allowed_vcf_regions[seq_name] = make_pair(start_pos - 1, stop_pos);
                 } else if (start_pos < 0 && stop_pos < 0) {
                     // We just got a name
-                    cerr << "Restricting to " << seq_name << " from 1 to end" << endl;
+                    cerr << context << ": Restricting to " << seq_name << " from 1 to end" << endl;
                     constructor.allowed_vcf_names.insert(seq_name);
                 } else {
                     // This doesn't make sense. Does it have like one coordinate?
-                    cerr << "error:[vg construct] could not parse " << region << endl;
-                    exit(1);
+                    error_and_exit(context, "could not parse " + region);
                 }
             } else {
                 // We have been told not to parse the region
-                cerr << "Restricting to " << region << " from 1 to end" << endl;
+                cerr << context << ": Restricting to " << region << " from 1 to end" << endl;
                 constructor.allowed_vcf_names.insert(region);
             }
         }
         
         
         if (fasta_filenames.empty()) {
-            cerr << "error:[vg construct] a reference is required for graph construction" << endl;
-            return 1;
+            error_and_exit(context, "a reference is required for graph construction");
         }
-        if (insertion_filenames.size() > 1){
-            cerr << "Error: only one insertion file may be provided." << endl;
-            exit(1);
+        if (insertion_filenames.size() > 1) {
+            error_and_exit(context, "only one insertion file may be provided");
         }
         
         if (construct_in_memory) {
@@ -346,11 +334,6 @@ int main_construct(int argc, char** argv) {
     else if (!msa_filename.empty()) {
         
         ifstream msa_file(msa_filename);
-        if (!msa_file) {
-            cerr << "error:[vg construct] could not open MSA file " << msa_filename << endl;
-            exit(1);
-        }
-        
         MSAConverter msa_converter;
         msa_converter.show_progress = show_progress;
         
@@ -360,8 +343,7 @@ int main_construct(int argc, char** argv) {
         msa_graph.serialize_to_ostream(cout);
     }
     else {
-        cerr << "error:[vg construct] a reference or an MSA is required for construct" << endl;
-        exit(1);
+        error_and_exit(context, "a reference or an MSA is required for graph construction");
     }
 
     return 0;

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -212,7 +212,8 @@ int main_convert(int argc, char** argv) {
             input_aln = error_if_file_does_not_exist(context, optarg);
             break;
         case 't':
-            omp_set_num_threads(parse_thread_count(context, optarg));
+            num_threads = parse_thread_count(context, optarg);
+            omp_set_num_threads(num_threads);
             break;
         default:
             abort();

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -25,6 +25,8 @@ using namespace vg;
 using namespace vg::subcommand;
 using namespace vg::io;
 
+const string context = "[vg convert]";
+
 //------------------------------------------------------------------------------
 
 // We need a type for describing what kind of input to parse.
@@ -146,7 +148,7 @@ int main_convert(int argc, char** argv) {
         case 'b':
             no_multiple_inputs(input);
             input = input_gbwtgraph;
-            gbwt_name = optarg;
+            gbwt_name = error_if_file_does_not_exist(context, optarg);
             break;
         case OPT_REF_SAMPLE:
             ref_samples.insert(optarg);
@@ -185,7 +187,7 @@ int main_convert(int argc, char** argv) {
             rgfa_pline = true;
             break;
         case 'T':
-            gfa_trans_path = optarg;
+            gfa_trans_path = error_if_file_does_not_exist(context, optarg);
             break;
         case 'W':
             wline = false;
@@ -202,23 +204,15 @@ int main_convert(int argc, char** argv) {
         case 'G':
             no_multiple_inputs(input);
             input = input_gam;
-            input_aln = optarg;
+            input_aln = error_if_file_does_not_exist(context, optarg);
             break;
         case 'F':
             no_multiple_inputs(input);
             input = input_gaf;
-            input_aln = optarg;
+            input_aln = error_if_file_does_not_exist(context, optarg);
             break;
         case 't':
-            {
-                num_threads = parse<int>(optarg);
-                if (num_threads <= 0) {
-                    cerr << "error:[vg convert] Thread count (-t) set to " << num_threads
-                         << ", must set to a positive integer." << endl;
-                    exit(1);
-                }
-                omp_set_num_threads(num_threads);
-            }
+            omp_set_num_threads(parse_thread_count(context, optarg));
             break;
         default:
             abort();
@@ -226,59 +220,49 @@ int main_convert(int argc, char** argv) {
     }
     
     if (!gfa_trans_path.empty() && input != input_gfa) {
-        cerr << "error [vg convert]: -T can only be used with -g" << endl;
-        return 1;
+        error_and_exit(context, "-T can only be used with -g");
     }
     if (output_format != "gfa" && (!rgfa_paths.empty() || !rgfa_prefixes.empty() || !wline)) {
-        cerr << "error [vg convert]: -P, -Q, and -W can only be used with -f" << endl;
-        return 1;
+        error_and_exit(context, "-P, -Q, and -W can only be used with -f");
     }
     if (gfa_output_algorithm == algorithm_gbwtgraph) {
         if (output_format != "gfa") {
-             cerr << "error [vg convert]: Only GFA output format can be used "
-                  << "with the GBWTGraph library GFA conversion algorithm" << endl;
-             return 1;
+            error_and_exit(context, "Only GFA output format can be used "
+                                     "with the GBWTGraph library GFA conversion algorithm");
         }
         if (input == input_gfa) {
-             cerr << "error [vg convert]: GFA input cannot be used "
-                  << "with the GBWTGraph library GFA conversion algorithm" << endl;
-             return 1;
+            error_and_exit(context, "GFA input cannot be used "
+                                    "with the GBWTGraph library GFA conversion algorithm");
         }
         if (!(rgfa_paths.empty() && rgfa_prefixes.empty() && wline)) {
-            cerr << "error [vg convert]: GFA output options (-P, -Q, -W) cannot be used "
-                 << "with the GBWTGraph library GFA conversion algorithm" << endl;
-            return 1;
+            error_and_exit(context, "GFA output options (-P, -Q, -W) cannot be used "
+                                     "with the GBWTGraph library GFA conversion algorithm");
         }
     }
     if (output_format == "gfa" && !ref_samples.empty()) {
-        cerr << "error [vg convert]: paths cannot be converted to reference sense when writing GFA output" << endl;
-        return 1;
+        error_and_exit(context, "paths cannot be converted to reference sense when writing GFA output");
     }
     if (output_format == "gfa" && !hap_locus.empty()) {
-        cerr << "error [vg convert]: paths cannot be converted to haplotype sense when writing GFA output" << endl;
-        return 1;
+        error_and_exit(context, "paths cannot be converted to haplotype sense when writing GFA output");
     }
     if (!ref_samples.empty() && !hap_locus.empty()) {
-        cerr << "error [vg convert]: cannot convert paths to haplotype and reference sense at the same time" << endl;
-        return 1;
+        error_and_exit(context, "cannot convert paths to haplotype and reference sense at the same time");
     }
     if (new_sample.empty() != hap_locus.empty()) {
-        cerr << "error [vg convert]: to convert a generic-sense path to a haplotype, "
-             << "both --hap-locus and --new-sample are required" << endl;
-        return 1;
+        error_and_exit(context, "to convert a generic-sense path to a haplotype, "
+                                "both --hap-locus and --new-sample are required");
     }
     if (output_format == "vg") {
-          cerr << "[vg convert] warning: vg-protobuf output (-v / --vg-out) is deprecated. "
-               << "please use -p instead." << endl;
+        emit_warning(context, "vg-protobuf output (-v / --vg-out) is deprecated. "
+                              "Please use -p instead");
     }
 
     
     // with -F or -G we convert an alignment and not a graph
     if (input == input_gam || input == input_gaf) {
         if (!output_format.empty()) {
-            cerr << "error [vg convert]: Alignment conversion options (-F and -G) cannot be used "
-                 << "with any graph conversion options" << endl;
-            return 1;
+            error_and_exit(context, "Alignment conversion options (-F and -G) "
+                                    "cannot be used with any graph conversion options");
         }
 
         unique_ptr<HandleGraph> input_graph;
@@ -328,8 +312,7 @@ int main_convert(int argc, char** argv) {
         // we have to check this manually since we're not using the istream-based loading
         // functions in order to be able to use the disk-backed loading algorithm
         if (optind >= argc) {
-            cerr << "error [vg convert]: no input graph supplied" << endl;
-            return 1;
+            error_and_exit(context, "no input graph supplied");
         }
         string input_stream_name = argv[optind];
         if (output_format == "xg") {
@@ -337,8 +320,8 @@ int main_convert(int argc, char** argv) {
             
             // Need to go through a handle graph
             bdsg::HashGraph intermediate;
-            cerr << "warning [vg convert]: currently cannot convert GFA directly to XG; "
-                 << "converting through another format" << endl;
+            emit_warning(context, "currently cannot convert GFA directly to XG; "
+                                  "converting through another format");
             algorithms::gfa_to_path_handle_graph(input_stream_name, &intermediate,
                                                  input_rgfa_rank, gfa_trans_path);
             graph_to_xg_adjusting_paths(&intermediate, xg_graph, ref_samples, hap_locus, new_sample, drop_haplotypes);
@@ -362,13 +345,9 @@ int main_convert(int argc, char** argv) {
                                                     gfa_trans_path);
                 }
             } catch (algorithms::GFAFormatError& e) {
-                cerr << "error [vg convert]: Input GFA is not acceptable." << endl;
-                cerr << e.what() << endl;
-                exit(1);
+                error_and_exit(context, "Input GFA is not acceptable.\n" + string(e.what()));
             } catch (std::ios_base::failure& e) {
-                cerr << "error [vg convert]: IO error processing input GFA." << endl;
-                cerr << e.what() << endl;
-                exit(1);
+                error_and_exit(context, "IO error processing input GFA.\n" + string(e.what()));
             }
         }
     }
@@ -380,8 +359,7 @@ int main_convert(int argc, char** argv) {
             });
             gbwtgraph::GBWTGraph* gbwt_graph = dynamic_cast<gbwtgraph::GBWTGraph*>(input_graph.get());
             if (gbwt_graph == nullptr) {
-                cerr << "error [vg convert]: input graph is not a GBWTGraph" << endl;
-                exit(1);
+                error_and_exit(context, "input graph is not a GBWTGraph");
             }
             input_gbwt = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_name);
             gbwt_graph->set_gbwt(*input_gbwt);
@@ -424,8 +402,8 @@ int main_convert(int argc, char** argv) {
             // HandleGraph output.
             else {
                 if (input_path_graph != nullptr) {
-                    cerr << "warning [vg convert]: output format does not support paths, "
-                         << "they are being dropped from the input" << endl;
+                    emit_warning(context, "output format does not support paths; "
+                                          "they are being dropped from the input");
                 }
                 MutableHandleGraph* mutable_output_graph = dynamic_cast<MutableHandleGraph*>(output_graph.get());
                 assert(mutable_output_graph != nullptr);
@@ -455,9 +433,8 @@ int main_convert(int argc, char** argv) {
             // We need to find a GBWTGraph to use for this
             const gbwtgraph::GBWTGraph* gbwt_graph = vg::algorithms::find_gbwtgraph(input_graph.get());
             if (gbwt_graph == nullptr) {
-                cerr << "error [vg convert]: input graph does not have a GBWTGraph, "
-                     << "so GBWTGraph library GFA conversion algorithm cannot be used." << endl;
-                return 1;
+                error_and_exit(context, "input graph does not have a GBWTGraph, "
+                                        "so GBWTGraph library GFA conversion algorithm cannot be used");
             }
             
             gbwtgraph::GFAExtractionParameters parameters;
@@ -474,8 +451,7 @@ int main_convert(int argc, char** argv) {
             }
             for (const string& path_name : rgfa_paths) {
                 if (!graph_to_write->has_path(path_name)) {
-                    cerr << "error [vg convert]: specified path, " << " not found in graph" << path_name << endl;
-                    return 1;
+                    error_and_exit(context, "specified path, " + path_name + ", not found in graph");
                 }
             }
             if (!rgfa_prefixes.empty()) {
@@ -556,8 +532,7 @@ void help_convert(char** argv) {
 
 void no_multiple_inputs(input_type input) {
     if (input != INPUT_DEFAULT) {
-        std::cerr << "error [vg convert]: cannot combine input types (GFA, GBWTGraph, GBZ, GAM, GAF)" << std::endl;
-        std::exit(EXIT_FAILURE);
+        error_and_exit(context, "cannot combine input types  (GFA, GBWTGraph, GBZ, GAM, GAF)");
     }
 }
 
@@ -597,11 +572,10 @@ std::unordered_map<std::string, std::unordered_set<int64_t>> check_duplicate_pat
             
             if (phase_block_set.size() > 1) {
                 // We can't resolve these.
-                std::cerr << "error [vg convert]: multiple phase blocks on sample " << sample
-                          << " haplotype " << haplotype
-                          << " contig " << contig
-                          << " prevent promoting the sample to a reference" << std::endl;
-                std::exit(EXIT_FAILURE);
+                error_and_exit(context, "multiple phase blocks on sample " + sample +
+                                        " haplotype " + std::to_string(haplotype) +
+                                        " contig " + contig +
+                                        " prevent promoting the sample to a reference");
             }
             
             // Log its haplotypes

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -212,8 +212,8 @@ int main_convert(int argc, char** argv) {
             input_aln = error_if_file_does_not_exist(context, optarg);
             break;
         case 't':
-            num_threads = parse_thread_count(context, optarg);
-            omp_set_num_threads(num_threads);
+            omp_set_num_threads(parse_thread_count(context, optarg));
+            num_threads = omp_get_num_threads();
             break;
         default:
             abort();

--- a/src/subcommand/convert_main.cpp
+++ b/src/subcommand/convert_main.cpp
@@ -187,7 +187,7 @@ int main_convert(int argc, char** argv) {
             rgfa_pline = true;
             break;
         case 'T':
-            gfa_trans_path = error_if_file_does_not_exist(context, optarg);
+            gfa_trans_path = error_if_file_cannot_be_written(context, optarg);
             break;
         case 'W':
             wline = false;

--- a/src/subcommand/dotplot_main.cpp
+++ b/src/subcommand/dotplot_main.cpp
@@ -24,6 +24,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg dotplot]";
+
 void help_dotplot(char** argv) {
     cerr << "usage: " << argv[0] << " dotplot [options]" << endl
          << "options:" << endl
@@ -63,7 +65,7 @@ int main_dotplot(int argc, char** argv) {
         {
 
         case 'x':
-            xg_file = optarg;
+            xg_file = error_if_file_does_not_exist(context, optarg);
             break;
 
         case 'h':
@@ -78,8 +80,7 @@ int main_dotplot(int argc, char** argv) {
     }
 
     if (xg_file.empty()) {
-        cerr << "[vg dotplot] Error: an xg index is required" << endl;
-        exit(1);
+        error_and_exit(context, "an XG index is required");
     } else {
         unique_ptr<PathHandleGraph> path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_file);
         bdsg::PathPositionOverlayHelper overlay_helper;

--- a/src/subcommand/explode_main.cpp
+++ b/src/subcommand/explode_main.cpp
@@ -17,6 +17,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg explode]";
+
 void help_explode(char** argv) {
     cerr << "usage: " << argv[0] << " explode [options] source.vg part_dir" << endl
          << "Breaks connected components of graph into" << endl
@@ -59,7 +61,7 @@ int main_explode(int argc, char** argv) {
         {
 
         case 't':
-            omp_set_num_threads(parse<int>(optarg));
+            omp_set_num_threads(parse_thread_count(context, optarg));
             break;
 
         case 'h':

--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -23,6 +23,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg filter]";
+
 void help_filter(char** argv) {
     cerr << "usage: " << argv[0] << " filter [options] <alignment.gam> > out.gam" << endl
          << "Filter alignments by properties." << endl
@@ -330,8 +332,7 @@ int main_filter(int argc, char** argv) {
                     auto point = opt_string.find('.');
                     
                     if (point == -1) {
-                        cerr << "error: no decimal point in seed/probability " << opt_string << endl;
-                        exit(1);
+                        error_and_exit(context, "no decimal point in seed/probability " + opt_string);
                     }
                     
                     // Everything including and after the decimal point is the probability
@@ -363,14 +364,12 @@ int main_filter(int argc, char** argv) {
                 set_min_base_quality = true;
                 vector<string> parts = split_delims(string(optarg), ":");
                 if (parts.size() != 2) {
-                    cerr << "[vg filter] Error: -b expects value in form of <INT>:<FLOAT>" << endl;
-                    return 1;
+                    error_and_exit(context, "-b expects value in form of <INT>:<FLOAT>");
                 }
                 min_base_quality = parse<int>(parts[0]);
                 min_base_quality_fraction = parse<double>(parts[1]);
                 if (min_base_quality_fraction < 0 || min_base_quality_fraction > 1) {
-                    cerr << "[vg filter] Error: second part of -b input must be between 0 and 1" << endl;
-                    return 1;
+                    error_and_exit(context, "second part of -b input must be between 0 and 1");
                 }
             }
             break;
@@ -390,7 +389,7 @@ int main_filter(int argc, char** argv) {
             batch_size = parse<size_t>(optarg);
             break;
         case 't':
-            omp_set_num_threads(parse<int>(optarg));
+            omp_set_num_threads(parse_thread_count(context, optarg));
             break;
         case OPT_PROGRESS:
             show_progress = true;
@@ -414,10 +413,10 @@ int main_filter(int argc, char** argv) {
     }
 
     if (interleaved && max_reads != std::numeric_limits<size_t>::max() && max_reads % 2 != 0) {
-        std::cerr << "warning [vg filter]: max read count is not divisible by 2, but reads are paired." << std::endl;
+        emit_warning(context, "max read count is not divisible by 2, but reads are paired.");
     }
     if (first_alignment) {
-        std::cerr << "warning [vg filter]: setting --threads 1 because --first-alignment requires one thread." << std::endl;
+        emit_warning(context, "setting --threads 1 because --first-alignment requires one thread.");
         omp_set_num_threads(1);
     }
 

--- a/src/subcommand/gamsort_main.cpp
+++ b/src/subcommand/gamsort_main.cpp
@@ -141,7 +141,7 @@ int main_gamsort(int argc, char **argv)
             gaf_params.stable = true;
             break;
         case 'g':
-            gaf_params.gbwt_file = error_if_file_does_not_exist(context, optarg);
+            gaf_params.gbwt_file = error_if_file_cannot_be_written(context, optarg);
             break;
         case 'b':
             gaf_params.bidirectional_gbwt = true;

--- a/src/subcommand/gamsort_main.cpp
+++ b/src/subcommand/gamsort_main.cpp
@@ -121,7 +121,7 @@ int main_gamsort(int argc, char **argv)
 
         // GAM sorting options.
         case 'i':
-            index_filename = error_if_file_does_not_exist(context, optarg);
+            index_filename = error_if_file_cannot_be_written(context, optarg);
             break;
         case 'd':
             easy_sort = true;

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -27,6 +27,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg ids]";
+
 void help_ids(char** argv) {
     cerr << "usage: " << argv[0] << " ids [options] <graph1.vg> [graph2.vg ...] >new.vg" << endl
          << "options:" << endl
@@ -97,7 +99,7 @@ int main_ids(int argc, char** argv) {
                 break;
 
             case 'm':
-                mapping_name = optarg;
+                mapping_name = error_if_file_does_not_exist(context, optarg);
                 break;
 
             case 's':
@@ -185,7 +187,7 @@ int main_ids(int argc, char** argv) {
             gcsa::NodeMapping mapping(max_node_id + 1);
             std::ofstream out(mapping_name, std::ios_base::binary);
             if (!out) {
-                std::cerr << "[vg ids]: cannot create node mapping file " << mapping_name << std::endl;
+                error_and_exit(context, "cannot create node mapping file " + mapping_name);
             } else {
                 mapping.serialize(out);
                 out.close();

--- a/src/subcommand/ids_main.cpp
+++ b/src/subcommand/ids_main.cpp
@@ -99,7 +99,7 @@ int main_ids(int argc, char** argv) {
                 break;
 
             case 'm':
-                mapping_name = error_if_file_does_not_exist(context, optarg);
+                mapping_name = error_if_file_cannot_be_written(context, optarg);
                 break;
 
             case 's':

--- a/src/subcommand/kmers_main.cpp
+++ b/src/subcommand/kmers_main.cpp
@@ -21,6 +21,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg kmers]";
+
 void help_kmers(char** argv) {
     cerr << "usage: " << argv[0] << " kmers [options] <graph1.vg> [graph2.vg ...] >kmers.tsv" << endl
          << "Generates kmers from both strands of the graph(s). Output is: kmer id pos" << endl
@@ -96,7 +98,7 @@ int main_kmers(int argc, char** argv) {
                 kmer_size = parse<size_t>(optarg);
                 break;
             case 't':
-                omp_set_num_threads(parse<int>(optarg));
+                omp_set_num_threads(parse_thread_count(context, optarg));
                 break;
             case 'p':
                 show_progress = true;
@@ -119,13 +121,9 @@ int main_kmers(int argc, char** argv) {
 
             // Obsolete options.
             case 'e':
-                cerr << "error: [vg kmers] Option --edge-max is obsolete. Use vg prune to prune the graph instead." << endl;
-                std::exit(EXIT_FAILURE);
-                break;
+                error_and_exit(context, "Option --edge-max is obsolete. Use vg prune to prune the graph instead.");
             case 'F':
-                cerr << "error: [vg kmers] Option --forward-only is obsolete" << endl;
-                std::exit(EXIT_FAILURE);
-                break;
+                error_and_exit(context, "Option --forward-only is obsolete");
 
             case 'h':
             case '?':
@@ -139,8 +137,7 @@ int main_kmers(int argc, char** argv) {
     }
 
     if (kmer_size == 0) {
-        cerr << "error: [vg kmers] --kmer-size was not specified" << endl;
-        std::exit(EXIT_FAILURE);
+        error_and_exit(context, "--kmer-size was not specified");
     }
 
     vector<string> graph_file_names;

--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -350,7 +350,7 @@ int main_map(int argc, char** argv) {
             db_name = optarg;
             error_if_file_does_not_exist(context, db_name + ".xg");
             error_if_file_does_not_exist(context, db_name + gcsa::GCSA::EXTENSION);
-            error_if_file_does_not_exist(context, db_name + gbwt::GBWT::EXTENSION);
+            // GBWT is optional
             break;
 
         case 'x':

--- a/src/subcommand/mask_main.cpp
+++ b/src/subcommand/mask_main.cpp
@@ -18,6 +18,8 @@ using namespace vg::subcommand;
 using namespace vg::io;
 using namespace std;
 
+const string context = "[vg mask]";
+
 vector<tuple<string, size_t, size_t>> parse_bed(istream& in){
     
     vector<tuple<string, size_t, size_t>> regions;
@@ -91,13 +93,13 @@ int main_mask(int argc, char** argv) {
                 help_mask(argv);
                 return 1;
             case 'b':
-                bed_filepath = optarg;
+                bed_filepath = error_if_file_does_not_exist(context, optarg);
                 break;
             case 'g':
                 gbz_input = true;
                 break;
             case 's':
-                snarls_filepath = optarg;
+                snarls_filepath = error_if_file_does_not_exist(context, optarg);
                 break;
             default:
                 help_mask(argv);
@@ -107,26 +109,12 @@ int main_mask(int argc, char** argv) {
     
     
     if (argc - optind != 1) {
-        cerr << "error: vg mask requires exactly 1 positional argument" << endl;
         help_mask(argv);
-        return 1;
+        error_and_exit(context, "vg mask requires exactly 1 positional argument");
     }
 
     if (bed_filepath.empty()) {
-        cerr << "error: vg mask requires an input BED file from -b / --bed" << endl;
-        return 1;
-    }
-    if (bed_filepath != "-") {
-        if (!ifstream(bed_filepath)) {
-            cerr << "error: could not open BED file from " << bed_filepath << endl;
-            return 1;
-        }
-    }
-    if (!snarls_filepath.empty() && snarls_filepath != "-") {
-        if (!ifstream(snarls_filepath)) {
-            cerr << "error: could not open snarls file from " << snarls_filepath << endl;
-            return 1;
-        }
+        error_and_exit(context, "vg mask requires an input BED file from -b / --bed");
     }
     
     // load the graph

--- a/src/subcommand/mcmc_main.cpp
+++ b/src/subcommand/mcmc_main.cpp
@@ -26,6 +26,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg mcmc]";
+
 void help_mcmc(char** argv) {
     cerr << "usage: " << argv[0] << " mcmc [options] multipath_alns.mgam graph.vg sites.snarls > graph_with_paths.vg" << endl
          << "Finds haplotypes based on reads using MCMC methods" << endl
@@ -113,7 +115,7 @@ int main_mcmc(int argc, char** argv) {
                 sample_name = optarg;
                 break;  
             case 'v':
-                vcf_out = optarg;
+                vcf_out = error_if_file_cannot_be_written(context, optarg);
                 break;
             case 'b':
                 burn_in = parse<int>(optarg);
@@ -161,9 +163,8 @@ int main_mcmc(int argc, char** argv) {
     //convert to VG graph if needed
     ensure_vg();
 
-    if(vg_graph == nullptr || vg_graph == 0){
-        cerr << "Graph is NULL" <<endl;
-        exit(1);
+    if(vg_graph == nullptr || vg_graph == 0) {
+        error_and_exit(context, "Graph is NULL");
     }
     PathPositionHandleGraph* graph = nullptr;
     graph = overlay_helper.apply(vg_graph);
@@ -172,20 +173,17 @@ int main_mcmc(int argc, char** argv) {
     // Check our paths
     for (const string& ref_path : ref_paths) {
         if (!graph->has_path(ref_path)) {
-            cerr << "error [vg call]: Reference path \"" << ref_path << "\" not found in graph" << endl;
-            return 1;
+            error_and_exit(context, "Reference path \"" + ref_path + "\" not found in graph");
         }
     }
     
     // Check our offsets
     if (ref_path_offsets.size() != 0 && ref_path_offsets.size() != ref_paths.size()) {
-        cerr << "error [vg call]: when using -o, the same number paths must be given with -p" << endl;
-        return 1;
+        error_and_exit(context, "when using -o, the same number paths must be given with -p");
     }
     // Check our ref lengths
     if (ref_path_lengths.size() != 0 && ref_path_lengths.size() != ref_paths.size()) {
-        cerr << "error [vg call]: when using -l, the same number paths must be given with -p" << endl;
-        return 1;
+        error_and_exit(context, "when using -l, the same number paths must be given with -p");
     }
 
     // No paths specified: use them all

--- a/src/subcommand/minimizer_main.cpp
+++ b/src/subcommand/minimizer_main.cpp
@@ -93,7 +93,7 @@ void help_minimizer(char** argv) {
     std::cerr << "                             (default: guess)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
-    std::cerr << "  -z, --zipcode-name FILE    store the distances that are too big in afile" << std::endl;
+    std::cerr << "  -z, --zipcode-name FILE    store the distances that are too big in a file" << std::endl;
     std::cerr << "                             if no -z, some distances may be discarded" << std::endl;
     std::cerr << "  -l, --load-index FILE      load this index and insert the new kmers into it" << std::endl;
     std::cerr << "                             (overrides minimizer / weighted minimizer options)" << std::endl;
@@ -223,7 +223,7 @@ int main_minimizer(int argc, char** argv) {
             break;
 
         case 'z':
-            zipcode_name = error_if_file_does_not_exist(context, optarg);
+            zipcode_name = error_if_file_cannot_be_written(context, optarg);
             break;
         case 'l':
             load_index = error_if_file_does_not_exist(context, optarg);

--- a/src/subcommand/msga_main.cpp
+++ b/src/subcommand/msga_main.cpp
@@ -18,6 +18,7 @@
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg msga]";
 
 void help_msga(char** argv) {
     cerr << "usage: " << argv[0] << " msga [options] >graph.vg" << endl
@@ -277,7 +278,7 @@ int main_msga(int argc, char** argv) {
             break;
 
         case 'f':
-            fasta_files.push_back(optarg);
+            fasta_files.push_back(error_if_file_does_not_exist(context, optarg));
             break;
 
         case 'n':
@@ -294,11 +295,10 @@ int main_msga(int argc, char** argv) {
 
         case 'g':
             if (graph_files.size() != 0) {
-                cerr << "[vg msga] Error: graph-graph alignment is not yet implemented." << endl
-                     << "We can only use one input graph." << endl;
-                return 1;
+                error_and_exit(context, "graph-graph alignment is not yet implemented. "
+                                        "We can only use one input graph.");
             }
-            graph_files.push_back(optarg);
+            graph_files.push_back(error_if_file_does_not_exist(context, optarg));
             break;
 
         case 'w':
@@ -358,7 +358,7 @@ int main_msga(int argc, char** argv) {
             break;
 
         case 't':
-            omp_set_num_threads(parse<int>(optarg));
+            omp_set_num_threads(parse_thread_count(context, optarg));
             break;
 
         case 'Q':
@@ -394,7 +394,7 @@ int main_msga(int argc, char** argv) {
             break;
 
         case 'R':
-            position_bed_file = optarg;
+            position_bed_file = error_if_file_does_not_exist(context, optarg);
             break;
 
         case 'T':
@@ -434,8 +434,8 @@ int main_msga(int argc, char** argv) {
         mapping_quality_method = Exact;
     }
     else {
-        cerr << "error:[vg map] unrecognized mapping quality method command line arg '" << method_code << "'" << endl;
-        return 1;
+        error_and_exit(context, "unrecognized mapping quality method command line arg '"
+                                + to_string(method_code) + "'");
     }
 
     if (band_overlap == -1) {
@@ -478,13 +478,14 @@ int main_msga(int argc, char** argv) {
     for (auto& fasta_file_name : fasta_files) {
         FastaReference ref;
         ref.open(fasta_file_name);
-        if (debug) cerr << "loading " << fasta_file_name << endl;
+        if (debug) cerr << context << ": loading " << fasta_file_name << endl;
         for (auto& name : ref.index->sequenceNames) {
             if (!seq_names.empty() && seq_names.count(name) == 0) continue;
             // only use the sequence if we have whitelisted it
             // and also sanitize the input so we have only ATGCN
             if (seen_seq_names.count(name)) {
-                cerr << "[vg msga] Warning: sequence " << name << " is seen multiple times in input, ignoring all but the first instance" << endl;
+                emit_warning(context, "sequence " + name + " is seen multiple times in input, "
+                                      + "ignoring all but the first instance");
                 continue;
             }
             strings[name] = vg::nonATGCNtoN(ref.getSequence(name));
@@ -528,7 +529,7 @@ int main_msga(int argc, char** argv) {
 
     // align, include, repeat
 
-    if (debug) cerr << "preparing initial graph" << endl;
+    if (debug) cerr << context << ": preparing initial graph" << endl;
 
     size_t max_query_size = pow(2, doubling_steps) * idx_kmer_size;
     // limit max node size
@@ -598,11 +599,11 @@ int main_msga(int argc, char** argv) {
             return;
         }
 
-        if (debug) cerr << "building xg index" << endl;
+        if (debug) cerr << context << ": building xg index" << endl;
         xgidx = new xg::XG();
         xgidx->from_path_handle_graph(*graph);
 
-        if (debug) cerr << "building GCSA2 index" << endl;
+        if (debug) cerr << context << ": building GCSA2 index" << endl;
         // Configure GCSA2 verbosity so it doesn't spit out loads of extra info
         if(!debug) gcsa::Verbosity::set(gcsa::Verbosity::SILENT);
 
@@ -613,17 +614,18 @@ int main_msga(int argc, char** argv) {
             Region region = position_hints[names_in_order[name_idx]];
             if (!xgidx->has_path(region.seq) || xgidx->get_path_length(xgidx->get_path_handle(region.seq)) <=
                 region.end) {
-                stringstream err_msg;
-                err_msg << "[vg msga] Error: Target region for \"" << names_in_order[name_idx] << "\" ("
-                     << region.seq << ":" << region.start << "-" << region.end << ") not found in graph." << endl;
-                throw runtime_error(err_msg.str());
+                error_and_exit(context, "Target region for \"" + names_in_order[name_idx] + "\" ("
+                                        + region.seq + ":" + to_string(region.start) + "-" + to_string(region.end) +
+                                        ") not found in graph.");
             }
             region_graph = new VG();
             Region out_region;
             PathChunker chunker(xgidx);
-            if (debug) cerr << "Subsetting graph to " << region.seq << ":" << region.start << "-" << region.end
-                            << " for sequence " << names_in_order[name_idx] << " using " << context_steps
-                            << " context steps." << endl;
+            if (debug) {
+                cerr << context << ": Subsetting graph to " << region.seq << ":"
+                     << region.start << "-" << region.end << " for sequence "
+                     << names_in_order[name_idx] << " using " << context_steps << " context steps." << endl;
+            }
             chunker.extract_subgraph(region, context_steps, 0, false, *region_graph, out_region);
             graph = region_graph;
         }
@@ -690,7 +692,7 @@ int main_msga(int argc, char** argv) {
             mapper->min_cluster_length = min_cluster_length;
             mapper->mem_reseed_length = round(mem_reseed_factor * mapper->min_mem_length);
             if (debug) {
-                cerr << "[vg msga] : min_mem_length = " << mapper->min_mem_length
+                cerr << context << ": min_mem_length = " << mapper->min_mem_length
                      << ", mem_reseed_length = " << mapper->mem_reseed_length
                      << ", min_cluster_length = " << mapper->min_cluster_length << endl;
             }
@@ -731,20 +733,24 @@ int main_msga(int argc, char** argv) {
 #endif
         while (incomplete && iter++ < iter_max) {
             stringstream s; s << iter; string iterstr = s.str();
-            if (debug) cerr << name << ": adding to graph " << i << "/" << names_in_order.size() << endl;
+            if (debug) {
+                cerr << context << " " << name << ": adding to graph "
+                     << i << "/" << names_in_order.size() << endl;
+            }
             vector<Path> paths;
             int j = 0;
             // align to the graph
-            if (debug) cerr << name << ": aligning " << seq.size() << "bp -> g:"
-                            << graph->length() << "bp "
-                            << "n:" << graph->node_count() << " "
-                            << "e:" << graph->edge_count() << endl;
+            if (debug) {
+                cerr << context << " " << name << ": aligning " << seq.size()
+                     << "bp -> g:" << graph->length() << "bp " << "n:"
+                     << graph->node_count() << " " << "e:" << graph->edge_count() << endl;
+            }
             Alignment aln = mapper->align(seq, 0, 0, 0, band_width, band_overlap, xdrop_alignment);
             aln.set_name(name);
             if (aln.path().mapping_size()) {
                 auto aln_seq = vg::algorithms::path_string(*graph, aln.path());
                 if (aln_seq != seq) {
-                    cerr << "[vg msga] alignment corrupted, failed to obtain correct banded alignment "
+                    cerr << context << ": alignment corrupted, failed to obtain correct banded alignment "
                          << "(alignment seq != input seq)" << endl;
                     cerr << "expected " << seq << endl;
                     cerr << "got      " << aln_seq << endl;
@@ -774,7 +780,7 @@ int main_msga(int argc, char** argv) {
             ++j;
 
             // now take the alignment and modify the graph with it
-            if (debug) cerr << name << ": editing graph" << endl;
+            if (debug) cerr << context << " " << name << ": editing graph" << endl;
             //graph->serialize_to_file(name + "-pre-edit.vg");
             // Modify graph and embed paths
             graph->edit(paths, nullptr, true);
@@ -784,13 +790,13 @@ int main_msga(int argc, char** argv) {
             handlealgs::chop(*graph, node_max);
             //if (!graph->is_valid()) cerr << "invalid after dice" << endl;
             //graph->serialize_to_file(name + "-post-dice.vg");
-            if (debug) cerr << name << ": sorting and compacting ids" << endl;
+            if (debug) cerr << context << " " << name << ": sorting and compacting ids" << endl;
             graph->sort();
             //if (!graph->is_valid()) cerr << "invalid after sort" << endl;
             graph->compact_ids(); // xg can't work unless IDs are compacted.
             //if (!graph->is_valid()) cerr << "invalid after compact" << endl;
             if (circularize) {
-                if (debug) cerr << name << ": circularizing" << endl;
+                if (debug) cerr << context << " " << name << ": circularizing" << endl;
                 graph->circularize({name});
                 //graph->serialize_to_file(name + "-post-circularize.vg");
             }
@@ -812,11 +818,11 @@ int main_msga(int argc, char** argv) {
             auto path_seq = vg::algorithms::path_string(*graph, graph->paths.path(name));
             incomplete = !(path_seq == seq) || !is_valid;
             if (incomplete) {
-                cerr << "[vg msga] failed to include alignment, retrying " << endl
-                    << "expected " << seq << endl
-                    << "got      " << path_seq << endl
-                    << pb2json(aln.path()) << endl
-                    << pb2json(graph->paths.path(name)) << endl;
+                cerr << context << ": failed to include alignment, retrying " << endl
+                     << "expected " << seq << endl
+                     << "got      " << path_seq << endl
+                     << pb2json(aln.path()) << endl
+                     << pb2json(graph->paths.path(name)) << endl;
                 graph->serialize_to_file(name + "-post-edit.vg");
                 ofstream f(name + "-failed-alignment-" + convert(j) + ".gam");
                 vg::io::write(f, 1, (std::function<Alignment(size_t)>)([&aln](size_t n) { return aln; }));
@@ -826,8 +832,7 @@ int main_msga(int argc, char** argv) {
         }
         // if (debug && !graph->is_valid()) cerr << "graph is invalid" << endl;
         if (incomplete && iter >= iter_max) {
-            cerr << "[vg msga] Error: failed to include path " << name << endl;
-            exit(1);
+            error_and_exit(context, "failed to include path " + name);
         }
     }
 
@@ -861,7 +866,7 @@ int main_msga(int argc, char** argv) {
     //      };
 
     if (normalize) {
-        if (debug) cerr << "normalizing graph" << endl;
+        if (debug) cerr << context << ": normalizing graph" << endl;
         if (graph_files.empty()) {
             // shouldn't be any reason to do this, but if we are going to do it,
             // only try if graph was made entirely of msga'd sequences.
@@ -872,7 +877,7 @@ int main_msga(int argc, char** argv) {
         graph->sort();
         graph->compact_ids();
         if (!graph->is_valid()) {
-            cerr << "[vg msga] warning! graph is not valid after normalization" << endl;
+            emit_warning(context, "graph is not valid after normalization");
         }
     }
 
@@ -893,14 +898,15 @@ int main_msga(int argc, char** argv) {
 
     if (!failures.empty()) {
         stringstream ss;
+        stringstream path_names;
         ss << "vg-msga-failed-include_";
         for (auto& s : failures) {
-            cerr << "[vg msga] Error: failed to include path " << s << endl;
+            path_names << s << endl;
             ss << s << "_";
         }
         ss << ".vg";
         graph->serialize_to_file(ss.str());
-        exit(1);
+        error_and_exit(context, "failed to include paths " + path_names.str() + "in output graph");
     }
 
     // return the graph

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -333,7 +333,7 @@ int main_paths(int argc, char** argv) {
         }
     } else {
         if (!gbwt_file.empty()) {
-            error_and_exit(context, "path sense selection is not done by GBWT");
+            emit_warning(context, "path sense selection is not done by GBWT");
         }
         // We asked for path senses specifically
         selection_criteria++;

--- a/src/subcommand/primers_main.cpp
+++ b/src/subcommand/primers_main.cpp
@@ -12,6 +12,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg primers]";
+
 void help_primers(char** argv) {
     cerr << "usage: " << argv[0] << " primers [options] input.primer3 > filtered_primers.out" << endl
          << endl
@@ -119,27 +121,27 @@ int main_primers(int argc, char** argv) {
         switch (c)
         {
         case 'x':
-            xg_path = optarg;
+            xg_path = error_if_file_does_not_exist(context, optarg);
             break;
         
         case 'd':
-            distance_index_path = optarg;
+            distance_index_path = error_if_file_does_not_exist(context, optarg);
             break;
         
         case 'r':
-            ri_path = optarg;
+            ri_path = error_if_file_does_not_exist(context, optarg);
             break;
         
         case 'g':
-            gbz_path = optarg;
+            gbz_path = error_if_file_does_not_exist(context, optarg);
             break;
         
         case 'M':
-            min_path = optarg;
+            min_path = error_if_file_does_not_exist(context, optarg);
             break;
         
         case 'Z':
-            zip_path = optarg;
+            zip_path = error_if_file_does_not_exist(context, optarg);
             break;
         
         case 'v':
@@ -174,23 +176,19 @@ int main_primers(int argc, char** argv) {
     }
 
     if (xg_path.empty()) {
-        cerr << "error:[vg primers] xg file (-x) is required" << endl;
-        exit(1);
+        error_and_exit(context, "XG file (-x) is required");
     }
 
     if (distance_index_path.empty()) {
-        cerr << "error:[vg primers] distance index file (-d) is required" << endl;
-        exit(1);
+        error_and_exit(context, "distance index file (-d) is required");
     }
 
     if (ri_path.empty()) {
-        cerr << "error:[vg primers] r index file (-r) is required" << endl;
-        exit(1);
+        error_and_exit(context, "r index file (-r) is required");
     }
 
     if (gbz_path.empty()) {
-        cerr << "error:[vg primers] gbz file (-g) is required" << endl;
-        exit(1);
+        error_and_exit(context, "GBZ file (-g) is required");
     }
 
     string primers_path = get_input_file_name(optind, argc, argv);

--- a/src/subcommand/rna_main.cpp
+++ b/src/subcommand/rna_main.cpp
@@ -21,6 +21,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg rna]";
+
 void help_rna(char** argv) {
     cerr << "usage: " << argv[0] << " rna [options] graph.[vg|pg|hg|gbz] > splicing_graph.[vg|pg|hg]" << endl
 
@@ -147,11 +149,13 @@ int32_t main_rna(int32_t argc, char** argv) {
         {
 
         case 'n':
-            transcript_filenames.push_back(optarg);
+            transcript_filenames.push_back(error_if_file_does_not_exist(context, optarg));
+            error_if_file_is_gzipped(context, transcript_filenames.back());
             break;
 
         case 'm':
-            intron_filenames.push_back(optarg);
+            intron_filenames.push_back(error_if_file_does_not_exist(context, optarg));
+            error_if_file_is_gzipped(context, intron_filenames.back());
             break;
 
         case 'y':
@@ -163,7 +167,7 @@ int32_t main_rna(int32_t argc, char** argv) {
             break;
 
         case 'l':
-            haplotypes_filename = optarg;
+            haplotypes_filename = error_if_file_does_not_exist(context, optarg);
             break;
 
         case 'z':
@@ -203,19 +207,19 @@ int32_t main_rna(int32_t argc, char** argv) {
             break;
                 
         case 'b':
-            gbwt_out_filename = optarg;
+            gbwt_out_filename = error_if_file_cannot_be_written(context, optarg);
             break;
             
         case 'v':
-            hap_gbwt_out_filename = optarg;
+            hap_gbwt_out_filename = error_if_file_cannot_be_written(context, optarg);
             break;
 
         case 'f':
-            fasta_out_filename = optarg;
+            fasta_out_filename = error_if_file_cannot_be_written(context, optarg);
             break;
 
         case 'i':
-            info_out_filename = optarg;
+            info_out_filename = error_if_file_cannot_be_written(context, optarg);
             break;
 
         case 'u':
@@ -231,7 +235,7 @@ int32_t main_rna(int32_t argc, char** argv) {
             break;
 
         case 't':
-            num_threads = stoi(optarg);
+            num_threads = parse_thread_count(context, optarg);
             break;
 
         case 'p':
@@ -255,50 +259,29 @@ int32_t main_rna(int32_t argc, char** argv) {
     }
 
     if (transcript_filenames.empty() && intron_filenames.empty()) {
-
-        cerr << "[vg rna] ERROR: No transcripts or introns were given. "
-             << "Use --transcripts FILE and/or --introns FILE." << endl;
-        return 1;       
-    }
-
-    for (const auto& filenames : {std::cref(transcript_filenames), std::cref(intron_filenames)}) {
-        // For each collection of filenames (see https://stackoverflow.com/a/64794991/)
-
-        for (auto filename : filenames.get()) {
-
-            // taken from https://stackoverflow.com/a/20446239/
-            if (ends_with(filename, vg::GZ_SUFFIX)) {
-
-                cerr << "[vg rna] ERROR: Annotation file " << filename 
-                     << " appears to be gzipped. Decompress it before use." << endl;    
-                return 1;
-            }
-        }
+        error_and_exit(context, "No transcripts or introns were given. "
+                                "Use --transcripts FILE and/or --introns FILE.");
     }
 
     if (!haplotypes_filename.empty() && gbz_format) {
-
-        cerr << "[vg rna] ERROR: Only one set of haplotypes can be provided "
-             << "(GBZ file contains both a graph and haplotypes). "
-             << "Use either --haplotypes or --gbz-format." << endl;
-        return 1;       
+        error_and_exit(context, "Only one set of haplotypes can be provided "
+                                "(GBZ file contains both a graph and haplotypes). "
+                                "Use either --haplotypes or --gbz-format.");
     }
 
     if (remove_non_transcribed_nodes && !add_reference_transcript_paths && !add_projected_transcript_paths) {
-
-        cerr << "[vg rna] WARNING: Reference paths are deleted when removing intergenic and intronic regions. "
-             << "Consider adding transcripts as embedded paths using --add-ref-paths and/or --add-hap-paths." << endl;
+        emit_warning(context, "Reference paths are deleted when removing intergenic and intronic regions. "
+                              "Consider adding transcripts as embedded paths "
+                              "using --add-ref-paths and/or --add-hap-paths.");
     }
 
     if (path_collapse_type != "no" && path_collapse_type != "haplotype" && path_collapse_type != "all") {
-
-        cerr << "[vg rna] ERROR: Path collapse type (--path-collapse) provided not supported. "
-             << "Options: no, haplotype or all." << endl;
-        return 1;
+        error_and_exit(context, "Path collapse type (--path-collapse) provided not supported. "
+                                "Options: no, haplotype or all.");
     }
 
     double time_parsing_start = gcsa::readTimer();
-    if (show_progress) { cerr << "[vg rna] Parsing graph file ..." << endl; }
+    if (show_progress) { cerr << context << ": Parsing graph file ..." << endl; }
 
     string graph_filename = get_input_file_name(optind, argc, argv);
 
@@ -313,7 +296,7 @@ int32_t main_rna(int32_t argc, char** argv) {
         if (!haplotypes_filename.empty()) {
 
             // Load haplotype GBWT index.
-            if (show_progress) { cerr << "[vg rna] Parsing haplotype GBWT index file ..." << endl; }
+            if (show_progress) { cerr << context << ": Parsing haplotype GBWT index file ..." << endl; }
             haplotype_index = vg::io::VPKG::load_one<gbwt::GBWT>(haplotypes_filename);
             assert(haplotype_index->bidirectional());
 
@@ -330,7 +313,7 @@ int32_t main_rna(int32_t argc, char** argv) {
         // Load GBZ file 
         unique_ptr<gbwtgraph::GBZ> gbz = vg::io::VPKG::load_one<gbwtgraph::GBZ>(graph_filename);
         
-        if (show_progress) { cerr << "[vg rna] Converting graph format ..." << endl; }
+        if (show_progress) { cerr << context << ": Converting graph format ..." << endl; }
 
         // Convert GBWTGraph to mutable graph type (PackedGraph).
         graph->set_id_increment(gbz->graph.min_node_id());
@@ -347,7 +330,7 @@ int32_t main_rna(int32_t argc, char** argv) {
     }
 
     if (graph == nullptr) {
-        cerr << "[transcriptome] ERROR: Could not load graph." << endl;
+        cerr << context << ": ERROR: Could not load graph." << endl;
         exit(1);
     }
 
@@ -362,7 +345,7 @@ int32_t main_rna(int32_t argc, char** argv) {
     transcriptome.path_collapse_type = path_collapse_type;
     
     if (show_progress) {
-        cerr << "[vg rna] Graph " << ((!haplotype_index->empty()) ? "and GBWT index " : "")
+        cerr << context << ": Graph " << ((!haplotype_index->empty()) ? "and GBWT index " : "")
              << "parsed in " << gcsa::readTimer() - time_parsing_start << " seconds, "
              << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
     };
@@ -371,7 +354,7 @@ int32_t main_rna(int32_t argc, char** argv) {
     if (!intron_filenames.empty()) {
 
         double time_intron_start = gcsa::readTimer();
-        if (show_progress) { cerr << "[vg rna] Adding intron splice-junctions to graph ..." << endl; }
+        if (show_progress) { cerr << context << ": Adding intron splice-junctions to graph ..." << endl; }
 
         vector<istream *> intron_streams;
         intron_streams.reserve(intron_filenames.size());
@@ -379,10 +362,6 @@ int32_t main_rna(int32_t argc, char** argv) {
         for (auto & filename: intron_filenames) {
 
             auto intron_stream = new ifstream(filename);
-            if (!(*intron_stream)) {
-                cerr << "ERROR: intron file " << filename << " could not be opened" << endl;
-                return 1;
-            }
             intron_streams.emplace_back(intron_stream);
         }
 
@@ -395,7 +374,7 @@ int32_t main_rna(int32_t argc, char** argv) {
         }
 
         if (show_progress) {
-            cerr << "[vg rna] Introns parsed and graph updated in "
+            cerr << context << ": Introns parsed and graph updated in "
                  << gcsa::readTimer() - time_intron_start << " seconds, "
                  << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
         };
@@ -406,17 +385,15 @@ int32_t main_rna(int32_t argc, char** argv) {
     if (!transcript_filenames.empty()) {
 
         double time_transcript_start = gcsa::readTimer();
-        if (show_progress) { cerr << "[vg rna] Adding transcript splice-junctions and exon boundaries to graph ..." << endl; }
+        if (show_progress) { 
+            cerr << context << ": Adding transcript splice-junctions and exon boundaries to graph ..." << endl;
+        }
 
         transcript_streams.reserve(transcript_filenames.size());
 
         for (auto & filename: transcript_filenames) {
 
             auto transcript_stream = new ifstream(filename);
-            if (!(*transcript_stream)) {
-                cerr << "ERROR: transcript file " << filename << " could not be opened" << endl;
-                return 1;
-            }
             transcript_streams.emplace_back(transcript_stream);
         }
 
@@ -424,7 +401,7 @@ int32_t main_rna(int32_t argc, char** argv) {
         transcriptome.add_reference_transcripts(transcript_streams, haplotype_index, use_hap_ref, !use_hap_ref);
 
         if (show_progress) {
-            cerr << "[vg rna] Transcripts parsed and graph updated in "
+            cerr << context << ": Transcripts parsed and graph updated in "
                  << gcsa::readTimer() - time_transcript_start << " seconds, "
                  << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
         };
@@ -433,7 +410,7 @@ int32_t main_rna(int32_t argc, char** argv) {
     if (!transcript_streams.empty() && (!haplotype_index->empty() || proj_emded_paths) && !use_hap_ref) {
 
         double time_project_start = gcsa::readTimer();
-        if (show_progress) { cerr << "[vg rna] Projecting transcripts to haplotypes ..." << endl; }
+        if (show_progress) { cerr << context << ": Projecting transcripts to haplotypes ..." << endl; }
 
         for (auto & transcript_stream: transcript_streams) {
 
@@ -447,7 +424,7 @@ int32_t main_rna(int32_t argc, char** argv) {
         transcriptome.add_haplotype_transcripts(transcript_streams, *haplotype_index, proj_emded_paths);
 
         if (show_progress) {
-            cerr << "[vg rna] Haplotype-specific transcripts constructed in "
+            cerr << context << ": Haplotype-specific transcripts constructed in "
                  << gcsa::readTimer() - time_project_start << " seconds, "
                  << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
         };
@@ -462,12 +439,12 @@ int32_t main_rna(int32_t argc, char** argv) {
     if (remove_non_transcribed_nodes) {
 
         double time_remove_start = gcsa::readTimer();
-        if (show_progress) { cerr << "[vg rna] Removing non-transcribed regions ..." << endl; }
+        if (show_progress) { cerr << context << ": Removing non-transcribed regions ..." << endl; }
 
         transcriptome.remove_non_transcribed_nodes();
 
         if (show_progress) {
-            cerr << "[vg rna] Regions removed in " << gcsa::readTimer() - time_remove_start
+            cerr << context << ": Regions removed in " << gcsa::readTimer() - time_remove_start
                  << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
         };
     }
@@ -476,12 +453,12 @@ int32_t main_rna(int32_t argc, char** argv) {
     if (max_node_length > 0) {
 
         double time_chop_start = gcsa::readTimer();
-        if (show_progress) { cerr << "[vg rna] Chopping long nodes ..." << endl; }
+        if (show_progress) { cerr << context << ": Chopping long nodes ..." << endl; }
 
         transcriptome.chop_nodes(max_node_length);
 
         if (show_progress) {
-            cerr << "[vg rna] Nodes chopped in " << gcsa::readTimer() - time_chop_start 
+            cerr << context << ": Nodes chopped in " << gcsa::readTimer() - time_chop_start 
                  << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
         };
     }
@@ -490,12 +467,14 @@ int32_t main_rna(int32_t argc, char** argv) {
     if (sort_collapse_graph) {
     
         double time_sort_start = gcsa::readTimer();
-        if (show_progress) { cerr << "[vg rna] Topological sorting graph and compacting node ids ..." << endl; }
+        if (show_progress) {
+            cerr << context << ": Topological sorting graph and compacting node ids ..." << endl;
+        }
         
         if (transcriptome.sort_compact_nodes()) {
 
             if (show_progress) { 
-                cerr << "[vg rna] Graph sorted and compacted in " 
+                cerr << context << ": Graph sorted and compacted in " 
                      << gcsa::readTimer() - time_sort_start << " seconds, " 
                      << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
             };
@@ -503,8 +482,8 @@ int32_t main_rna(int32_t argc, char** argv) {
         } else {
 
             if (show_progress) {
-                cerr << "[vg rna] WARNING: Can only sort and compact node ids " 
-                     << "for a graph in the PackedGraph format" << endl;
+                emit_warning(context, "Can only sort and compact node ids "
+                                      "for a graph in the PackedGraph format");
             };            
         }        
     }
@@ -517,20 +496,21 @@ int32_t main_rna(int32_t argc, char** argv) {
         if (add_reference_transcript_paths && add_projected_transcript_paths) {
 
             if (show_progress) {
-                cerr << "[vg rna] Adding reference and projected transcripts as embedded paths in the graph ..." << endl;
+                cerr << context << ": Adding reference and projected transcripts "
+                    << "as embedded paths in the graph ..." << endl;
             }
 
         } else {
 
             if (show_progress) { 
-                cerr << "[vg rna] Adding " << ((add_reference_transcript_paths) ? "reference" : "projected")
+                cerr << context << ": Adding " << ((add_reference_transcript_paths) ? "reference" : "projected")
                      << " transcripts as embedded paths in the graph ..." << endl;
             }
         }
 
         transcriptome.embed_transcript_paths(add_reference_transcript_paths, add_projected_transcript_paths);
 
-        if (show_progress) { cerr << "[vg rna] Transcript paths added in " << gcsa::readTimer() - time_add_start 
+        if (show_progress) { cerr << context << ": Transcript paths added in " << gcsa::readTimer() - time_add_start 
                                   << " seconds, " << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl; };
     }
 
@@ -541,7 +521,9 @@ int32_t main_rna(int32_t argc, char** argv) {
 
     if (write_pantranscriptome) {
 
-        if (show_progress) { cerr << "[vg rna] Writing pantranscriptome transcripts to file(s) ..." << endl; }
+        if (show_progress) {
+            cerr << context << ": Writing pantranscriptome transcripts to file(s) ..." << endl;
+        }
     }
 
     // Write transcript paths in transcriptome as GBWT index.
@@ -564,8 +546,8 @@ int32_t main_rna(int32_t argc, char** argv) {
     // Write a haplotype GBWT with node IDs updated to match the spliced graph.
     if (!hap_gbwt_out_filename.empty()) {
         if (!haplotype_index.get()) {
-            cerr << "[vg rna] Warning: not saving updated haplotypes to " << hap_gbwt_out_filename 
-                 << " because haplotypes were not provided as input" << endl;
+            emit_warning(context, "not saving updated haplotypes to " + hap_gbwt_out_filename 
+                                  + " because haplotypes were not provided as input");
         }
         else {
             ofstream hap_gbwt_ostream;
@@ -597,13 +579,13 @@ int32_t main_rna(int32_t argc, char** argv) {
         info_ostream.close();
     }    
 
-    if (show_progress) { cerr << "[vg rna] Writing splicing graph to stdout ..." << endl; }
+    if (show_progress) { cerr << context << ": Writing splicing graph to stdout ..." << endl; }
 
     // Write splicing graph to stdout 
     transcriptome.write_graph(&cout);
 
     if (show_progress) {
-        cerr << "[vg rna] Graph " << (write_pantranscriptome ? "and pantranscriptome " : "")
+        cerr << context << ": Graph " << (write_pantranscriptome ? "and pantranscriptome " : "")
              << "written in " << gcsa::readTimer() - time_writing_start << " seconds, " 
              << gcsa::inGigabytes(gcsa::memoryUsage()) << " GB" << endl;
     };

--- a/src/subcommand/sift_main.cpp
+++ b/src/subcommand/sift_main.cpp
@@ -18,6 +18,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg sift]";
+
 //TODO ideal behavior is to filter READ PAIRS
 //when a mate fails one of the individual read filters.
 //
@@ -57,16 +59,15 @@ void help_sift(char** argv) {
 }
 
 
-int main_sift(int argc, char** argv){
+int main_sift(int argc, char** argv) {
 
-    if (argc <= 2){
+    if (argc <= 2) {
         help_sift(argv);
         return 1;
     }
 
     string alignment_file = "";
     string graph_name = "";
-    int threads = 1;
 
     bool inverse = false;
     bool is_paired = false;
@@ -148,10 +149,10 @@ int main_sift(int argc, char** argv){
                 help_sift(argv);
                 return 1;
             case 't':
-                threads = parse<int>(optarg);
+                omp_set_num_threads(parse_thread_count(context, optarg));
                 break;
             case 'G':
-                graph_name = optarg;
+                graph_name = error_if_file_does_not_exist(context, optarg);
                 break;
             case 'u':
                 do_unmapped = true;
@@ -165,7 +166,7 @@ int main_sift(int argc, char** argv){
                 break;
             case 's':
                 do_split_read = true;
-                if (softclip_max < 0){
+                if (softclip_max < 0) {
                     softclip_max = 15;
                     ff.set_soft_clip_limit(15);
                 }
@@ -227,29 +228,27 @@ int main_sift(int argc, char** argv){
 
     }
 
-    if (optind >= argc){
-        cerr << "Error: no alignment file given" << endl;
-        exit(1);
+    if (optind >= argc) {
+        error_and_exit(context, "No alignment file given");
     }
     alignment_file = argv[optind];
 
-    cerr << "Filtering  " << alignment_file << endl;
+    cerr << context << ": Filtering  " << alignment_file << endl;
 
     vg::VG* graph;
-    if (!graph_name.empty()){
+    if (!graph_name.empty()) {
         ifstream gstream(graph_name);
         ff.my_vg = new vg::VG(gstream);
     }
 
-    omp_set_num_threads(threads);
     ff.set_inverse(inverse);
 
-    if (softclip_max >= 0){
+    if (softclip_max >= 0) {
         ff.set_soft_clip_limit(softclip_max);
     }
 
 
-    if (do_all){
+    if (do_all) {
     do_orientation = true;
     do_oea = true;
     do_insert_size = true;
@@ -307,42 +306,42 @@ int main_sift(int argc, char** argv){
     ofstream clean_stream;
     ofstream perfect_stream;
 
-    if (do_reversing){
+    if (do_reversing) {
         reversing_stream.open(reversing_fn);
     }
 
-    if (do_unmapped){
+    if (do_unmapped) {
         unmapped_stream.open(unmapped_fn);
     }
 
-    if (do_orientation){
+    if (do_orientation) {
         discordant_stream.open(discordant_fn);
     }
 
-    if (do_oea){
+    if (do_oea) {
         oea_stream.open(oea_fn);
     }
 
-    if (do_split_read){
+    if (do_split_read) {
         split_stream.open(split_fn);
     }
-    if (do_insert_size){
+    if (do_insert_size) {
         insert_stream.open(insert_fn);
     }
-    if (do_softclip){
+    if (do_softclip) {
         clipped_stream.open(clipped_fn);
     }
 
-    std::function<bool(Alignment, Alignment)> normalish = [&](Alignment a, Alignment b){
+    std::function<bool(Alignment, Alignment)> normalish = [&](Alignment a, Alignment b) {
         bool a_forward = true;
         bool b_reverse = false;
-        for (int i = 0; i < a.path().mapping_size(); i++){
-            if (a.path().mapping(i).position().is_reverse()){
+        for (int i = 0; i < a.path().mapping_size(); i++) {
+            if (a.path().mapping(i).position().is_reverse()) {
                 a_forward = false;
             }
         }
-        for (int i = 0; i < b.path().mapping_size(); i++){
-            if (b.path().mapping(i).position().is_reverse()){
+        for (int i = 0; i < b.path().mapping_size(); i++) {
+            if (b.path().mapping(i).position().is_reverse()) {
                 b_reverse = true;
             }
         }
@@ -350,12 +349,12 @@ int main_sift(int argc, char** argv){
     };
 
 
-    std::function<void(Alignment&, Alignment&)> pair_filters = [&](Alignment& alns_first, Alignment& alns_second){
+    std::function<void(Alignment&, Alignment&)> pair_filters = [&](Alignment& alns_first, Alignment& alns_second) {
         bool ret;
         bool flagged = false;
 
-        if (do_unmapped && !flagged){
-            if (ff.unmapped_filter(alns_first) && ff.unmapped_filter(alns_second)){
+        if (do_unmapped && !flagged) {
+            if (ff.unmapped_filter(alns_first) && ff.unmapped_filter(alns_second)) {
 
                     #pragma omp critical (unmapped_selected)
                     {
@@ -371,10 +370,10 @@ int main_sift(int argc, char** argv){
                 }
         }
 
-        if (do_orientation && !flagged){
+        if (do_orientation && !flagged) {
             
             ret = ff.pair_orientation_filter(alns_first, alns_second);
-            if (ret){
+            if (ret) {
                 #pragma omp critical (discordant_selected)
             {
                 flagged = true;
@@ -385,9 +384,9 @@ int main_sift(int argc, char** argv){
             
 
         }
-        if (do_oea && !flagged){
+        if (do_oea && !flagged) {
             ret = ff.one_end_anchored_filter(alns_first, alns_second);
-            if (ret){
+            if (ret) {
                 #pragma omp critical (oea_selected)
                 {
                     one_end_anchored.push_back(alns_first);
@@ -397,10 +396,10 @@ int main_sift(int argc, char** argv){
             
 
         }
-        if (do_insert_size && !flagged){
+        if (do_insert_size && !flagged) {
             
             ret = ff.insert_size_filter(alns_first, alns_second);
-            if (ret){
+            if (ret) {
                 #pragma omp critical (insert_selected)
                 {
                     insert_selected.push_back(alns_first);
@@ -411,9 +410,9 @@ int main_sift(int argc, char** argv){
 
 
         }
-        if (do_split_read && !flagged){
+        if (do_split_read && !flagged) {
 
-            if (ff.split_read_filter(alns_first)){
+            if (ff.split_read_filter(alns_first)) {
                 #pragma omp critical (split_selected)
                 {
                     split_selected.push_back(alns_first);
@@ -423,7 +422,7 @@ int main_sift(int argc, char** argv){
                 }
                 
             }
-            if (ff.split_read_filter(alns_second)){
+            if (ff.split_read_filter(alns_second)) {
                 #pragma omp critical (split_selected)
                 {
                     split_selected.push_back(alns_first);
@@ -435,10 +434,10 @@ int main_sift(int argc, char** argv){
             
 
         }
-        if (do_reversing && !flagged){
+        if (do_reversing && !flagged) {
             Alignment x = ff.reversing_filter(alns_first);
             Alignment y = ff.reversing_filter(alns_second);
-            if (x.name() != "" || y.name() != ""){
+            if (x.name() != "" || y.name() != "") {
                #pragma omp critical (reversing_selected)
                {
                    reversing_selected.push_back(alns_first);
@@ -449,18 +448,18 @@ int main_sift(int argc, char** argv){
 
 
         }
-        if (do_softclip && !flagged){
+        if (do_softclip && !flagged) {
 
             bool x = ff.soft_clip_filter(alns_first);
             bool y = ff.soft_clip_filter(alns_second);
-            if (x){
+            if (x) {
                 #pragma omp critical (clipped_selected)
                 {
                     clipped_selected.push_back(alns_first);
                     flagged = true;
                 }
             } 
-            if (y){
+            if (y) {
                 #pragma omp critical (clipped_selected)
                 {
                     flagged = true;
@@ -469,7 +468,7 @@ int main_sift(int argc, char** argv){
             } 
 
         }
-        if (do_quality && !flagged){
+        if (do_quality && !flagged) {
 
             #pragma omp critical (quality_selected)
             {
@@ -478,7 +477,7 @@ int main_sift(int argc, char** argv){
             }
 
         }
-        if (do_depth && !flagged){
+        if (do_depth && !flagged) {
 
             #pragma omp critical (depth_selected)
             {
@@ -487,10 +486,10 @@ int main_sift(int argc, char** argv){
             }
             
         }
-        if (!flagged){
+        if (!flagged) {
             // Check if read is perfect
 
-            if (ff.perfect_filter(alns_first) && ff.perfect_filter(alns_second)){
+            if (ff.perfect_filter(alns_first) && ff.perfect_filter(alns_second)) {
 
             }
             else{
@@ -516,24 +515,24 @@ int main_sift(int argc, char** argv){
         vg::io::write_buffered(perfect_stream, perfect, 100);
     };
 
-    std::function<void(Alignment&)> single_filters = [&](Alignment& aln){
-        if (do_split_read){
+    std::function<void(Alignment&)> single_filters = [&](Alignment& aln) {
+        if (do_split_read) {
             split_selected.push_back(aln);
         }
-        if (do_reversing){
+        if (do_reversing) {
             reversing_selected.push_back(aln);
         }
-        if (do_softclip){
-           if (ff.soft_clip_filter(aln)){
+        if (do_softclip) {
+           if (ff.soft_clip_filter(aln)) {
                 clipped_selected.push_back(aln);
            }
            //vg::io::write_buffered(clipped_stream, clipped_selected, 1000);
 
         }
-        if (do_quality){
+        if (do_quality) {
             quality_selected.push_back(aln);
         }
-        if (do_depth){
+        if (do_depth) {
             depth_selected.push_back(aln);
         }
 
@@ -543,12 +542,12 @@ int main_sift(int argc, char** argv){
     // double insert_tot = 0.0;
     // int insert_count = 0;
     // double curr_sigma = 0.0;
-    // std::function<void(Alignment&, Alignment&)> calc_insert = [&](Alignment& a, Alignment& b){
-    //     if (a.fragment_size() > 1){
+    // std::function<void(Alignment&, Alignment&)> calc_insert = [&](Alignment& a, Alignment& b) {
+    //     if (a.fragment_size() > 1) {
     //         insert_count += 1;
     //         insert_tot += (double) a.fragment(0).length();   
     //     }
-    //     else if (b.fragment_size() > 1){
+    //     else if (b.fragment_size() > 1) {
 
     //     }
     // };
@@ -557,21 +556,19 @@ int main_sift(int argc, char** argv){
 
 
 
-if (alignment_file == "-"){
-    vg::io::for_each_interleaved_pair_parallel(cin, pair_filters);
-}
-else{
-    ifstream in;
-    in.open(alignment_file);
-    if (in.good()){
-
-        // if (just_calc_insert){
+    if (alignment_file == "-") {
+        vg::io::for_each_interleaved_pair_parallel(cin, pair_filters);
+    }
+    else {
+        ifstream in;
+        in.open(alignment_file);
+        // if (just_calc_insert) {
         //     vg::io::for_each_interleaved_pair_parallel(in, calc_insert);
         //     exit(0);
         // }
 
-        if (is_paired){
-            cerr << "Processing..." << endl;
+        if (is_paired) {
+            cerr << context << ": Processing..." << endl;
             vg::io::for_each_interleaved_pair_parallel(in, pair_filters);
         }
         else{
@@ -579,11 +576,7 @@ else{
 
         }
     }
-    else{
-        cerr << "Could not open " << alignment_file << endl;
-        help_sift(argv);
-    }
-}
+    
     vg::io::write_buffered(unmapped_stream, unmapped_selected, 0);
     vg::io::write_buffered(discordant_stream, discordant_selected, 0);
     vg::io::write_buffered(oea_stream, one_end_anchored, 0);

--- a/src/subcommand/sim_main.cpp
+++ b/src/subcommand/sim_main.cpp
@@ -30,6 +30,8 @@ using namespace vg;
 using namespace vg::subcommand;
 using namespace vg::io;
 
+const string context = "[vg sim]";
+
 // Gets the transcript IDs and TPM values from an RSEM output .tsv file
 vector<pair<string, double>> parse_rsem_expression_file(istream& rsem_in) {
     vector<pair<string, double>> return_val;
@@ -46,10 +48,9 @@ vector<pair<string, double>> parse_rsem_expression_file(istream& rsem_in) {
             token.clear();
         }
         if (tokens.size() != 8) {
-            cerr << "[vg sim] error: Cannot parse transcription file. "
-                 << "Expected 8-column TSV file as produced by RSEM, got "
-                 << tokens.size() << " columns." << endl;
-            exit(1);
+            error_and_exit(context, "Cannot parse transcription file. "
+                                    "Expected 8-column TSV file as produced by RSEM, got "
+                                     + to_string(tokens.size()) + " columns.");
         }
         return_val.emplace_back(tokens[0], parse<double>(tokens[5]));
         line.clear();
@@ -73,10 +74,9 @@ vector<tuple<string, string, size_t>> parse_haplotype_transcript_file(istream& h
             token.clear();
         }
         if (tokens.size() != 5) {
-            cerr << "[vg sim] error: Cannot parse haplotype transcript file. "
-                 << "Expected 5-column TSV file as produced by vg rna -i, got "
-                 << tokens.size() << " columns." << endl;
-            exit(1);
+            error_and_exit(context, "Cannot parse haplotype transcript file. "
+                                    "Expected 5-column TSV file as produced by vg rna -i, got "
+                                     + to_string(tokens.size()) + " columns.");
         }
         // contributing haplotypes are separeted by commas
         size_t haplo_count = 1 + std::count(tokens[4].begin(), tokens[4].end(), ',');
@@ -152,7 +152,6 @@ int main_sim(int argc, char** argv) {
     int num_reads = 1;
     int read_length = 100;
     bool progress = false;
-    int threads = 1;
 
     int seed_val = time(NULL);
     double base_error = 0;
@@ -249,7 +248,7 @@ int main_sim(int argc, char** argv) {
         {
 
         case 'x':
-            xg_name = optarg;
+            xg_name = error_if_file_does_not_exist(context, optarg);
             break;
             
         case 'r':
@@ -257,16 +256,7 @@ int main_sim(int argc, char** argv) {
             break;
 
         case 'F':
-            if (fastq_name.empty()) {
-                fastq_name = optarg;
-            }
-            else if (fastq_2_name.empty()) {
-                fastq_2_name = optarg;
-            }
-            else {
-                cerr << "error: cannot provide more than 2 FASTQs to train simulator" << endl;
-                exit(1);
-            }
+            assign_fastq_files(context, optarg, fastq_name, fastq_2_name);
             break;
             
         case 'I':
@@ -290,8 +280,7 @@ int main_sim(int argc, char** argv) {
                 // For each comma-separated rule
                 auto parts = split_delims(rule, ":");
                 if (parts.size() != 2) {
-                    cerr << "error: ploidy rules must be REGEX:PLOIDY" << endl;
-                    exit(1);
+                    error_and_exit(context, "ploidy rules must be REGEX:PLOIDY");
                 }
                 try {
                     // Parse the regex
@@ -301,22 +290,21 @@ int main_sim(int argc, char** argv) {
                     ploidy_rules.emplace_back(match, weight);
                 } catch (const std::regex_error& e) {
                     // This is not a good regex
-                    cerr << "error: unacceptable regular expression \"" << parts[0] << "\": " << e.what() << endl;
-                    exit(1);
+                    error_and_exit(context, "unacceptable regular expression \"" + parts[0] + "\": " + e.what());
                 }
             }
             break;
 
         case 'g':
-            gbwt_name = optarg;
+            gbwt_name = error_if_file_does_not_exist(context, optarg);
             break;
 
         case 'T':
-            rsem_file_name = optarg;
+            rsem_file_name = error_if_file_does_not_exist(context, optarg);
             break;
                 
         case 'H':
-            haplotype_transcript_file_name = optarg;
+            haplotype_transcript_file_name = error_if_file_does_not_exist(context, optarg);
             break;
 
         case 'l':
@@ -331,9 +319,8 @@ int main_sim(int argc, char** argv) {
             seed_val = parse<int>(optarg);
             if (seed_val == 0) {
                 // Don't let the user specify seed 0 as we will confuse it with no deterministic seed.
-                cerr << "error[vg sim]: seed 0 cannot be used. "
-                     << "Omit the seed option if you want nondeterministic results." << endl;
-                exit(1);
+                error_and_exit(context, "seed 0 cannot be used. Omit the seed option "
+                                        "if you want nondeterministic results.");
             }
             break;
 
@@ -358,26 +345,14 @@ int main_sim(int argc, char** argv) {
             break;
 
         case 'a':
-            if (fastq_out) {
-                cerr << "[vg sim] error: only one output format (-a/-J or -q) can be selected." << endl;
-                exit(1);
-            }
             align_out = true;
             break;
 
         case 'q':
-            if (align_out) {
-                cerr << "[vg sim] error: only one output format (-a/-J or -q) can be selected." << endl;
-                exit(1);
-            }
             fastq_out = true;
             break;
 
         case 'J':
-            if (fastq_out) {
-                cerr << "[vg sim] error: only one output format (-a/-J or -q) can be selected." << endl;
-                exit(1);
-            }
             json_out = true;
             align_out = true;
             break;
@@ -407,11 +382,11 @@ int main_sim(int argc, char** argv) {
             break;
                 
         case 't':
-            threads = parse<int>(optarg);
+            omp_set_num_threads(parse_thread_count(context, optarg));
             break;
                 
         case 'E':
-            path_pos_filename = optarg;
+            path_pos_filename = error_if_file_does_not_exist(context, optarg);
             break;
             
         case 'h':
@@ -424,8 +399,6 @@ int main_sim(int argc, char** argv) {
             abort ();
         }
     }
-    
-    omp_set_num_threads(threads);
     
     // We'll fill this in with ploidies for each path in path_names
     std::vector<double> path_ploidies;
@@ -443,70 +416,62 @@ int main_sim(int argc, char** argv) {
         return 2.0;
     };
 
+    if (align_out && fastq_out) {
+        error_and_exit(context, "only one output format (-a/-J or -q) can be selected.");
+    }
+
     if (xg_name.empty()) {
-        cerr << "[vg sim] error: we need a graph to sample reads from" << endl;
-        return 1;
+        error_and_exit(context, "we need a graph to sample reads from");
     }
     if (!gbwt_name.empty() && sample_names.empty() && rsem_file_name.empty()) {
-        cerr << "[vg sim] error: --gbwt-name requires --sample-name or --tx-expr-file" << endl;
-        return 1;
+        error_and_exit(context, "--gbwt-name requires --sample-name or --tx-expr-file");
     }
     if (!gbwt_name.empty() && !rsem_file_name.empty() && !haplotype_transcript_file_name.empty()) {
         // TODO: This message doesn't really make sense.
-        cerr << "[vg sim] error: using --gbwt-name requires that HSTs be included --tx-expr-file, "
-             << "combination with --haplo-tx-file is not implemented" << endl;
-        return 1;
+        error_and_exit(context, "using --gbwt-name requires that HSTs be included --tx-expr-file; "
+                                "combination with --haplo-tx-file is not implemented");
     }
 
     if (!rsem_file_name.empty()) {
         if (progress) {
-            std::cerr << "Reading transcription profile from " << rsem_file_name << std::endl;
+            std::cerr << context << ": Reading transcription profile from "
+                      << rsem_file_name << std::endl;
         }
         ifstream rsem_in(rsem_file_name);
-        if (!rsem_in) {
-            cerr << "[vg sim] error: could not open transcription profile file " << rsem_file_name << endl;
-            return 1;
-        }
         transcript_expressions = parse_rsem_expression_file(rsem_in);
     }
     
     if (!haplotype_transcript_file_name.empty()) {
         if (progress) {
-            std::cerr << "Reading haplotype transcript file " << haplotype_transcript_file_name << std::endl;
+            std::cerr << context << ": Reading haplotype transcript file "
+                      << haplotype_transcript_file_name << std::endl;
         }
         ifstream haplo_tx_in(haplotype_transcript_file_name);
-        if (!haplo_tx_in) {
-            cerr << "[vg sim] error: could not open haplotype transcript file "
-                 << haplotype_transcript_file_name << endl;
-            return 1;
-        }
         haplotype_transcripts = parse_haplotype_transcript_file(haplo_tx_in);
     }
 
     if (progress) {
-        std::cerr << "Loading graph " << xg_name << std::endl;
+        std::cerr << context << ": Loading graph " << xg_name << std::endl;
     }
     unique_ptr<PathHandleGraph> path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
     
     if (!path_pos_filename.empty() && fastq_name.empty()) {
-        cerr << "[vg sim] error: path usage table is not available unless using trained simulation (-F)" << endl;
-        exit(1);
+        error_and_exit(context, "path usage table is not available unless using trained simulation (-F)");
     }
     
     if (fastq_name.empty() && unsheared_fragments) {
-        cerr << "[vg sim] error: unsheared fragment option only available "
-             << "when simulating from FASTQ-trained errors" << endl;
-        exit(1);
+        error_and_exit(context, "unsheared fragment option only available "
+                                "when simulating from FASTQ-trained errors");
     }
     
     // Deal with path names. Do this before we create paths to represent threads.
     if (any_path) {
         if (progress) {
-            std::cerr << "Selecting all " << path_handle_graph->get_path_count() << " paths" << std::endl;
+            std::cerr << context << ": Selecting all " << path_handle_graph->get_path_count()
+                      << " paths" << std::endl;
         }
         if (path_handle_graph->get_path_count() == 0) {
-            cerr << "[vg sim] error: the graph does not contain paths" << endl;
-            return 1;
+            error_and_exit(context, "the graph does not contain paths");
         }
         path_names.clear();
         path_handle_graph->for_each_path_handle([&](const path_handle_t& handle) {
@@ -519,12 +484,11 @@ int main_sim(int argc, char** argv) {
         });
     } else if (!path_names.empty()) {
         if (progress) {
-            std::cerr << "Checking " << path_names.size() << " selected paths" << std::endl;
+            std::cerr << context << ": Checking " << path_names.size() << " selected paths" << std::endl;
         }
         for (auto& path_name : path_names) {
             if (path_handle_graph->has_path(path_name) == false) {
-                cerr << "[vg sim] error: path \""<< path_name << "\" not found in index" << endl;
-                return 1;
+                error_and_exit(context, "path \"" + path_name + "\" not found in index");
             }
             // Synthesize ploidies for explicitly specified paths
             path_ploidies.push_back(consult_ploidy_rules(path_name));
@@ -545,7 +509,7 @@ int main_sim(int argc, char** argv) {
         
         // We actually want to visit them, so we have to find them
         if (progress) {
-            std::cerr << "Inventorying contigs" << std::endl;
+            std::cerr << context << ": Inventorying contigs" << std::endl;
         }
         // We assume the generic paths in the graph are contigs ("chr1", "chr2", etc.)
         path_handle_graph->for_each_path_of_sense(PathSense::GENERIC, [&](const path_handle_t& handle) {
@@ -560,13 +524,12 @@ int main_sim(int argc, char** argv) {
     // Deal with GBWT threads
     if (!gbwt_name.empty()) {
         if (progress) {
-            std::cerr << "Loading GBWT index " << gbwt_name << std::endl;
+            std::cerr << context << ": Loading GBWT index " << gbwt_name << std::endl;
         }
         std::unique_ptr<gbwt::GBWT> gbwt_index = vg::io::VPKG::load_one<gbwt::GBWT>(gbwt_name);
         if (!(gbwt_index->hasMetadata()) || !(gbwt_index->metadata.hasSampleNames()) 
                                               || !(gbwt_index->metadata.hasPathNames())) {
-            std::cerr << "[vg sim] error: GBWT index does not contain sufficient metadata" << std::endl;
-            return 1;
+            error_and_exit(context, "GBWT index does not contain sufficient metadata");
         }
         
         // we will add these threads to the graph as named paths and index them for easy look up
@@ -575,14 +538,13 @@ int main_sim(int argc, char** argv) {
         if (!sample_names.empty()) {
             // we're consulting the provided sample names to determine which threads to include
             if (progress) {
-                std::cerr << "Checking " << sample_names.size() << " samples" << std::endl;
+                std::cerr << context << ": Checking " << sample_names.size() << " samples" << std::endl;
             }
             for (std::string& sample_name : sample_names) {
                 gbwt::size_type id = gbwt_index->metadata.sample(sample_name);
                 if (id >= gbwt_index->metadata.samples()) {
-                    std::cerr << "[vg sim] error: sample \"" << sample_name 
-                              << "\" not found in the GBWT index" << std::endl;
-                    return 1;
+                    error_and_exit(context, "sample \"" + sample_name 
+                                        + "\" not found in the GBWT index");
                 }
                 auto idx = sample_id_to_idx.size();
                 sample_id_to_idx[id] = idx;
@@ -593,9 +555,8 @@ int main_sim(int argc, char** argv) {
             for (const auto& transcript_expression  : transcript_expressions) {
                 gbwt::size_type id = gbwt_index->metadata.sample(transcript_expression.first);
                 if (id >= gbwt_index->metadata.samples()) {
-                    std::cerr << "[vg sim] error: haplotype-specific transcript \"" << transcript_expression.first
-                              << "\" not found in the GBWT index" << std::endl;
-                    return 1;
+                    error_and_exit(context, "haplotype-specific transcript \"" + transcript_expression.first
+                                        + "\" not found in the GBWT index");
                 }
                 auto idx = sample_id_to_idx.size();
                 sample_id_to_idx[id] = idx;
@@ -606,14 +567,15 @@ int main_sim(int argc, char** argv) {
             = dynamic_cast<MutablePathMutableHandleGraph*>(path_handle_graph.get());
         if (mutable_graph == nullptr) {
             if (progress) {
-                std::cerr << "Converting the graph into HashGraph" << std::endl;
+                std::cerr << context << ": Converting the graph into HashGraph" << std::endl;
             }
             mutable_graph = new bdsg::HashGraph();
             handlealgs::copy_path_handle_graph(path_handle_graph.get(), mutable_graph);
             path_handle_graph.reset(mutable_graph);
         }
         if (progress) {
-            std::cerr << "Inserting " << sample_id_to_idx.size() << " GBWT threads into the graph" << std::endl;
+            std::cerr << context << ": Inserting " << sample_id_to_idx.size()
+                      << " GBWT threads into the graph" << std::endl;
         }
         
         for (gbwt::size_type i = 0; i < gbwt_index->metadata.paths(); i++) {
@@ -648,7 +610,8 @@ int main_sim(int argc, char** argv) {
             }
         }
         if (progress) {
-            std::cerr << "Inserted " << inserted_path_names.size() << " paths" << std::endl;
+            std::cerr << context << ": Inserted " << inserted_path_names.size()
+                      << " paths" << std::endl;
         }
     } else {
         // We're not using a separate GBWT, so when asked to simulate from a
@@ -661,15 +624,14 @@ int main_sim(int argc, char** argv) {
 
             if (sample_name_set.size() != sample_names.size()) {
                 // Do a quick check for duplicates since we've bothered to make the set.
-                std::cerr << "[vg sim] error: Of the " << sample_names.size()
-                          << " samples, there are only " << sample_name_set.size()
-                          << " distinct values. Remove the duplicate entries." << std::endl;
-                return 1;
+                error_and_exit(context, "Of the " + std::to_string(sample_names.size())
+                                         + " samples, there are only " + to_string(sample_name_set.size())
+                                         + " distinct values. Remove the duplicate entries.");
             }
 
             if (progress) {
-                std::cerr << "Finding matching paths for " << sample_name_set.size()
-                          << " samples" << std::endl;
+                std::cerr << context << ": Finding matching paths for "
+                          << sample_name_set.size() << " samples" << std::endl;
             }
 
             // Also keep a set of sample names actually seen
@@ -692,19 +654,20 @@ int main_sim(int argc, char** argv) {
             });
 
             if (seen_sample_names.size() != sample_name_set.size()) {
-                // TODO: Use std::set_difference in C++17.
-                std::cerr << "[vg sim] error: Some samples requested are not in the graph:";
+                // TODO: Use std::set_difference in C++17
+                stringstream error_msg;
+                error_msg << "Some samples requested are not in the graph:";
                 for (auto& s : sample_name_set) {
                     if (!seen_sample_names.count(s)) {
-                        std::cerr << " " << s;
+                        error_msg << " " << s;
                     }
                 }
-                std::cerr << std::endl;
-                return 1;
+                error_and_exit(context, error_msg.str());
             }
 
             if (progress) {
-                std::cerr << "Using " << sample_path_count << " sample paths" << std::endl;
+                std::cerr << context << ": Using " << sample_path_count
+                          << " sample paths" << std::endl;
             }
         }
     }
@@ -718,41 +681,41 @@ int main_sim(int argc, char** argv) {
             path_ploidies.push_back(consult_ploidy_rules(name));
         }
         if (progress) {
-            std::cerr << "Also sampling from " << unvisited_contigs.size() << " paths representing unvisited contigs" << std::endl;
+            std::cerr << context << ": Also sampling from " << unvisited_contigs.size()
+                      << " paths representing unvisited contigs" << std::endl;
         }
     }
     
     if (haplotype_transcript_file_name.empty()) {
         if (!transcript_expressions.empty()) {
             if (progress) {
-                std::cerr << "Checking " << transcript_expressions.size() << " transcripts" << std::endl;
+                std::cerr << context << ": Checking " << transcript_expressions.size()
+                          << " transcripts" << std::endl;
             }
             for (auto& transcript_expression : transcript_expressions) {
                 if (!path_handle_graph->has_path(transcript_expression.first)) {
-                    cerr << "[vg sim] error: transcript path for \""<< transcript_expression.first 
-                         << "\" not found in index" << endl;
-                    cerr << "if you embedded haplotype-specific transcripts in the graph, "
-                         << "you may need the haplotype transcript file from vg rna -i" << endl;
-                    return 1;
+                    error_and_exit(context, "transcript path \"" + transcript_expression.first 
+                                            + "\" not found in index. If you embedded haplotype-specific transcripts "
+                                            "in the graph, you may need the haplotype transcript file from vg rna -i");
                 }
             }
         }
     }
     else {
         if (progress) {
-            std::cerr << "Checking " << haplotype_transcripts.size() << " haplotype transcripts" << std::endl;
+            std::cerr << context << ": Checking " << haplotype_transcripts.size()
+                      << " haplotype transcripts" << std::endl;
         }
         for (auto& haplotype_transcript : haplotype_transcripts) {
             if (!path_handle_graph->has_path(get<0>(haplotype_transcript))) {
-                cerr << "[vg sim] error: transcript path for \""<< get<0>(haplotype_transcript) 
-                     << "\" not found in index" << endl;
-                return 1;
+                error_and_exit(context, "transcript path for \"" + get<0>(haplotype_transcript) 
+                                         + "\" not found in index.");
             }
         }
     }
     
     if (progress) {
-        std::cerr << "Creating path position overlay" << std::endl;
+        std::cerr << context << ": Creating path position overlay" << std::endl;
     }
     
     bdsg::ReferencePathVectorizableOverlayHelper overlay_helper;
@@ -773,7 +736,7 @@ int main_sim(int argc, char** argv) {
     unordered_set<path_handle_t> inserted_path_handles;
     if (!inserted_path_names.empty()) {
         if (progress) {
-            std::cerr << "Finding inserted paths" << std::endl;
+            std::cerr << context << ": Finding inserted paths" << std::endl;
         }
         for (auto& name : inserted_path_names) {
             inserted_path_handles.insert(xgidx->get_path_handle(name));
@@ -789,7 +752,7 @@ int main_sim(int argc, char** argv) {
     // Otherwise we're just dumping sequence strings; leave it null.
     
     if (progress) {
-        std::cerr << "Simulating " << (fragment_length > 0 ? "read pairs" : "reads") << std::endl;
+        std::cerr << context << ": Simulating " << (fragment_length > 0 ? "read pairs" : "reads") << std::endl;
         std::cerr << "--num-reads " << num_reads << std::endl;
         std::cerr << "--read-length " << read_length << std::endl;
         if (align_out) {
@@ -847,7 +810,7 @@ int main_sim(int argc, char** argv) {
         // Use the fixed error rate sampler
         
         if (unsheared_fragments) {
-            cerr << "warning: Unsheared fragment option only available when simulating from FASTQ-trained errors" << endl;
+            emit_warning(context, "Unsheared fragments option is only available when simulating from FASTQ-trained errors");
         }
         
         sampler.reset(new Sampler(xgidx, seed_val, forward_only, reads_may_contain_Ns, path_names,

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -23,6 +23,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg sort]";
+
 void help_sort(char** argv) {
     cerr << "usage: " << argv[0] << " sort [options] > sorted.vg " << endl
          << "options: " << endl
@@ -87,7 +89,7 @@ int main_sort(int argc, char *argv[]) {
             without_grooming = true;
             break;
         case 'I':
-            sorted_index_filename = optarg;
+            sorted_index_filename = error_if_file_cannot_be_written(context, optarg);
             break;
         case 'h':
         case '?':
@@ -108,25 +110,20 @@ int main_sort(int argc, char *argv[]) {
     // Validate the algorithm selection and option combination
     if (algorithm == "id" || algorithm == "topo") {
         if (!reference_name.empty()) {
-            cerr << "error[vg sort]: Reference name not used with " << algorithm << " sort algorithm" << endl;
-            exit(1);
+            error_and_exit(context, "Reference name not used with " + algorithm + " sort algorithm");
         }
         if (without_grooming) {
-            cerr << "error[vg sort]: Not sensible to turn off grooming with " << algorithm << " sort algorithm" << endl;
-            exit(1);
+            error_and_exit(context, "Not sensible to turn off grooming with " + algorithm + " sort algorithm");
         }
     } else if (algorithm == "max-flow" || algorithm == "eades") {
         if (reference_name.empty()) {
-            cerr << "error[vg sort]: Reference name required with " << algorithm << " sort algorithm" << endl;
-            exit(1);
+            error_and_exit(context, "Reference name required with " + algorithm + " sort algorithm");
         }
     } else {
-        cerr << "error[vg sort]: Unrecognized sort algorithm " << algorithm << endl;
-        exit(1);
+        error_and_exit(context, "Unrecognized sort algorithm: " + algorithm);
     }
     if (!sorted_index_filename.empty() && algorithm != "id") {
-        cerr << "error[vg sort]: Sorted VG index can only be produced when sorting by ID" << endl;
-        exit(1);
+        error_and_exit(context, "Sorted VG index can only be produced when sorting by ID");
     }
     
     // With the input graph file

--- a/src/subcommand/subcommand.hpp
+++ b/src/subcommand/subcommand.hpp
@@ -25,7 +25,7 @@
  * Subcommands get passed all of argv, so they have to skip past their names
  * when parsing arguments.
  *
- * To make a subcommand, do something like this in a cpp file in this
+ * To make a subcommand, do something like this in a *_main.cpp file in this
  * "subcommand" directory:
  * 
  *     #include "subcommand.hpp"
@@ -38,6 +38,8 @@
  *     static Subcommand vg_frobnicate("frobnicate", "frobnicate nodes and edges",
  *         main_frobnicate);
  * 
+ * All src/subcommand/*_main.cpp files must pass the checks (formatting etc.) in
+ * scripts/check_options.py as part of an automated test.
  */
  
 #include <map>

--- a/src/subcommand/trace_main.cpp
+++ b/src/subcommand/trace_main.cpp
@@ -15,12 +15,14 @@ using namespace vg;
 using namespace std;
 using namespace vg::subcommand;
 
+const string context = "[vg trace]";
+
 void help_trace(char** argv) {
     cerr << "usage: " << argv[0] << " trace [options]" << endl
          << "Trace and extract haplotypes from an index" << endl
          << endl
          << "options:" << endl
-         << "  -x, --index FILE            use this xg index or graph" << endl
+         << "  -x, --index FILE            use this XG index or graph" << endl
          << "  -G, --gbwt-name FILE        use GBWT haplotype index instead of any in graph" << endl
          << "  -n, --start-node INT        start at this node ID" << endl
         //TODO: implement backwards iteration over graph
@@ -32,132 +34,129 @@ void help_trace(char** argv) {
 }
 
 int main_trace(int argc, char** argv) {
-  if (argc == 2) {
-      help_trace(argv);
-      return 1;
-  }
-
-  string xg_name;
-  string gbwt_name;
-  string annotation_path;
-  int64_t start_node = 0;
-  int extend_distance = 50;
-  bool backwards = false;
-  bool json = false;
-
-  int c;
-  optind = 2; // force optind past command positional argument
-  while (true) {
-    static struct option long_options[] =
-        {
-            /* These options set a flag. */
-            //{"verbose", no_argument,       &verbose_flag, 1},
-            {"index", required_argument, 0, 'x'},
-            {"gbwt-name", required_argument, 0, 'G'},
-            {"annotation-path", required_argument, 0, 'a'},
-            {"start-node", required_argument, 0, 'n'},
-            {"extend-distance", required_argument, 0, 'd'},
-            {"json", no_argument, 0, 'j'},
-            {"help", no_argument, 0, 'h'},
-            //{"backwards", no_argument, 0, 'b'},
-            {0, 0, 0, 0}
-        };
-
-    int option_index = 0;
-    c = getopt_long (argc, argv, "x:G:a:n:d:jh?",
-                     long_options, &option_index);
-
-    /* Detect the end of the options. */
-    if (c == -1)
-        break;
-
-    switch (c)
-    {
-    case 'x':
-        xg_name = optarg;
-        break;
-
-    case 'G':
-        gbwt_name = optarg;
-        break;
-
-    case 'a':
-        annotation_path = optarg;
-        break;
-
-    case 'n':
-        start_node = parse<int>(optarg);
-        break;
-
-    case 'd':
-        extend_distance = parse<int>(optarg);
-        break;
-
-    case 'j':
-        json = true;
-        break;
-
-    //case 'b':
-        //backwards = true;
-        //break;
-
-    case '?':
-    case 'h':
+    if (argc == 2) {
         help_trace(argv);
         return 1;
-
-    default:
-        help_trace(argv);
-        abort();
     }
-  }
 
-  if (xg_name.empty()) {
-    cerr << "error:[vg trace] xg index must be specified with -x" << endl;
-    return 1;
-  }
-  if (start_node < 1) {
-    cerr << "error:[vg trace] start node must be specified with -n" << endl;
-    return 1;
-  }
-  unique_ptr<PathHandleGraph> path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
-  bdsg::PathPositionOverlayHelper overlay_helper;
-  PathPositionHandleGraph* xindex = overlay_helper.apply(path_handle_graph.get());    
+    string xg_name;
+    string gbwt_name;
+    string annotation_path;
+    int64_t start_node = 0;
+    int extend_distance = 50;
+    bool backwards = false;
+    bool json = false;
 
-  // Now load the haplotype data
-  unique_ptr<gbwt::GBWT> gbwt_index_holder;
-  const gbwt::GBWT* gbwt_index = vg::algorithms::find_gbwt(path_handle_graph.get(), gbwt_index_holder, gbwt_name);
+    int c;
+    optind = 2; // force optind past command positional argument
+    while (true) {
+        static struct option long_options[] =
+            {
+                /* These options set a flag. */
+                //{"verbose", no_argument,       &verbose_flag, 1},
+                {"index", required_argument, 0, 'x'},
+                {"gbwt-name", required_argument, 0, 'G'},
+                {"annotation-path", required_argument, 0, 'a'},
+                {"start-node", required_argument, 0, 'n'},
+                {"extend-distance", required_argument, 0, 'd'},
+                {"json", no_argument, 0, 'j'},
+                {"help", no_argument, 0, 'h'},
+                //{"backwards", no_argument, 0, 'b'},
+                {0, 0, 0, 0}
+            };
 
-  if (gbwt_index == nullptr) {
-    // Complain if we couldn't.
-    cerr << "error:[vg trace] unable to find gbwt index in graph or separate file" << endl;
-    exit(1);
-  }
-  
-  // trace out our graph and paths from the start node
-  Graph trace_graph;
-  map<string, int> haplotype_frequences;
-  trace_haplotypes_and_paths(*xindex, *gbwt_index, start_node, extend_distance,
-                             trace_graph, haplotype_frequences);
+        int option_index = 0;
+        c = getopt_long (argc, argv, "x:G:a:n:d:jh?",
+                         long_options, &option_index);
 
-  // dump our graph to stdout
-  if (json) {
-    cout << pb2json(trace_graph);
-  } else {
-    VG vg_graph;
-    vg_graph.extend(trace_graph);
-    vg_graph.serialize_to_ostream(cout);
-  }
+        /* Detect the end of the options. */
+        if (c == -1)
+            break;
 
-  // if requested, write thread frequencies to a file
-  if (!annotation_path.empty()) {
-    ofstream annotation_file(annotation_path);
-    for (auto tf : haplotype_frequences) {
-      annotation_file << tf.first << "\t" << tf.second << endl;
+        switch (c)
+        {
+        case 'x':
+            xg_name = error_if_file_does_not_exist(context, optarg);
+            break;
+
+        case 'G':
+            gbwt_name = error_if_file_does_not_exist(context, optarg);
+            break;
+
+        case 'a':
+            annotation_path = error_if_file_cannot_be_written(context, optarg);
+            break;
+
+        case 'n':
+            start_node = parse<int>(optarg);
+            break;
+
+        case 'd':
+            extend_distance = parse<int>(optarg);
+            break;
+
+        case 'j':
+            json = true;
+            break;
+
+        //case 'b':
+            //backwards = true;
+            //break;
+
+        case '?':
+        case 'h':
+            help_trace(argv);
+            return 1;
+
+        default:
+            help_trace(argv);
+            abort();
+        }
     }
-  }
 
-  return 0;
+    if (xg_name.empty()) {
+        error_and_exit(context, "XG index must be specified with -x");
+    }
+    if (start_node < 1) {
+        error_and_exit(context, "start node must be specified with -n");
+    }
+    unique_ptr<PathHandleGraph> path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
+    bdsg::PathPositionOverlayHelper overlay_helper;
+    PathPositionHandleGraph* xindex = overlay_helper.apply(path_handle_graph.get());    
+
+    // Now load the haplotype data
+    unique_ptr<gbwt::GBWT> gbwt_index_holder;
+    const gbwt::GBWT* gbwt_index = vg::algorithms::find_gbwt(path_handle_graph.get(), gbwt_index_holder, gbwt_name);
+
+    if (gbwt_index == nullptr) {
+        // Complain if we couldn't.
+        error_and_exit(context, "unable to find GBWT index in graph or separate file");
+    }
+    
+    // trace out our graph and paths from the start node
+    Graph trace_graph;
+    map<string, int> haplotype_frequences;
+    trace_haplotypes_and_paths(*xindex, *gbwt_index, start_node, extend_distance,
+                               trace_graph, haplotype_frequences);
+
+    // dump our graph to stdout
+    if (json) {
+        cout << pb2json(trace_graph);
+    } else {
+        VG vg_graph;
+        vg_graph.extend(trace_graph);
+        vg_graph.serialize_to_ostream(cout);
+    }
+
+    // if requested, write thread frequencies to a file
+    if (!annotation_path.empty()) {
+        ofstream annotation_file(annotation_path);
+        for (auto tf : haplotype_frequences) {
+            annotation_file << tf.first << "\t" << tf.second << endl;
+        }
+    }
+
+    return 0;
 }
 
 static Subcommand vg_trace("trace", "trace haplotypes", main_trace);

--- a/src/subcommand/translate_main.cpp
+++ b/src/subcommand/translate_main.cpp
@@ -20,6 +20,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg translate]";
+
 void help_translate(char** argv) {
     cerr << "usage: " << argv[0] << " translate [options] translation" << endl
          << "Translate alignments or paths using the translation map." << endl
@@ -82,19 +84,19 @@ int main_translate(int argc, char** argv) {
             break;
 
         case 'p':
-            path_file = optarg;
+            path_file = error_if_file_does_not_exist(context, optarg);
             break;
 
         case 'a':
-            aln_file = optarg;
+            aln_file = error_if_file_does_not_exist(context, optarg);
             break;
 
         case 'l':
-            loci_file = optarg;
+            loci_file = error_if_file_does_not_exist(context, optarg);
             break;
 
         case 'o':
-            overlay_file = optarg;
+            overlay_file = error_if_file_does_not_exist(context, optarg);
             break;
 
         case 'h':

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -20,6 +20,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg validate]";
+
 void help_validate(char** argv) {
     cerr << "usage: " << argv[0] << " validate [options] [graph]" << endl
          << "Validate the graph." << endl
@@ -73,7 +75,7 @@ int main_validate(int argc, char** argv) {
                 break;
 
             case 'a':
-                gam_path = optarg;
+                gam_path = error_if_file_does_not_exist(context, optarg);
                 break;
                 
             case 'A':

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -12,6 +12,8 @@
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg viz]";
+
 void help_viz(char** argv) {
     cerr << "usage: " << argv[0] << " viz [options]" << endl
          << "options:" << endl
@@ -79,16 +81,16 @@ int main_viz(int argc, char** argv) {
             help_viz(argv);
             return 1;
         case 'x':
-            xg_name = optarg;
+            xg_name = error_if_file_does_not_exist(context, optarg);
             break;
         case 'n':
             pack_names.push_back(optarg);
             break;
         case 'i':
-            packs_in.push_back(optarg);
+            packs_in.push_back(error_if_file_does_not_exist(context, optarg));
             break;
         case 'o':
-            image_out = optarg;
+            image_out = error_if_file_cannot_be_written(context, optarg);
             break;
         case 'X':
             image_width = parse<int>(optarg);
@@ -117,8 +119,7 @@ int main_viz(int argc, char** argv) {
     unique_ptr<PathHandleGraph> path_handle_graph;
     bdsg::PathPositionVectorizableOverlayHelper overlay_helper;
     if (xg_name.empty()) {
-        cerr << "No input graph given. An input graph (-x) must be provided." << endl;
-        exit(1);
+        error_and_exit(context, "No input graph given. An input graph (-x) must be provided.");
     } else {
         path_handle_graph = vg::io::VPKG::load_one<PathHandleGraph>(xg_name);
         // We know the PathPositionVectorizableOverlayHelper produces a PathPositionVectorizableOverlay

--- a/src/subcommand/zipcode_main.cpp
+++ b/src/subcommand/zipcode_main.cpp
@@ -34,6 +34,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const string context = "[vg zipcode]";
+
 void help_zipcode(char** argv) {
     cerr
     << "usage: " << argv[0] << " test zipcodes on minimizers from reads [options] input.gam > output.gam" << endl
@@ -89,35 +91,21 @@ int main_zipcode(int argc, char** argv) {
         switch (c)
         {
             case 'x':
-                xg_name = optarg;
-                if (xg_name.empty()) {
-                    cerr << "error:[vg zipcode] Must provide XG file with -x." << endl;
-                    exit(1);
-                }
+                xg_name = error_if_file_does_not_exist(context, optarg);
                 break;
                 
             case 'g':
-                gcsa_name = optarg;
-                if (gcsa_name.empty()) {
-                    cerr << "error:[vg zipcode] Must provide GCSA file with -g." << endl;
-                    exit(1);
-                }
+                gcsa_name = error_if_file_does_not_exist(context, optarg);
+                // We also need the LCP index
+                error_if_file_does_not_exist(context, gcsa_name + ".lcp");
                 break;
             
             case 'm':
-                minimizer_name = optarg;
-                if (minimizer_name.empty()) {
-                    cerr << "error:[vg zipcode] Must provide minimizer file with -m." << endl;
-                    exit(1);
-                }
+                minimizer_name = error_if_file_does_not_exist(context, optarg);
                 break;
                 
             case 'd':
-                distance_name = optarg;
-                if (distance_name.empty()) {
-                    cerr << "error:[vg zipcode] Must provide distance index file with -d." << endl;
-                    exit(1);
-                }
+                distance_name = error_if_file_does_not_exist(context, optarg);
                 break;
             
             case 'c':
@@ -125,15 +113,7 @@ int main_zipcode(int argc, char** argv) {
                 break;
                 
             case 't':
-            {
-                int num_threads = parse<int>(optarg);
-                if (num_threads <= 0) {
-                    cerr << "error:[vg zipcode] Thread count (-t) set to " << num_threads 
-                         << ", must set to a positive integer." << endl;
-                    exit(1);
-                }
-                omp_set_num_threads(num_threads);
-            }
+                omp_set_num_threads(parse_thread_count(context, optarg));
                 break;
                 
             case 'h':
@@ -147,19 +127,15 @@ int main_zipcode(int argc, char** argv) {
     
     
     if (xg_name.empty()) {
-        cerr << "error:[vg zipcode] Finding zipcodes requires an XG index, must provide XG file (-x)" << endl;
-        exit(1);
+        error_and_exit(context, "Finding zipcodes requires an XG index, must provide XG file (-x)");
     }
     
     if (gcsa_name.empty() && minimizer_name.empty()) {
-        cerr << "error:[vg zipcode] Finding zipcodes requires a GCSA2 index or minimizer index (-g, -m)" << endl;
-        exit(1);
+        error_and_exit(context, "Finding zipcodes requires a GCSA2 index or minimizer index (-g, -m)");
     }
     
-    
     if (distance_name.empty()) {
-        cerr << "error:[vg zipcode] Finding zipcodes requires a distance index, must provide distance index file (-d)" << endl;
-        exit(1);
+        error_and_exit(context, "Finding zipcodes requires a distance index, must provide distance index file (-d)");
     }
     
     // create in-memory objects

--- a/src/unittest/index_registry.cpp
+++ b/src/unittest/index_registry.cpp
@@ -22,6 +22,8 @@ using namespace std;
 TEST_CASE("IndexRegistry can make plans on a dummy recipe graph", "[indexregistry]") {
     
     TestIndexRegistry registry;
+    // Turn off file existence checking for unit tests
+    registry.check_files = false;
     
     // name the indexes
     registry.register_index("FASTA", "fasta");

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1075,4 +1075,21 @@ void assign_fastq_files(const string& context, const string& input_filename, str
     }
 }
 
+pair<string, string> parse_split_string(const string& context, const string& arg,
+                                        const char& delimiter, const string& option_name) {
+    size_t delim_index = arg.find(delimiter);
+    if (delim_index == string::npos || delim_index == 0 || delim_index + 1 == arg.size()) {
+        error_and_exit(context, option_name + " must have two parts separated by a " + delimiter
+                                + ", not \"" + arg + "\"");
+    }
+    string second_part = arg.substr(delim_index + 1);
+    if (second_part.find(delimiter) != string::npos) {
+        // The second part has another delimiter in it, which is not allowed.
+        error_and_exit(context, option_name + " must have two parts separated by a " + delimiter
+                                + ", not \"" + arg + "\"");
+    }
+    // Parse out the two parts
+    return make_pair(arg.substr(0, delim_index), arg.substr(delim_index + 1));
+}
+
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -687,7 +687,7 @@ string get_input_file_name(int& optind, int argc, char** argv, bool test_open) {
         error_and_exit("[get_input_file_name]", "specify a non-empty input filename");
     }
 
-    if (test_open && file_name != "-") {
+    if (test_open) {
         error_if_file_does_not_exist("[get_input_file_name]", file_name);
     }
     

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -764,6 +764,10 @@ string file_base_name(const string& filename) {
 bool file_exists(const string& filename) {
     // TODO: use C++17 features to actually poll existence.
     // For now we see if we can open it.
+    if (filename == "-") {
+        // Standard input is always open
+        return true;
+    }
     ifstream in(filename);
     return in.is_open();
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -971,4 +971,16 @@ bool parse(const string& arg, pos_t& dest) {
     return true;
 }
 
+int parse_thread_count(const string& arg, const string& context) {
+    int num_threads = parse<int>(arg);
+    
+    if (num_threads <= 0) {
+        cerr << "error" << context << ": Thread count (-t) set to " 
+             << num_threads << ", must set to a positive integer." << endl;
+        exit(1);
+    }
+    
+    return num_threads;
+}
+
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1038,12 +1038,16 @@ bool parse(const string& arg, pos_t& dest) {
     return true;
 }
 
-int parse_thread_count(const string& context, const string& arg) {
+int parse_thread_count(const string& context, const string& arg, int max_threads) {
     int num_threads = parse<int>(arg);
+    if (max_threads == 0) {
+        // If the user didn't specify a maximum, use the OMP default.
+        max_threads = omp_get_max_threads();
+    }
     
     if (num_threads <= 0) {
         error_and_exit(context, "Thread count (-t) must be a positive integer, not " + arg);
-    } else if (num_threads > omp_get_max_threads()) {
+    } else if (num_threads > max_threads) {
         // If the user asked for more threads than we can actually use, cap it.
         emit_warning(context, "Thread count (-t) is greater than the maximum number of threads available (" 
                               + to_string(omp_get_max_threads()) + "), capping to that value");

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -729,14 +729,14 @@ bool file_can_be_written(const string& filename) {
     }
 }
 
-string error_if_file_does_not_exist(const string& filename, const string& context) {
+string error_if_file_does_not_exist(const string& context, const string& filename) {
     if (!file_exists(filename)) {
         error_and_exit(context, "file \"" + filename + "\" does not exist");
     }
     return filename;
 }
 
-string error_if_file_cannot_be_written(const string& filename, const string& context) {
+string error_if_file_cannot_be_written(const string& context, const string& filename) {
     if (!file_can_be_written(filename)) {
         error_and_exit(context, "file \"" + filename + "\" cannot be written to");
     }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -785,7 +785,7 @@ string error_if_file_does_not_exist(const string& context, const string& filenam
 }
 
 void error_if_file_is_gzipped(const string& context, const string& filename) {
-    if (ends_with(filename, vg::GZ_SUFFIX)) {
+    if (ends_with(filename, ".gz")) {
         error_and_exit(context, "file \"" + filename + "\" appears to be gzipped; "
                                 "please decompress it before use");
     }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -25,14 +25,20 @@
 namespace vg {
 
 void error_and_exit(const string& context, const string& message) {
-    cerr << "error" << context << ": ";
-    emit_with_indent(cerr, message, 7 + context.size());
+    #pragma omp critical (cerr)
+    {
+        cerr << "error" << context << ": ";
+        emit_with_indent(cerr, message, 7 + context.size());
+    }
     exit(EXIT_FAILURE);
 }
 
 void emit_warning(const string& context, const string& message) {
-    cerr << "warning" << context << ": ";
-    emit_with_indent(cerr, message, 9 + context.size());
+    #pragma omp critical (cerr)
+    {
+        cerr << "warning" << context << ": ";
+        emit_with_indent(cerr, message, 9 + context.size());
+    }
 }
 
 void emit_with_indent(ostream& outstream, const string& message, size_t indent) {

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -26,7 +26,7 @@ namespace vg {
 
 void error_and_exit(const string& context, const string& message) {
     cerr << "error" << context << ": " << message << endl;
-    exit(1);
+    exit(EXIT_FAILURE);
 }
 
 void emit_warning(const string& context, const string& message) {

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -716,7 +716,7 @@ bool file_exists(const string& filename) {
     return in.is_open();
 }
 
-string error_if_file_does_not_exist(const string& filename, const string& context = "") {
+string error_if_file_does_not_exist(const string& filename, const string& context) {
     if (!file_exists(filename)) {
         // Complain that the user didn't specify a filename
         cerr << "error" << context << ": file \"" << filename << "\" does not exist" << endl;
@@ -931,7 +931,8 @@ bool parse(const string& arg, float& dest) {
 template<>
 bool parse(const string& arg, std::regex& dest) {
     // This throsw std::regex_error if it can't parse.
-    // That contains a kind of useless error code that we can't turn itno a string without switching on all the values.
+    // That contains a kind of useless error code that we
+    // can't turn into a string without switching on all the values.
     dest = std::regex(arg);
     return true;
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1063,4 +1063,16 @@ int parse_thread_count(const string& context, const string& arg, int max_threads
     return num_threads;
 }
 
+void assign_fastq_files(const string& context, const string& input_filename, string& fastq1, string& fastq2) {
+    if (fastq1.empty()) {
+        fastq1 = error_if_file_does_not_exist(context, input_filename);
+    }
+    else if (fastq2.empty()) {
+        fastq2 = error_if_file_does_not_exist(context, input_filename);
+    }
+    else {
+        error_and_exit(context, "Cannot specify more than two FASTQ files");
+    }
+}
+
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -75,8 +75,12 @@ void emit_with_indent(ostream& outstream, const string& message, size_t indent) 
             start_pos = next_pos + 1;
             cur_col += word_length + 1; // +1 for the space
         }
+        if ((line.size() - start_pos) + cur_col > 80) {
+            // If the last word would go past the end of the line, break
+            outstream << "\n" << string(indent, ' ');
+        }
         // Output the last bit of the line
-        outstream << line.substr(start_pos, next_pos - start_pos) << "\n";
+        outstream << line.substr(start_pos) << "\n";
     }
     outstream.flush();
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -716,9 +716,29 @@ bool file_exists(const string& filename) {
     return in.is_open();
 }
 
+bool file_can_be_written(const string& filename) {
+    // Try to open it for writing
+    ofstream out(filename);
+    if (out.is_open()) {
+        // We can write to it, so close it.
+        out.close();
+        return true;
+    } else {
+        // We can't write to it
+        return false;
+    }
+}
+
 string error_if_file_does_not_exist(const string& filename, const string& context) {
     if (!file_exists(filename)) {
         error_and_exit(context, "file \"" + filename + "\" does not exist");
+    }
+    return filename;
+}
+
+string error_if_file_cannot_be_written(const string& filename, const string& context) {
+    if (!file_can_be_written(filename)) {
+        error_and_exit(context, "file \"" + filename + "\" cannot be written to");
     }
     return filename;
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -778,6 +778,13 @@ string error_if_file_does_not_exist(const string& context, const string& filenam
     return filename;
 }
 
+void error_if_file_is_gzipped(const string& context, const string& filename) {
+    if (ends_with(filename, vg::GZ_SUFFIX)) {
+        error_and_exit(context, "file \"" + filename + "\" appears to be gzipped; "
+                                "please decompress it before use");
+    }
+}
+
 string error_if_file_cannot_be_written(const string& context, const string& filename) {
     if (!file_can_be_written(filename)) {
         error_and_exit(context, "file \"" + filename + "\" cannot be written to");

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -989,11 +989,16 @@ bool parse(const string& arg, pos_t& dest) {
     return true;
 }
 
-int parse_thread_count(const string& arg, const string& context) {
+int parse_thread_count(const string& context, const string& arg) {
     int num_threads = parse<int>(arg);
     
     if (num_threads <= 0) {
         error_and_exit(context, "Thread count (-t) must be a positive integer, not " + arg);
+    } else if (num_threads > omp_get_max_threads()) {
+        // If the user asked for more threads than we can actually use, cap it.
+        emit_warning(context, "Thread count (-t) is greater than the maximum number of threads available (" 
+                              + to_string(omp_get_max_threads()) + "), capping to that value");
+        num_threads = omp_get_max_threads();
     }
     
     return num_threads;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -636,7 +636,7 @@ string get_input_file_name(int& optind, int argc, char** argv, bool test_open) {
     }
 
     if (test_open && file_name != "-") {
-        error_if_file_does_not_exist(file_name, "[get_input_file_name]");
+        error_if_file_does_not_exist("[get_input_file_name]", file_name);
     }
     
     return file_name;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -716,6 +716,14 @@ bool file_exists(const string& filename) {
     return in.is_open();
 }
 
+string error_if_file_does_not_exist(const string& filename, const string& context = "") {
+    if (!file_exists(filename)) {
+        // Complain that the user didn't specify a filename
+        cerr << "error" << context << ": file \"" << filename << "\" does not exist" << endl;
+        exit(1);
+    }
+    return filename;
+}
     
 void create_ref_allele(vcflib::Variant& variant, const std::string& allele) {
     // Set the ref allele

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -858,6 +858,13 @@ string error_if_file_cannot_be_written(const string& context, const string& file
 /// If max_threads is zero, max is omp_get_max_threads()
 int parse_thread_count(const string& context, const string& arg, int max_threads = 0);
 
+/// A special parser for possibly-paired FASTQ files
+/// If the first file is unset, then it gets the input filename
+/// Else if the second file is unset, then it gets the input filename
+/// If both are already set, then this errors
+/// Also calls error_if_file_does_not_exist() on the filenames
+void assign_fastq_files(const string& context, const string& input_filename, string& fastq1, string& fastq2);
+
 /// Parse a command-line argument string. Exits with an error if the string
 /// does not contain exactly an item of the appropriate type.
 template<typename Result>

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -846,6 +846,9 @@ bool file_can_be_written(const string& filename);
 /// Uses file_exists() and is intended to be called when parsing arguments.
 string error_if_file_does_not_exist(const string& context, const string& filename);
 
+/// Error if a file looks like it's gzipped.
+void error_if_file_is_gzipped(const string& context, const string& filename);
+
 /// Check if a file can be written to and return its name (if so) or error.
 /// Uses file_can_be_written() and is intended to be called when parsing arguments.
 string error_if_file_cannot_be_written(const string& context, const string& filename);

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -853,8 +853,10 @@ void error_if_file_is_gzipped(const string& context, const string& filename);
 /// Uses file_can_be_written() and is intended to be called when parsing arguments.
 string error_if_file_cannot_be_written(const string& context, const string& filename);
 
-// A special parser for thread count which errors if non-positive
-int parse_thread_count(const string& context, const string& arg);
+/// A special parser for thread count which errors if non-positive
+/// If max_threads is non-zero, it will also decrease to that maximum.
+/// If max_threads is zero, max is omp_get_max_threads()
+int parse_thread_count(const string& context, const string& arg, int max_threads = 0);
 
 /// Parse a command-line argument string. Exits with an error if the string
 /// does not contain exactly an item of the appropriate type.

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -26,6 +26,8 @@ namespace vg {
 using namespace std;
 
 /// Error (and crash) with a standard format
+/// If you're erroring because a file doesn't exist,
+/// consider using error_if_file_does_not_exist() instead.
 void error_and_exit(const string& context, const string& message);
 /// Warn the user with a standard format
 void emit_warning(const string& context, const string& message);

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -826,9 +826,19 @@ string file_base_name(const string& filename);
 /// Only works for files readable by the current user.
 bool file_exists(const string& filename);
 
+/// Determine if a file can be written to.
+/// Only works for files writable by the current user.
+/// Meant to be used to validate output file names.
+/// Will actually open the file, so it will overwrite the current contents.
+bool file_can_be_written(const string& filename);
+
 /// Check if a file exists and return its name (if so) or error.
 /// Uses file_exists() and is intended to be called when parsing arguments.
 string error_if_file_does_not_exist(const string& filename, const string& context);
+
+/// Check if a file can be written to and return its name (if so) or error.
+/// Uses file_can_be_written() and is intended to be called when parsing arguments.
+string error_if_file_cannot_be_written(const string& filename, const string& context);
 
 // A special parser for thread count which errors if non-positive
 int parse_thread_count(const string& arg, const string& context);

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -25,6 +25,11 @@ namespace vg {
 
 using namespace std;
 
+/// Error (and crash) with a standard format
+void error_and_exit(const string& context, const string& message);
+/// Warn the user with a standard format
+void emit_warning(const string& context, const string& message);
+
 char reverse_complement(const char& c);
 string reverse_complement(const string& seq);
 void reverse_complement_in_place(string& seq);
@@ -823,7 +828,7 @@ bool file_exists(const string& filename);
 
 /// Check if a file exists and return its name (if so) or error.
 /// Uses file_exists() and is intended to be called when parsing arguments.
-string error_if_file_does_not_exist(const string& filename, const string& context = "");
+string error_if_file_does_not_exist(const string& filename, const string& context);
 
 // A special parser for thread count which errors if non-positive
 int parse_thread_count(const string& arg, const string& context);

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -73,7 +73,6 @@ std::vector<std::string> split_delims(const std::string &s, const std::string& d
 bool starts_with(const std::string& value, const std::string& prefix);
 /// Check if a string ends with another string
 bool ends_with(const std::string& value, const std::string& suffix);
-const std::string GZ_SUFFIX = ".gz";
 
 const std::string sha1sum(const std::string& data);
 const std::string sha1head(const std::string& data, size_t head);

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -32,6 +32,14 @@ void error_and_exit(const string& context, const string& message);
 /// Warn the user with a standard format
 void emit_warning(const string& context, const string& message);
 
+/// Write a message to an output stream with indentation
+/// Inserts "indent" spaces on the beginning of each line
+/// Honors existing newlines, but otherwise adds newlines between words
+/// such that everything gets printed with width no more than 80
+/// Assumes that the first line is already indented
+/// (because you put something there and you want others to line up)
+void emit_with_indent(ostream& outstream, const string& message, size_t indent);
+
 char reverse_complement(const char& c);
 string reverse_complement(const string& seq);
 void reverse_complement_in_place(string& seq);

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -825,6 +825,9 @@ bool file_exists(const string& filename);
 /// Uses file_exists() and is intended to be called when parsing arguments.
 string error_if_file_does_not_exist(const string& filename, const string& context = "");
 
+// A special parser for thread count which errors if non-positive
+int parse_thread_count(const string& arg, const string& context);
+
 /// Parse a command-line argument string. Exits with an error if the string
 /// does not contain exactly an item of the appropriate type.
 template<typename Result>

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -821,6 +821,10 @@ string file_base_name(const string& filename);
 /// Only works for files readable by the current user.
 bool file_exists(const string& filename);
 
+/// Check if a file exists and return its name (if so) or error.
+/// Uses file_exists() and is intended to be called when parsing arguments.
+string error_if_file_does_not_exist(const string& filename, const string& context = "");
+
 /// Parse a command-line argument string. Exits with an error if the string
 /// does not contain exactly an item of the appropriate type.
 template<typename Result>

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -864,6 +864,11 @@ int parse_thread_count(const string& context, const string& arg, int max_threads
 /// Also calls error_if_file_does_not_exist() on the filenames
 void assign_fastq_files(const string& context, const string& input_filename, string& fastq1, string& fastq2);
 
+/// Parse an argument that should be a pair of strings separated by a delimiter.
+/// Errors if the string does not contain exactly one delimiter.
+pair<string, string> parse_split_string(const string& context, const string& arg,
+                                        const char& delimiter, const string& option_name);
+
 /// Parse a command-line argument string. Exits with an error if the string
 /// does not contain exactly an item of the appropriate type.
 template<typename Result>

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -836,14 +836,14 @@ bool file_can_be_written(const string& filename);
 
 /// Check if a file exists and return its name (if so) or error.
 /// Uses file_exists() and is intended to be called when parsing arguments.
-string error_if_file_does_not_exist(const string& filename, const string& context);
+string error_if_file_does_not_exist(const string& context, const string& filename);
 
 /// Check if a file can be written to and return its name (if so) or error.
 /// Uses file_can_be_written() and is intended to be called when parsing arguments.
-string error_if_file_cannot_be_written(const string& filename, const string& context);
+string error_if_file_cannot_be_written(const string& context, const string& filename);
 
 // A special parser for thread count which errors if non-positive
-int parse_thread_count(const string& arg, const string& context);
+int parse_thread_count(const string& context, const string& arg);
 
 /// Parse a command-line argument string. Exits with an error if the string
 /// does not contain exactly an item of the appropriate type.

--- a/test/t/03_vg_view.t
+++ b/test/t/03_vg_view.t
@@ -48,17 +48,17 @@ is $(vg view -d ./cyclic/all.vg | wc -l) 23 "view produces the expected number o
 vg construct -r small/x.fa -v small/x.vcf.gz | vg view -v - >x.vg
 is $(cat x.vg x.vg x.vg x.vg | vg view -c - | wc -l) 4 "streaming JSON output produces the expected number of chunks"
 
-is "$(cat x.vg x.vg | vg view -vVD - 2>&1 > /dev/null | grep -v deprecated | wc -l)" 0 "duplicate warnings can be suppressed when loading as vg::VG"
+is "$(cat x.vg x.vg | vg view -vVD - 2>&1 > /dev/null | grep warning | grep -v deprecated | wc -l)" 0 "duplicate warnings can be suppressed when loading as vg::VG"
 
 rm x.vg
 
 vg view -Fv overlaps/two_snvs_assembly1.gfa >/dev/null 2>errors.txt
 is "${?}" "1" "gfa graphs with overlaps are rejected"
-is "$(cat errors.txt | grep -v deprecated | wc -l)" "2" "GFA import produces a concise error message when overlaps are present"
+is "$(cat errors.txt | grep -P "error[.+]?:" | wc -l)" "2" "GFA import produces a concise error message when overlaps are present"
 
 vg view -Fv overlaps/incorrect_overlap.gfa >/dev/null 2>errors.txt
 is "$?" "1" "GFA import rejects a GFA file with an overlap that goes beyond its sequences"
-is "$(cat errors.txt | grep -v deprecated | wc -l)" "2" "GFA import produces a concise error message in that case"
+is "$(cat errors.txt | grep -P "error[.+]?:" | wc -l)" "2" "GFA import produces a concise error message in that case"
 
 rm -f errors.txt
 

--- a/test/t/03_vg_view.t
+++ b/test/t/03_vg_view.t
@@ -62,13 +62,13 @@ is "$(cat errors.txt | grep -v deprecated | wc -l)" "2" "GFA import produces a c
 
 rm -f errors.txt
 
-vg paths -M -x test/graphs/rgfa_with_reference.rgfa > paths.truth.txt
-vg view test/graphs/rgfa_with_reference.rgfa | vg paths -M -x - > paths.test.txt
+vg paths -M -x graphs/rgfa_with_reference.rgfa > paths.truth.txt
+vg view graphs/rgfa_with_reference.rgfa | vg paths -M -x - > paths.test.txt
 cmp paths.test.txt paths.truth.txt
 is "${?}" "0" "vg view preserves path metadata of rGFA file"
 
-vg paths -M -x test/graphs/gfa_with_reference.gfa > paths.truth.txt
-vg view test/graphs/gfa_with_reference.gfa | vg paths -M -x - > paths.test.txt
+vg paths -M -x graphs/gfa_with_reference.gfa > paths.truth.txt
+vg view graphs/gfa_with_reference.gfa | vg paths -M -x - > paths.test.txt
 cmp paths.test.txt paths.truth.txt
 is "${?}" "0" "vg view preserves path metadata of GFA file"
 

--- a/test/t/03_vg_view.t
+++ b/test/t/03_vg_view.t
@@ -62,13 +62,13 @@ is "$(cat errors.txt | grep -P "error[.+]?:" | wc -l)" "2" "GFA import produces 
 
 rm -f errors.txt
 
-vg paths -M -x graphs/rgfa_with_reference.rgfa > paths.truth.txt
-vg view graphs/rgfa_with_reference.rgfa | vg paths -M -x - > paths.test.txt
+vg paths -M -x graphs/rgfa_with_reference.rgfa | sort > paths.truth.txt
+vg view graphs/rgfa_with_reference.rgfa | vg paths -M -x - | sort > paths.test.txt
 cmp paths.test.txt paths.truth.txt
 is "${?}" "0" "vg view preserves path metadata of rGFA file"
 
-vg paths -M -x graphs/gfa_with_reference.gfa > paths.truth.txt
-vg view graphs/gfa_with_reference.gfa | vg paths -M -x - > paths.test.txt
+vg paths -M -x graphs/gfa_with_reference.gfa | sort > paths.truth.txt
+vg view graphs/gfa_with_reference.gfa | vg paths -M -x - | sort > paths.test.txt
 cmp paths.test.txt paths.truth.txt
 is "${?}" "0" "vg view preserves path metadata of GFA file"
 

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -41,7 +41,7 @@ is $(vg surject -x x.xg -t 1 -s j.gam | grep -v "@" | cut -f3 | grep x | wc -l) 
 head -c -10 j.gam >j-truncated.gam
 vg surject -p x -x x.xg -t 1 j-truncated.gam >/dev/null 2>log.txt
 is "${?}" "1" "vg surject stops when the input read file is truncated"
-is "$(grep "truncate" log.txt | wc -l)" "1" "vg surject reports that files are truncated"
+is "$(grep "truncated input" log.txt | wc -l)" "1" "vg surject reports that files are truncated"
 rm -f j-truncated.gam log.txt
 
 is $(vg surject -x x.xg -t 1 -s x.gam | grep AS | wc -l) 100 "vg surject reports alignment scores"

--- a/test/t/37_vg_gbwt.t
+++ b/test/t/37_vg_gbwt.t
@@ -420,11 +420,11 @@ vg gbwt -g gfa2.gbz --gbz-format -Z gfa.gbz --set-tag "reference_samples=GRCh38 
 is $? 0 "GBZ GBWT tag modification works"
 is "$(vg paths -M -S GRCh37 -x gfa2.gbz | grep -v "^#" | cut -f2 | grep HAPLOTYPE | wc -l)" "1" "Changing reference_samples tag can make a reference a haplotype"
 is "$(vg paths -M -S CHM13 -x gfa2.gbz | grep -v "^#" | cut -f2 | grep REFERENCE | wc -l)" "1" "Changing reference_samples tag can make a haplotype a reference"
-vg gbwt -g gfa2.gbz --gbz-format -Z gfa.gbz --set-tag "reference_samples=GRCh38#1 CHM13" 2>/dev/null
-is $? 1 "GBZ GBWT tag modification validation works"
 vg gbwt -g gfa3.gbz --gbz-format --set-reference GRCh37 --set-reference CHM13 -Z gfa2.gbz
 is $? 0 "Samples can be direcly set as references"
 is "$(vg gbwt --tags -Z gfa3.gbz | grep reference_samples | cut -f 2)" "GRCh37 CHM13" "Direct reference assignment works"
+vg gbwt -g gfa2.gbz --gbz-format -Z gfa.gbz --set-tag "reference_samples=GRCh38#1 CHM13" 2>/dev/null
+is $? 1 "GBZ GBWT tag modification validation works"
 
 rm -f gfa.gbz gfa2.gbz gfa3.gbz tags.tsv
 

--- a/test/t/48_vg_convert.t
+++ b/test/t/48_vg_convert.t
@@ -113,7 +113,8 @@ diff mut.cs.back.gaf mut.cs.exp.gaf
 is "$?" 0 "vg convert cg-gaf -> gam -> cs-gaf gives expected output (snps converted to matches, insertion converted to Ns)"
 rm -f mut.cs.gaf mut.cg.gaf mut.cs.exp.gaf
 
-rm -f x.vg x.gcsa sim.gam sim-rm.gam sim-rm.gaf sim-rm2.gaf sim-rm2-mt-sort.gaf sim-rm2-mtbg-sort.gaf sim-rm2-sort.gaf mut.gam mut-back.gam mut.gaf mut-back.gaf mut.path mut-back.path mut.seq mut-back.seq
+rm -f x.vg x.gcsa sim.gam sim-rm.gam sim-rm.gaf sim-rm2.gaf sim-rm2-mt-sort.gaf sim-rm2-mtbg-sort.gaf sim-rm2-sort.gaf
+rm -f mut.gam mut-back.gam mut.gaf mut-back.gaf mut.path mut-back.path mut.seq mut-back.seq mut.cs.back.gaf
 
 vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz > z.vg 2> /dev/null
 vg sim -n 10000 -s 23 -a -x z.vg > sim.gam
@@ -139,7 +140,8 @@ vg convert zflat.vg -F split.gaf | vg convert zflat.vg -G - > split-back.gaf
 diff split.gaf split-back.gaf
 is "$?" 0 "vg convert gam -> gaf ->gam -> gaf makes same gaf each time for split alignment"
 
-rm -f z.vg zflat.vg sim.gam sim-map.gam sim-map-back.gam sim-map.gaf.gz sim-map.sequence sim-map-back.sequence sim-map-back.gaf sim-map.gaf split.gam split.gaf split-back.gaf
+rm -f z.vg zflat.vg zflat.gcsa sim.gam sim-map.gam sim-map-back.gam sim-map.gaf.gz sim-map.sequence
+rm -f sim-map-back.sequence sim-map-back.gaf sim-map.gaf split.gam split.gaf split-back.gaf
 
 printf "H\tVN:Z:1.0
 S\t73333\tGGTGGGCGAGGACCTCCACACGTGTCACCA
@@ -350,6 +352,8 @@ is $? 0 "HashGraph to GFA conversion writing walks as paths"
 is "$(grep "^W" no-walks.gfa | wc -l)" "0" "HashGraph to GFA conversion writing walks as paths produces no walks"
 is "$(grep "^P" no-walks.gfa | wc -l)" ""$(grep "^[PW]" correct.gfa | wc -l)"" "HashGraph to GFA conversion writing walks as paths produces all expected paths"
 
+rm no-walks.gfa
+
 # GBZ to GFA with paths and walks (needs 1 thread)
 vg convert --gbwtgraph-algorithm  -f -t 1 components.gbz > gbz.gfa
 is $? 0 "GBZ to GFA conversion with paths and walks, GBWTGraph algorithm"
@@ -509,4 +513,4 @@ diff out.gaf out2.gaf
 is $? 0 "GAF-GAM double roundtrip works on deletion problem case for chunked vg output for long node (GAF check)"
 vg validate ref.vg -a out2.gam
 is $? 0 "GAF-GAM double roundtrip works on deletion problem case for chunked vg output for long node (GAM check)"
-rm -f ref.fa query.fa ref.vg ref.gcsa out.gam out.gaf out2.gam
+rm -f ref.fa query.fa ref.vg ref.gcsa out.gam out.gaf out2.gam out2.gaf


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Create utility functions for basic parsing/validity checks, and use them in subcommands + `src/index_registry.cpp`
     * `parse_thread_count()`, `parse_split_string()`, and `assign_fastq_files()` are meant to accept `optarg` and then do common nontrivial parsing
     * `error_if_file_does_not_exist()`, `error_if_file_cannot_be_written()`, and `error_if_file_is_gzipped()` are meant to accept `optarg` and perform standardized checks for file validity
* At least attempt to enforce the use of some new standardized parsing/validity functions
* Create utility functions for pretty error/warning printing, and use them in subcommands + `src/index_registry.cpp`
* Fix two broken tests in `test/t/03_vg_view.t`

## Description

Welcome back to Faith's Nitpick Corner, where today we are serving a sizzling side project of centralized utility functions.

### Motivation

Many `vg` subcommand options have similar basic parsing logic. In the best-case scenario, this led to copious copy-pasting, which is why so many subcommands have e.g. [the](https://github.com/vgteam/vg/blob/e78e9d57dbd9777c9430ae0eb21ca6f82b880b4f/src/subcommand/paths_main.cpp#L306) [same](https://github.com/vgteam/vg/blob/e78e9d57dbd9777c9430ae0eb21ca6f82b880b4f/src/subcommand/zipcode_main.cpp#L127) [code](https://github.com/vgteam/vg/blob/e78e9d57dbd9777c9430ae0eb21ca6f82b880b4f/src/subcommand/call_main.cpp#L303) for parsing `--threads`. In the worst-case scenario, people didn't bother adding validity checks. In the confusing-case scenario, people copy-pasted badly, which is how you get [`vg augment` claiming to be `vg call`](https://github.com/vgteam/vg/blob/e78e9d57dbd9777c9430ae0eb21ca6f82b880b4f/src/subcommand/augment_main.cpp#L233).

Initially this was only supposed to be `parse_thread_count()` (errors if given nonpositive input) and `error_if_file_does_not_exist()` (errors if file can't be read). Then it ballooned into adding functions that check for if a file is gzipped (`error_if_file_is_gzipped()`), use the same option to accept up to two FASTQ files (`assign_fastq_files()`), accept an argument of the form `X<delimiter>Y` and extract `X` and `Y` (`parse_split_string()`), or check if a file can be _output_ to (`error_if_file_cannot_be_written()`).

Since all of these new utility functions needed to print out errors, I also made `error_and_exit()` and `emit_warning()` to print an error/warning in a standardized format via `emit_with_indent()`. `error_and_exit()` additionally exits with an error code. These pretty printing functions I used all over the subcommands as well as `src/index_registry.cpp`. I don't _have_ to use them; I just like them. I could revert to the previous error/exit stuff if we want. Though if we do that, we should make sure that all errors actually *error* ([example](https://github.com/vgteam/vg/blob/e78e9d57dbd9777c9430ae0eb21ca6f82b880b4f/src/subcommand/gbwt_main.cpp#L682)).

### Fiddly bits

* Currently `error_if_file_cannot_be_written()` checks if a file can be written to by attempting to open a file for writing. This means it will overwrite whatever was there before. I had to [change a test](https://github.com/vgteam/vg/commit/7f4171cd8f99e05eaaf325ce0a1f2e64db2bb3d1) to move an error test to later, to prevent it from overwriting a file used by a different test.
* I belatedly realized that `split_delims()` is a thing that [already exists](https://github.com/vgteam/vg/blob/e78e9d57dbd9777c9430ae0eb21ca6f82b880b4f/src/utility.cpp#L191-L209), but I think `parse_split_string()` is still useful for its simpler interface in an argument parsing context.
* In places where I'd already validated a filename validity during argument parsing, I removed later duplicate validity checks ([example](https://github.com/vgteam/vg/blob/e78e9d57dbd9777c9430ae0eb21ca6f82b880b4f/src/subcommand/add_main.cpp#L159)). I think it's better to have the validity checks centralized and, crucially, _early_: this way we'll error before doing any expensive algorithms.
* While I _generally_ kept the error/warning messages the same as before, some of the `vg mpmap` error messages used the wrong shortforms for options ([example](https://github.com/vgteam/vg/blob/e78e9d57dbd9777c9430ae0eb21ca6f82b880b4f/src/subcommand/mpmap_main.cpp#L1249)), which I fixed.
* The pretty printing functions are [thread-safe](https://github.com/vgteam/vg/blob/27a9042e8c53d36c0f72a3f7784bedae58c656a4/src/utility.cpp#L28), which feels slightly overkill but at least one of the subcommand files had a thread-safe error print so I ported that functionality.
* I had to slightly rewrite some tests to make them expect my new pretty-printed errors. Their intent/purpose was not changed.
* [Two tests](https://github.com/vgteam/vg/blob/e78e9d57dbd9777c9430ae0eb21ca6f82b880b4f/test/t/03_vg_view.t#L65-L73) in `test/t/03_vg_view.t` were accessing bad file names, which led to empty output. Since these empty outputs were compared to each other, the test passed. I swapped to the correct file names.
* I used `error_if_file_does_not_exist()` in `IndexRegistry`. To then get it past unit tests which intentionally use dummy files, I added a flag to the object which tells it to skip checking the files passed to `provide()`.
* `scripts/check_options.py` attempts to enforce the usage of `error_if_file_does_not_exist()`, `error_if_file_cannot_be_written()`, and `parse_thread_count()`. Unfortunately it has to use heuristics for all of them: filenames variables are auto-detected as `<variable name ending> = optarg` where the known endings are in `FILENAME_VAR_ENDS`. This will fail to catch other name formats such as `xg_name = optarg` as `_name` would lead to false positives. It also won't catch things like `vcf_filenames.append(optarg)` where there's a list of filenames in use. The thread count heuristic requires `omp_set_num_threads()` and `parse_thread_count()` to be on the same line.