### PR TITLE
Add hints to vg autoindex errors to suggest what missing files might un-stick the planner

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -5768,7 +5768,7 @@ InsufficientInputException::InsufficientInputException(const IndexName& target,
     }
     ss << "are insufficient to create target index " << target << "." << endl;
     if (!missing_index_sets.empty()) {
-        ss << "Hint: more planning progress would be possible if you provided one of these:" << endl;
+        ss << "Hint: more progress would be possible if you provided one of these:" << endl;
         for (auto& index_set : missing_index_sets) {
             ss << "\t";
             for (auto name_iter = index_set.begin(); name_iter != index_set.end(); ++name_iter) {

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -452,12 +452,14 @@ class InsufficientInputException : public runtime_error {
 public:
     InsufficientInputException() = delete;
     InsufficientInputException(const IndexName& target,
-                               const IndexRegistry& registry) noexcept;
+                               const IndexRegistry& registry,
+                               const set<IndexGroup>& missing_index_sets = {}) noexcept;
     const char* what() const noexcept;
 private:
     string msg;
     IndexName target;
     vector<IndexName> inputs;
+    set<IndexGroup> missing_index_sets;
 };
 
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` now gives you hints about what files would help it, when it can't make the indexes it wants to make.

## Description

This should help with cases like #4691 where `vg autoindex` is all "I'm afraid I can't do that Dave" and it's not clear (without digging through the recipe code) what you could possibly do to change that.

Now the error messages include helpful hints about what missing leaf files (with no recipes themselves) it hit that caused it to back out of planning tree branches. If you provide these files, you should at least get a *different* error, and you might get a working indexing plan.

This only suggests leaf files, so if you *really* were supposed to provide e.g. a graph, it will suggest that you provide stuff to build a graph from instead.

Now if I `touch fake.gtf fake.gfa && vg autoindex -w "mpmap" -H fake.gtf -g fake.gfa`, I get:
```
[vg autoindex] Executing command: vg autoindex -w mpmap -H fake.gtf -g fake.gfa
[IndexRegistry]: Checking for haplotype lines in GFA.
error:[vg autoindex] Input is not sufficient to create indexes
Inputs:
	Haplotype GTF/GFF
	Reference GFA
are insufficient to create target index Spliced Distance Index.
Hint: more progress would be possible if you provided one of these:
	GTF/GFF
```
