### PR TITLE
Leave flagged-as-unmapped BAM reads unmapped

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1823,8 +1823,8 @@ Alignment bam_to_alignment(const bam1_t *b,
         
     }
     alignment.set_read_paired((b->core.flag & BAM_FPAIRED) != 0);
-    
-    if (graph != nullptr && bh != nullptr && b->core.tid >= 0) {
+    // Only set mapping fields if BAM_FUNMAP is not set
+    if (!(b->core.flag & BAM_FUNMAP) && graph != nullptr && bh != nullptr && b->core.tid >= 0) {
         alignment.set_mapping_quality(b->core.qual);
         alignment.set_read_mapped(true);
         // Look for the path handle this is against.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg inject` will no longer spontaneously map SAM/BAM reads that have their mapping fields filled in but are flagged as unmapped.

## Description
This should fix #4676, or at least the aspect of it where unmapped
reads can be mysteriously resurrected into mapped reads.

This two-line change was prepared with the "help" of Copilot Agent Mode
running on GPT4, which only had to be badgered moderately over a thirty
minute coding session to translate my issue comment explaining the
solution into code.
