### PR TITLE
Add subpaths when extracting graph using GAM

### DIFF
--- a/src/subcommand/find_main.cpp
+++ b/src/subcommand/find_main.cpp
@@ -868,6 +868,7 @@ int main_find(int argc, char** argv) {
             }
             vg::algorithms::expand_subgraph_by_steps(*xindex, graph, max(1, context_size)); // get connected edges
             vg::algorithms::add_connecting_edges_to_subgraph(*xindex, graph);
+            vg::algorithms::add_subpaths_to_subgraph(*xindex, graph);
             vg::io::save_handle_graph(&graph, cout);
         }
         if (id(connecting_start) != 0) {

--- a/test/t/05_vg_find.t
+++ b/test/t/05_vg_find.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 29
+plan tests 30
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 is $? 0 "construction"
@@ -68,7 +68,9 @@ is $(vg find -A <(vg find -N <(seq 37 52 ) -x x.xg ) --sorted-gam x.sorted.gam |
 
 rm -rf x.gam x.sorted.gam x.sorted.gam.gai
 
-is $(vg find -G small/x-s1337-n1.gam -x x.xg | vg view - | grep ATTAGCCATGTGACTTTGAACAAGTTAGTTAATCTCTCTGAACTTCAGTT | wc -l) 1 "the index can be queried using GAM alignments"
+is "$(vg find -G small/x-s1337-n1.gam -x x.xg | vg view - | grep ATTAGCCATGTGACTTTGAACAAGTTAGTTAATCTCTCTGAACTTCAGTT | wc -l)" "1" "the index can be queried using GAM alignments"
+
+is "$(vg find -G small/x-s1337-n1.gam -x x.xg | vg paths --list -x -)" "x[121-272]" "querying the index with GAM alignments finds relevant subpaths"
 
 rm -rf x.vg x.xg x.gcsa{,.lcp}
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg find -G` now includes regions of paths touched by the extracted graph

## Description
I noticed a while ago that these path regions were missing and made this change on a branch I eventually threw away. Here it is by itself.

It could perhaps use a test to prove it works.
