### PR TITLE
Magical manpage generation

### DIFF
--- a/doc/vgmanmd.desc.md
+++ b/doc/vgmanmd.desc.md
@@ -8,7 +8,7 @@ When adding a new subcommand, add it to the appropriate section(s) in the descri
 
 vg is a toolkit for variation graph data structures, interchange formats, alignment, genotyping, and variant calling methods.
 
-For more in-depth explanations of tools and workflows, see the [vg wiki page](https://github.com/vgteam/vg/wiki)
+For more in-depth explanations of tools and workflows, see the [vg wiki page](https://github.com/vgteam/vg/wiki).
 
 # synopsis
 This is an incomplete list of vg subcommands. For a complete list, run `vg help`.
@@ -57,42 +57,6 @@ This is an incomplete list of vg subcommands. For a complete list, run `vg help`
 - **Subgraph extraction**
     - [`vg chunk`](#chunk): split a graph and/or alignment into smaller chunks.
     - [`vg find`](#find): use an index to find nodes, edges, kmers, paths, or positions.
-
-# annotate
-
-Annotate alignments with graphs and graphs with alignments.
-
-# autoindex
-
-Mapping tool-oriented index construction from interchange formats.
-
-# convert
-
-Convert graphs between handle-graph compliant formats as well as GFA.
-
-# find
-
-Use an index to find nodes, edges, kmers, paths, or positions.
-
-# ids
-
-Manipulate node ids.
-
-# pack
-
-Convert alignments to a compact coverage index.
-
-# paths
-
-Traverse paths in the graph.
-
-# view
-
-format conversions for graphs and alignments
-
-# filter
-
-Filter alignments by properties.
 
 # bugs
 

--- a/doc/vgmanmd.py
+++ b/doc/vgmanmd.py
@@ -69,8 +69,16 @@ print("COMMANDS")
 print("====")
 
 # help for each cmd
+vg_help = subprocess.run(['vg', 'help'], capture_output=True)
+cmd_desc = dict()
+for line in vg_help.stderr.decode().split('\n'):
+    if '--' in line:
+        parts = line.split()
+        cmd_desc[parts[1]] = ' '.join(parts[2:])
+        cmd = parts[1]
+
 for cmd in cmds:
-    print('## {cmd}\n\n'.format(cmd=cmd))
+    print('## {cmd}: {blurb}\n\n'.format(cmd=cmd, blurb=cmd_desc[cmd]))
     try:
         # Try first with the help option to get all options described.
         # Use check=True to raise CalledProcessError on non-zero exit codes (e.g., when --help fails),
@@ -81,9 +89,6 @@ for cmd in cmds:
         # vg subcommands (e.g., construct) don’t recognize --help
         ret = subprocess.run(['vg', cmd], capture_output=True)
     print('```')
-    if cmd in desc:
-        print(desc[cmd])
-        print('\n\n')
     print(ret.stderr.decode())
     print('```\n\n')
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Improve automatic manpage generation

## Description

This standardizes how the manpage is generated per #4700 to attach short descriptions of each subcommand to the subheaders. As in, how I have it right now. It removes the necessity of writing a manual extra description for each subcommand by simply using whatever `vg help` sees.

Once this is in, I'll update the checklist on the [wiki page](https://github.com/vgteam/vg/wiki/Releases) and the v1.69.0 issue.