### PR TITLE
Add warnings when using options affecting vg snarls --traversals without outputting traversals

### DIFF
--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -188,6 +188,18 @@ int main_snarl(int argc, char** argv) {
         }
     }
 
+    if (traversal_file.empty()) {
+        if (!ultrabubble_only) {
+            cerr << "warning:[vg snarls] --any-snarl-type (-a) has no effect without --traversals file" << endl;
+        }
+        if (top_level_only) {
+            cerr << "warning:[vg snarls] --top-level (-o) has no effect without --traversals file" << endl;
+        }
+        if (leaf_only) {
+            cerr << "warning:[vg snarls] --leaf-only (-l) has no effect without --traversals file" << endl;
+        }
+    }
+
     // Prepare traversal output stream
     ofstream trav_stream;
     if (!traversal_file.empty()) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Warn in `vg snarls` when `-l`, `-o`, or `-a` is used without `--traversals`

## Description

These options affect the `SnarlTraversals` output file produced by `vg snarls --traversals`, but they don't affect the `.pb` file sent to standard out. So if you use them without `--traversals` these supposedly output-affecting options don't affect output. This confused a user in #4708 so here I'm adding a warning.

To be more elaborate, current behavior is to only check the flags set by these options here. Note that if no traversals file has been set, the entire conditional is short-circuited past.

https://github.com/vgteam/vg/blob/f48ffc87ae02fb8b0d1e1cc543fe140295acf9ae/src/subcommand/snarls_main.cpp#L403-L407