### PR TITLE
Actually detect and use paths in payloads

### DIFF
--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -475,8 +475,8 @@ gbwtgraph::DefaultMinimizerIndex build_minimizer_index(
 }
 
 void require_payload(const gbwtgraph::DefaultMinimizerIndex& index, MinimizerIndexParameters::PayloadType expected_payload) {
-    std::string expected_str = MinimizerIndexParameters::payload_str(expected_payload);
     std::string found = index.get_tag(MinimizerIndexParameters::PAYLOAD_KEY);
+    std::string expected_str = MinimizerIndexParameters::payload_str(expected_payload);
     if (found != expected_str) {
         std::cerr << "error: expected a minimizer index with payload type \""
             << expected_str << "\" but found \"" << found << "\"" << std::endl;
@@ -486,24 +486,48 @@ void require_payload(const gbwtgraph::DefaultMinimizerIndex& index, MinimizerInd
 
 void require_payload(
     const gbwtgraph::DefaultMinimizerIndex& index,
-    const std::vector<MinimizerIndexParameters::PayloadType>& expected_payload
+    const std::vector<MinimizerIndexParameters::PayloadType>& expected_payloads
 ) {
     std::string found = index.get_tag(MinimizerIndexParameters::PAYLOAD_KEY);
-    for (MinimizerIndexParameters::PayloadType type : expected_payload) {
+    for (MinimizerIndexParameters::PayloadType type : expected_payloads) {
         std::string expected_str = MinimizerIndexParameters::payload_str(type);
         if (found == expected_str) {
             return;
         }
     }
     std::cerr << "error: expected a minimizer index with one of payload types {";
-    for (size_t i = 0; i < expected_payload.size(); ++i) {
-        std::cerr << " \"" << MinimizerIndexParameters::payload_str(expected_payload[i]) << "\"";
-        if (i + 1 < expected_payload.size()) {
+    for (size_t i = 0; i < expected_payloads.size(); ++i) {
+        std::cerr << " \"" << MinimizerIndexParameters::payload_str(expected_payloads[i]) << "\"";
+        if (i + 1 < expected_payloads.size()) {
             std::cerr << ",";
         }
     }
     std::cerr << " } but found \"" << found << "\"" << std::endl;
     std::exit(EXIT_FAILURE);
+}
+
+// TODO: I couldn't figure out a way to factor out a checker/stringifier
+// function and share code between require_payload() and has_payload() without
+// some cost for the abstraction.
+
+bool has_payload(const gbwtgraph::DefaultMinimizerIndex& index, MinimizerIndexParameters::PayloadType payload) {
+    std::string found = index.get_tag(MinimizerIndexParameters::PAYLOAD_KEY);
+    std::string expected_str = MinimizerIndexParameters::payload_str(payload);
+    return found == expected_str;
+}
+
+bool has_payload(
+    const gbwtgraph::DefaultMinimizerIndex& index,
+    const std::vector<MinimizerIndexParameters::PayloadType>& payloads
+) {
+    std::string found = index.get_tag(MinimizerIndexParameters::PAYLOAD_KEY);
+    for (MinimizerIndexParameters::PayloadType type : payloads) {
+        std::string expected_str = MinimizerIndexParameters::payload_str(type);
+        if (found == expected_str) {
+            return true;
+        }
+    }
+    return false;
 }
 
 //------------------------------------------------------------------------------

--- a/src/gbwtgraph_helper.hpp
+++ b/src/gbwtgraph_helper.hpp
@@ -209,7 +209,20 @@ void require_payload(const gbwtgraph::DefaultMinimizerIndex& index, MinimizerInd
 /// Prints an error message and exits on failure.
 void require_payload(
     const gbwtgraph::DefaultMinimizerIndex& index,
-    const std::vector<MinimizerIndexParameters::PayloadType>& expected_payload
+    const std::vector<MinimizerIndexParameters::PayloadType>& expected_payloads
+);
+
+/// Returns true if the minimizer index has the given payload, and false otherwise.
+///
+/// The check is based on tag "payload" stored in the index.
+bool has_payload(const gbwtgraph::DefaultMinimizerIndex& index, MinimizerIndexParameters::PayloadType payload);
+
+/// Returns true if the minimizer index has any of the given payloads, and false otherwise.
+///
+/// The check is based on tag "payload" stored in the index.
+bool has_payload(
+    const gbwtgraph::DefaultMinimizerIndex& index,
+    const std::vector<MinimizerIndexParameters::PayloadType>& payloads
 );
 
 //------------------------------------------------------------------------------

--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -59,7 +59,7 @@ MinimizerMapper::MinimizerMapper(const gbwtgraph::GBWTGraph& graph,
     path_graph(path_graph),
     minimizer_index(minimizer_index),
     k(minimizer_index.k()), w(minimizer_index.w()),
-    payload_with_paths(false), // FIXME: how do we determine this?
+    payload_with_paths(has_payload(minimizer_index, MinimizerIndexParameters::PAYLOAD_ZIPCODES_WITH_PATHS)),
     uses_syncmers(minimizer_index.uses_syncmers()),
     distance_index(distance_index),  
     zipcodes(zipcodes),
@@ -70,8 +70,6 @@ MinimizerMapper::MinimizerMapper(const gbwtgraph::GBWTGraph& graph,
     fragment_length_distr(1000,1000,0.95)
 {
     crash_unless(graph.index != nullptr);
-
-    // FIXME: Check the payload type and set payload_with_paths accordingly
 }
 
 void MinimizerMapper::set_alignment_scores(const int8_t* score_matrix, int8_t gap_open, int8_t gap_extend, int8_t full_length_bonus) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` will again use path payloads from the minimizer index

## Description
@dcmonti noted that path payloads from the minimizer index weren't actually being used, I think after #4727. This adds the missing logic to check the payload type in the `MinimizerMapper` and turn on the flag that says they are there if they are there.