### PR TITLE
use ref-guided snarls in simplify, clip and stats

### DIFF
--- a/src/traversal_clusters.cpp
+++ b/src/traversal_clusters.cpp
@@ -670,9 +670,13 @@ void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const
 
     // load up the reference paths
     unordered_map<path_handle_t, int64_t> ref_paths;
+    std::unordered_map<nid_t, size_t> extra_node_weight;
+    constexpr size_t EXTRA_WEIGHT = 10000000000;
     graph->for_each_path_handle([&](path_handle_t path_handle) {
         if (graph->get_path_name(path_handle).compare(0, ref_path_prefix.length(), ref_path_prefix) == 0) {
             ref_paths[path_handle] = 0;
+            extra_node_weight[graph->get_id(graph->get_handle_of_step(graph->path_begin(path_handle)))] += EXTRA_WEIGHT;
+            extra_node_weight[graph->get_id(graph->get_handle_of_step(graph->path_back(path_handle)))] += EXTRA_WEIGHT;
         }
     });
 
@@ -710,7 +714,7 @@ void simplify_graph_using_traversals(MutablePathMutableHandleGraph* graph, const
         // compute the distance index
         SnarlDistanceIndex distance_index;
         {
-            IntegratedSnarlFinder snarl_finder(*graph);
+            IntegratedSnarlFinder snarl_finder(*graph, extra_node_weight);
             fill_in_distance_index(&distance_index, graph, &snarl_finder, 0);
         }
         


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg clip`, `vg simplify` and `vg stats` now use reference information when applicable/available during snarl computation. 

## Description

Like #4743 but applied to `vg clip`, `vg simplify` and `vg stats`.  