### PR TITLE
Have no-arg "vg augment" print helptext

### DIFF
--- a/src/subcommand/augment_main.cpp
+++ b/src/subcommand/augment_main.cpp
@@ -243,6 +243,11 @@ int main_augment(int argc, char** argv) {
         }
     });
 
+    if (argc == 2) {
+        help_augment(argv, parser);
+        return 1;
+    }
+
     // Parse the command line options, updating optind.
     parser.parse(argc, argv);
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Running `vg augment` with no arguments will print helptext

## Description

For some reason, running `vg augment` with no arguments was printing just `error[vg augment] too few arguments` instead of the full helptext as is normal for vg commands.