### PR TITLE
add --ban-sample option to haplotype sampling

### DIFF
--- a/src/recombinator.cpp
+++ b/src/recombinator.cpp
@@ -1935,7 +1935,14 @@ std::vector<std::pair<size_t, double>> select_haplotypes(
     std::vector<std::pair<size_t, double>> selected_haplotypes;
     std::vector<std::pair<size_t, double>> remaining_haplotypes;
     for (size_t seq_offset = 0; seq_offset < subchain.sequences.size(); seq_offset++) {
-        remaining_haplotypes.push_back( { seq_offset, 0.0 });
+        // Metadata to make sure this haplotype isn't among the banned
+        gbwt::size_type sequence_id = subchain.sequences[seq_offset].first;
+        gbwt::size_type path_id = gbwt::Path::id(sequence_id);
+        gbwt::FullPathName path_name = gbz.index.metadata.fullPath(path_id);
+
+        if (parameters.banned_samples.find(path_name.sample_name) == parameters.banned_samples.end()) {
+            remaining_haplotypes.push_back( { seq_offset, 0.0 });
+        }
     }
     while (selected_haplotypes.size() < parameters.num_haplotypes && !remaining_haplotypes.empty()) {
         // Score the remaining haplotypes.

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -594,6 +594,9 @@ public:
         /// Include named and reference paths.
         bool include_reference = false;
 
+        /// Samples whose haplotypes shouldn't be used, even if they score well.
+        unordered_set<std::string> banned_samples;
+
         // TODO: Should we use extra_fragments?
         /// Preset parameters for common use cases.
         enum preset_t {

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -244,6 +244,7 @@ void help_haplotypes(char** argv, bool developer_options) {
                                              << "[" << haplotypes_defaults::badness() << "]" << std::endl;
     std::cerr << "      --include-reference      include named and reference paths in the output" << std::endl;
     std::cerr << "      --set-reference NAME     use sample X as a reference sample (may repeat)" << std::endl;
+    std::cerr << "      --ban-sample NAME        don't use NAME haplotypes, no matter the score" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Other options:" << std::endl;
     std::cerr << "  -v, --verbosity N            verbosity level [0]" << std::endl;
@@ -279,6 +280,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
     constexpr int OPT_BADNESS = 1309;
     constexpr int OPT_INCLUDE_REFERENCE = 1310;
     constexpr int OPT_SET_REFERENCE = 1311;
+    constexpr int OPT_BAN_SAMPLE = 1312;
     constexpr int OPT_VALIDATE = 1400;
     constexpr int OPT_STATISTICS = 1500;
 
@@ -306,6 +308,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
         { "badness", required_argument, 0, OPT_BADNESS },
         { "include-reference", no_argument, 0, OPT_INCLUDE_REFERENCE },
         { "set-reference", required_argument, 0, OPT_SET_REFERENCE },
+        { "ban-sample", required_argument, 0, OPT_BAN_SAMPLE },
         { "verbosity", required_argument, 0, 'v' },
         { "threads", required_argument, 0, 't' },
         { "validate", no_argument, 0,  OPT_VALIDATE },
@@ -432,6 +435,9 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
             break;
         case OPT_SET_REFERENCE:
             this->reference_samples.insert(optarg);
+            break;
+        case OPT_BAN_SAMPLE:
+            this->recombinator_parameters.banned_samples.insert(optarg);
             break;
 
         case 'v':

--- a/test/t/54_vg_haplotypes.t
+++ b/test/t/54_vg_haplotypes.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 32
+plan tests 34
 
 # The test graph consists of two subgraphs of the HPRC Minigraph-Cactus v1.1 graph:
 # - GRCh38#chr6:31498145-31511124 (micb)
@@ -42,6 +42,12 @@ is $? 0 "sampling without adding reference"
 is $(vg gbwt -S -Z no_ref.gbz) 1 "1 sample"
 is $(vg gbwt -C -Z no_ref.gbz) 2 "2 contigs"
 is $(vg gbwt -H -Z no_ref.gbz) 4 "4 haplotypes"
+
+# Sample banning the selection of CHM13
+vg haplotypes --validate -i full.hapl -k haplotype-sampling/HG003.kff --ban-sample CHM13 -g ban_ref.gbz full.gbz
+is $? 0 "sampling banning the selection of CHM13"
+cmp ban_ref.gbz no_ref.gbz
+is $? 1 "the output changes"
 
 # Diploid sampling
 vg haplotypes --validate -i full.hapl -k haplotype-sampling/HG003.kff --include-reference --diploid-sampling -g diploid.gbz full.gbz
@@ -93,7 +99,7 @@ is $(grep -c "error.*are not compatible" log.txt) 1 "an appropriate error messag
 
 # Cleanup
 rm -r full.gbz full.ri full.dist full.hapl
-rm -f indirect.gbz direct.gbz no_ref.gbz
+rm -f indirect.gbz direct.gbz no_ref.gbz ban_ref.gbz
 rm -f diploid.gbz diploid2.gbz diploid3.gbz
 rm -f full.HG003.* default.gam
 rm -f sampled.003HG.* specified.gam


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add option `vg haplotypes --ban-sample`

## Description

Per [Jouni's suggestion on a previous PR](https://github.com/vgteam/vg/pull/4758#issuecomment-3604192669), this partially redos #4758 to add `--ban-sample` as an option which will prevent the sampler from selecting any haplotypes from a particular sample. Useful when you want to do a poor man's leave-one-out experiment without actually rebuilding the entire graph.