### PR TITLE
Nice error when passing non-GAM file to vg filter

### DIFF
--- a/src/subcommand/filter_main.cpp
+++ b/src/subcommand/filter_main.cpp
@@ -548,8 +548,15 @@ int main_filter(int argc, char** argv) {
         filter.graph = xindex;
     };
     
+    // Make sure that this is a GAM (or the parser gets confused)
+    std::string gam_file = get_input_file_name(optind, argc, argv);
+    if (gam_file != "-" && !ends_with(gam_file, ".gam")) {
+        logger.error() << "Input alignment file " << gam_file 
+                       << " does not appear to be a GAM" << std::endl;
+    }
+
     // Read in the alignments and filter them.
-    get_input_file(optind, argc, argv, [&](istream& in) {
+    get_input_file(gam_file, [&](istream& in) {
         // Open up the alignment stream
         
         // Read in the alignments and filter them.

--- a/test/t/21_vg_filter.t
+++ b/test/t/21_vg_filter.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 15
+plan tests 17
 
 vg construct -m 1000 -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg  x.vg
@@ -13,6 +13,11 @@ vg sim -x x.xg -l 100 -n 5000 -e 0.01 -i 0.001 -a > x.gam
 
 # sanity check: does passing no options preserve input
 is $(vg filter x.gam | vg view -a - | jq . | grep mapping | wc -l) 5000 "vg filter with no options preserves input."
+
+# Passing a non-GAM gives a useful error
+vg filter x.vg 2> err.txt
+is $? 1 "vg filter fails on non-GAM input"
+is "$(grep 'does not appear to be a GAM' err.txt | wc -l)" 1 "vg filter gives useful error message on non-GAM input"
 
 # Downsampling works
 SAMPLED_COUNT=$(vg filter x.gam --downsample 0.5 | vg view -aj - | wc -l)
@@ -83,6 +88,6 @@ is "$(echo '{"sequence": "GATTACA", "name": "read1", "annotation": {"features": 
 is "$(echo '{"sequence": "GATTACA", "name": "read1"}' | vg view -JGa - | vg filter -P - | vg view -aj - | wc -l)" "0" "unmapped reads can be filtered out"
 
 
-rm -f x.gam filter_chunk*.gam chunks.bed
+rm -f x.gam filter_chunk*.gam chunks.bed err.txt
 rm -f x.vg x.xg paired.gam paired.sam paired.annotated.gam single.gam single.sam filtered.gam filtered.sam
                                                                


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg filter` gives a clean error when passing files that don't look like GAMs

## Description

A long-term minor annoyance of mine: if you accidentally pass a valid non-GAM file (e.g. a TSV) to `vg filter` it would try to read it as a GAM and then very verbosely and confusingly crash. This change checks whether the filename ends with `.gam`. If not, a short and readable error is printed. Standard input works as before since that can't be easily checked.