### PR TITLE
remove extra space

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -1958,7 +1958,7 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
         
         if (IndexingParameters::verbosity != IndexingParameters::None) {
             auto log_msg = info(context);
-            log_msg << " Constructing";
+            log_msg << "Constructing";
             if (has_transcripts) {
                 log_msg << " spliced";
             }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Random double space in a `vg autoindex` logging line is now a single space

## Description

Running some commands and saw:
```
[...]
[IndexRegistry] Chunking inputs for parallelism.
[IndexRegistry]  Constructing VG graph from FASTA and VCF input.
[IndexRegistry] Constructing GBWT from VG graph and phased VCF input.
[...]
```
So I fixed it.