### PR TITLE
get rid of vg construct check which is impossible to hit

### DIFF
--- a/src/subcommand/construct_main.cpp
+++ b/src/subcommand/construct_main.cpp
@@ -280,10 +280,6 @@ int main_construct(int argc, char** argv) {
             }
         }
         
-        
-        if (fasta_filenames.empty()) {
-            logger.error() << "a reference is required for graph construction" << endl;
-        }
         if (insertion_filenames.size() > 1) {
             logger.error() << "only one insertion file may be provided" << endl;
         }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Remove useless a check/error that can by definition never be raised

## Description

To get inside of this if statement, `fasta_filenames` cannot be empty:

https://github.com/vgteam/vg/blob/cc0195eaa4369d00b5e2134751c205ea14569e7e/src/subcommand/construct_main.cpp#L233

Thus it is useless to have an error occur if it is empty, since it cannot be.