### PR TITLE
Strip the parts HX Antimalware doesn't like the look of out of test/build_graph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,7 +610,7 @@ else
 endif
 
 test/build_graph: test/build_graph.o $(LIB_DIR)/libvg.a
-	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) -o test/build_graph $(PRE_LINK_DEPS) test/build_graph.o $(LD_LIB_DIR_FLAGS) $(LDFLAGS) $(LIB_DIR)/libvg.a $(LD_LIB_FLAGS) $(START_STATIC) $(LD_STATIC_LIB_FLAGS) $(END_STATIC) $(LD_STATIC_LIB_DEPS) $(LD_EXE_LIB_FLAGS)
+	$(CXX) $(INCLUDE_FLAGS) $(CPPFLAGS) $(CXXFLAGS) -o test/build_graph $(PRE_LINK_DEPS) test/build_graph.o $(LD_LIB_DIR_FLAGS) $(LDFLAGS) $(LIB_DIR)/libvg.a $(LD_LIB_FLAGS) $(START_STATIC) $(LD_STATIC_LIB_FLAGS) $(END_STATIC) $(LD_STATIC_LIB_DEPS) $(LD_EXE_LIB_FLAGS)
 	# UCSC's HX Antimalware endpoint security thinks test/build_graph is Atomic
 	# macOS Stealer if the debug symbols are in it. It probably isn't. But we
 	# need to delete the debug symbols or our binary will get deleted shortly


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `test/build_graph` executable should no longer be mistaken for malware

## Description

UCSC's endpoint security setup has a grudge against `test/build_graph`. Our IT people noted that the problem goes away if you get rid of the debug symbols, and the antimalware tool is willing to let the binary be on disk for at least a *little* time, so this tries to strip out the debug symbols before they can offend the endpoint security setup.