### PR TITLE
Document the range sweep feature of Giraffe better

### DIFF
--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -688,7 +688,10 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
              << "                                in the GR tag as a cs-style difference string" << endl
              << "  -n, --discard                 discard all output alignments (for profiling)" << endl
              << "      --output-basename NAME    write output to a GAM file with the given prefix" << endl
-             << "                                for each setting combination" << endl
+             << "                                for each setting combination. Setting values for" << endl
+             << "                                many other options can be provided as ranges" << endl
+             << "                                in the format start[:end[:step]], with end"
+             << "                                being inclusive." << endl
              << "      --report-name FILE        write a TSV of output file and mapping speed" << endl
              << "      --show-work               log how the mapper comes to its conclusions" << endl
              << "                                about mapping locations (use one read at a time)" << endl;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` help now mentions its `start[:end[:step]]` range specification syntax
## Description
I wanted to use the range sweep feature for testing recombination penalty values, and I couldn't remember the syntax and had to look a the code. This adds it to a relevant part of the help.
