### PR TITLE
actually make vg index helptext wrap

### DIFF
--- a/src/subcommand/index_main.cpp
+++ b/src/subcommand/index_main.cpp
@@ -73,8 +73,8 @@ void help_index(char** argv) {
          << "      --no-nested-distance  only store distances along the top-level chain" << endl
          << "  -w, --upweight-node N     upweight the node with ID N to push it to be part" << endl
          << "                            of a top-level chain (may repeat)" << endl
-         << "  -P, --path-prefix NAME    upweight tips of paths with given prefix to orient"
-         << "                            snarl tree. often necessary when running vg"
+         << "  -P, --path-prefix NAME    upweight tips of paths with given prefix to orient" << endl
+         << "                            snarl tree. often necessary when running vg" << endl
          << "                            haplotypes downstream" << endl;
 }
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fixed some non-wrapping `vg index` helptext

## Description

No good way to auto-catch this since there are legitimate reasons to have no `endl` to end a line (e.g. if you're using a long variable name for a default). So spot-fix.