### PR TITLE
Bugfix in supplementary alignment identification in Giraffe

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -3818,7 +3818,7 @@ vector<Alignment> MinimizerMapper::identify_supplementary_alignments(vector<Alig
             supplementaries.reserve(supplementary_idxs.size());
             for (size_t i = 0, s = 0; i < alignments.size(); ++i) {
 
-                if (i == supplementary_idxs[s]) {
+                if (s < supplementary_idxs.size() && i == supplementary_idxs[s]) {
                     // Move this alignment to the supplementaries vector
                     supplementaries.emplace_back(std::move(alignments[i]));
                     ++s;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Bugfix in the `vg giraffe --supplementary` option

## Description

Had an indexing error that could lead to out-of-bounds memory accesses