### PR TITLE
Add subcommand anchor targets to their sections, since we link to them

### DIFF
--- a/doc/vgmanmd.py
+++ b/doc/vgmanmd.py
@@ -79,7 +79,7 @@ for line in vg_help.stderr.decode().split('\n'):
         cmd = parts[1]
 
 for cmd in cmds:
-    print('## {cmd}: {blurb}\n\n'.format(cmd=cmd, blurb=cmd_desc[cmd]))
+    print('<a id="{cmd}"/>\n\n## {cmd}: {blurb}\n\n'.format(cmd=cmd, blurb=cmd_desc[cmd]))
     try:
         # Try first with the help option to get all options described.
         # Use check=True to raise CalledProcessError on non-zero exit codes (e.g., when --help fails),


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg wiki manpage links to subcommand sections now work

## Description
For some reason we were linking to anchors in the wiki page that were just the subcommand names, but we were including the descriptions in the section headers.

This adds anchor tags to the wiki page so links to just the subcommand as an anchor work.