### PR TITLE
Revert path sense filtering in clip, depth, simplify and traversal_fi…

### DIFF
--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -123,7 +123,7 @@ void visit_contained_snarls(const PathPositionHandleGraph* graph, const vector<R
         path_name_set.insert(region.seq);
     }
     unordered_set<string> graph_path_name_set;
-    graph->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](path_handle_t path_handle) {
+    graph->for_each_path_handle([&](path_handle_t path_handle) {
             string graph_path_name = graph->get_path_name(path_handle);
             if (path_name_set.count(Paths::strip_subrange(graph_path_name))) {
                 graph_path_name_set.insert(graph_path_name);
@@ -614,7 +614,7 @@ void clip_low_depth_nodes_and_edges_generic(MutablePathMutableHandleGraph* graph
     bdsg::PackedVector<> edge_depths;
     edge_depths.resize(edge_count + 1);
     
-    graph->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](path_handle_t path_handle) {
+    graph->for_each_path_handle([&](path_handle_t path_handle) {
             bool is_ref_path = check_prefixes(graph->get_path_name(path_handle));
             handle_t prev_handle;
             bool first = true;
@@ -1053,7 +1053,7 @@ void clip_deletion_edges(MutablePathMutableHandleGraph* graph, int64_t max_delet
     
     // load up the reference paths and their ids
     unordered_set<path_handle_t> ref_paths;
-    graph->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](path_handle_t path_handle) {
+    graph->for_each_path_handle([&](path_handle_t path_handle) {
             string path_name = graph->get_path_name(path_handle);
             for (const string& ref_prefix : ref_prefixes) {
                 if (path_name.compare(0, ref_prefix.length(), ref_prefix) == 0) {
@@ -1312,7 +1312,7 @@ void clip_contained_stubs(MutablePathMutableHandleGraph* graph, PathPositionHand
 void stubbify_ref_paths(MutablePathMutableHandleGraph* graph, const vector<string>& ref_prefixes, int64_t min_fragment_len, bool verbose) {
     unordered_set<edge_t> edges_to_delete;
     int64_t stubbified_path_count = 0; // just for logging
-    graph->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](path_handle_t path_handle) {
+    graph->for_each_path_handle([&](path_handle_t path_handle) {
         string path_name = graph->get_path_name(path_handle);
         for (const string& ref_prefix : ref_prefixes) {
             bool was_stubbified = false;

--- a/src/rare_variant_simplifier.cpp
+++ b/src/rare_variant_simplifier.cpp
@@ -12,11 +12,11 @@ void RareVariantSimplifier::simplify() {
     // This holds the IDs of all the nodes we want to keep around
     unordered_set<id_t> to_keep;
 
-    graph.for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](const path_handle_t& path) {
+    graph.for_each_path_handle([&](const path_handle_t& path) {
         // For each path
-        
+
         if (!Paths::is_alt(graph.get_path_name(path))) {
-            // If it isn't an alt or haplotype path, we want to trace it
+            // If it isn't an alt path, we want to trace it
 
             // For each occurrence from start to end
             // Put the ID of the node we are visiting in the to-keep set

--- a/src/subcommand/clip_main.cpp
+++ b/src/subcommand/clip_main.cpp
@@ -300,7 +300,7 @@ int main_clip(int argc, char** argv) {
             for (const Region& region : bed_regions) {
                 contig_set.insert(region.seq);
             }
-            graph->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&] (path_handle_t path_handle) {
+            graph->for_each_path_handle([&] (path_handle_t path_handle) {
                     string base_name = Paths::strip_subrange(graph->get_path_name(path_handle));
                     if (contig_set.count(base_name)) {
                         // todo: should take into account coordinate comp
@@ -329,7 +329,7 @@ int main_clip(int argc, char** argv) {
             assert(need_pp);
             assert(!ref_prefixes.empty());
             // load the BED regions from the reference path prefix
-            pp_graph->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](path_handle_t path_handle) {
+            pp_graph->for_each_path_handle([&](path_handle_t path_handle) {
                     string path_name = pp_graph->get_path_name(path_handle);
                     subrange_t subrange;
                     path_name = Paths::strip_subrange(path_name, &subrange);

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -339,7 +339,6 @@ int main_deconstruct(int argc, char** argv) {
     }
 
     // process the prefixes to find ref paths
-    // Altpaths are included (priority given to non-altpaths in deconstructor.cpp)
     if (!refpath_prefixes.empty()) {
         graph->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](const path_handle_t& path_handle) {
             string path_name = graph->get_path_name(path_handle);

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -222,7 +222,7 @@ int main_depth(int argc, char** argv) {
         map<pair<string, int64_t>, string> ref_paths;
         unordered_set<string> base_path_set;
         
-        graph->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](path_handle_t path_handle) {
+        graph->for_each_path_handle([&](path_handle_t path_handle) {
                 string path_name = graph->get_path_name(path_handle);
                 subrange_t subrange;
                 string base_name = Paths::strip_subrange(path_name, &subrange);

--- a/src/subcommand/simplify_main.cpp
+++ b/src/subcommand/simplify_main.cpp
@@ -243,7 +243,7 @@ int main_simplify(int argc, char** argv) {
 
         if (!keep_nonref_paths) {
             vector<path_handle_t> to_destroy;
-            graph->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](const path_handle_t path_handle) {
+            graph->for_each_path_handle([&](const path_handle_t path_handle) {
                 if (graph->get_path_name(path_handle).compare(0, ref_path_prefix.length(), ref_path_prefix) != 0) {
                     to_destroy.push_back(path_handle);
                 }

--- a/src/traversal_finder.cpp
+++ b/src/traversal_finder.cpp
@@ -72,7 +72,7 @@ vector<SnarlTraversal> PathBasedTraversalFinder::find_traversals(const Snarl& si
     regex alt_str ("(_alt_)");
     regex back ("(_[0-9]*)");
     set<string> gpath_names;
-    graph.for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC}, [&](const path_handle_t& path_handle) {
+    graph.for_each_path_handle([&](const path_handle_t& path_handle) {
         gpath_names.insert(graph.get_path_name(path_handle));
     });
     


### PR DESCRIPTION
…nder

The "no secret paths" commit (2315642ac) mechanically replaced for_each_path_handle() with for_each_path_of_sense({REFERENCE, GENERIC}) across the codebase, which inadvertently excluded haplotype paths from depth calculations, path enumeration, and path destruction in several tools. This caused regressions where more content was clipped (clip), depth was underreported (depth), haplotype paths survived when they should have been removed (simplify), and haplotype path traversals were lost (traversal_finder).

I noticed this when [updating to vg 1.72.0](https://github.com/ComparativeGenomicsToolkit/cactus/pull/1895) in Cactus caused its tests to start [failing](https://ucsc-ci.com/comparativegenomicstoolkit/cactus/-/jobs/104238).

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fix regression in `vg clip`, `depth`, `simplify` and potentially some uses of `deconstruct` and `call`, that results from a change that ignores haplotypes in .vg files (to be consistent with how .gbz files would have been treated). 

