### PR TITLE
Preserve read names in spliced surject with GAM input

### DIFF
--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -383,6 +383,7 @@ using namespace std;
                     for (const auto& surjection : surjections) {
                         aln_surjections[surj_record.first].emplace_back(Alignment(), surjection.second);
                         optimal_alignment(surjection.first, aln_surjections[surj_record.first].back().first, allow_negative_scores);
+                        transfer_read_metadata(*source_aln, aln_surjections[surj_record.first].back().first);
                     }
                     choose_primary(aln_surjections[surj_record.first]);
                 }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject -S` no longer loses read names with GAM input

## Description

Resolves https://github.com/vgteam/vg/issues/4776