### PR TITLE
Score seeds correctly

### DIFF
--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -17,7 +17,10 @@ from collections import defaultdict, Counter
 def parse_seeds_file(filepath):
     """
     Parse a chain seeds file.
-    Returns list of dicts with keys: read_pos, ref_name, ref_pos, strand, seed_num, seed_name
+    Returns list of dicts with keys: read_pos, ref_name, ref_pos, strand,
+    seed_num, seed_name. Seeds that don't lie on any linear reference path
+    have empty strings for ref_name, ref_pos, and strand; ref_pos is stored
+    as None in that case.
     """
     seeds = []
     with open(filepath, 'r') as f:
@@ -30,9 +33,9 @@ def parse_seeds_file(filepath):
                 continue
             seeds.append({
                 'read_pos': int(parts[0]),
-                'ref_name': parts[1],
-                'ref_pos': int(parts[2]),
-                'strand': parts[3],
+                'ref_name': parts[1] or None,
+                'ref_pos': int(parts[2]) if parts[2] else None,
+                'strand': parts[3] or None,
                 'seed_num': int(parts[4]),
                 'seed_name': parts[5]
             })
@@ -76,32 +79,90 @@ def find_all_chaindump_files(data_dir):
     return glob.glob(pattern)
 
 
+def compute_winning_traceback(seeds, transitions):
+    """
+    Compute the winning chain traceback on the full transition graph.
+
+    Returns an ordered list of seed names from the highest-scoring seed
+    backward to the chain start.
+    """
+    max_score_by_dest = {}
+    best_transition_to = {}
+    for t in transitions:
+        if t['score'] > 0:
+            dest = t['dest_name']
+            prev = max_score_by_dest.get(dest, 0)
+            if t['score'] > prev:
+                max_score_by_dest[dest] = t['score']
+                best_transition_to[dest] = t
+
+    if not max_score_by_dest:
+        return []
+
+    best_seed_name = max(max_score_by_dest, key=max_score_by_dest.get)
+
+    traceback = []
+    visited = set()
+    current = best_seed_name
+    while current and current not in visited:
+        traceback.append(current)
+        visited.add(current)
+        bt = best_transition_to.get(current)
+        if bt:
+            current = bt['source_name']
+        else:
+            break
+    return traceback
+
+
 def generate_svg(seeds, transitions, output_path):
     """Generate an SVG file with embedded D3.js visualization."""
 
-    # Filter seeds to the most common reference path
-    ref_name_counts = Counter(s['ref_name'] for s in seeds)
-    if ref_name_counts:
-        best_ref_name = ref_name_counts.most_common(1)[0][0]
-        seeds = [s for s in seeds if s['ref_name'] == best_ref_name]
+    # Compute the winning traceback on the complete, unfiltered graph so that
+    # the visualization can show the real best chain even when it passes
+    # through seeds that don't lie on the displayed linear reference.
+    winning_traceback = compute_winning_traceback(seeds, transitions)
+    traceback_name_set = set(winning_traceback)
+
+    print(f"Winning traceback has {len(winning_traceback)} seeds:", file=sys.stderr)
+    for name in winning_traceback:
+        print(f"  {name}", file=sys.stderr)
+
+    # Identify transitions on the winning traceback path.
+    # The traceback list goes [dest, ..., source], so consecutive pairs are
+    # (traceback[i] = dest, traceback[i+1] = source).
+    traceback_edge_set = set()
+    for i in range(len(winning_traceback) - 1):
+        traceback_edge_set.add(
+            (winning_traceback[i + 1], winning_traceback[i])
+        )
+
+    # Find the most common linear reference among the seeds.
+    ref_name_counts = Counter(s['ref_name'] for s in seeds if s['ref_name'] is not None)
+    best_ref_name = ref_name_counts.most_common(1)[0][0] if ref_name_counts else None
+
+    # Keep seeds that are on the best reference path, plus any seeds on the
+    # winning traceback that aren't.
+    seeds = [s for s in seeds if s['ref_name'] == best_ref_name or s['seed_name'] in traceback_name_set]
 
     # Index seeds by name.
     # We use the index in seeds as our main identifier for the seeds in the
     # visualization, though we still track the "seed number" and human-readable
     # name to display.
     seed_index = {s['seed_name']: i for i, s in enumerate(seeds)}
-    
-    # Filter transitions and translate them to be in terms of seed index.
+
+    # Keep transitions where both endpoints are included seeds.
     translated_transitions = []
     for t in transitions:
         source_index = seed_index.get(t['source_name'])
         dest_index = seed_index.get(t['dest_name'])
-        if source_index is not None and dest_index is not None:
-            translated_transitions.append({
-                'source_index': source_index,
-                'dest_index': dest_index,
-                'score': t['score']
-            })
+        if source_index is None or dest_index is None:
+            continue
+        translated_transitions.append({
+            'source_index': source_index,
+            'dest_index': dest_index,
+            'score': t['score']
+        })
     transitions.clear()
 
     # Compute max positive score per destination index
@@ -191,6 +252,12 @@ def generate_svg(seeds, transitions, output_path):
       stroke: red;
       stroke-width: 3px;
       opacity: 1;
+    }
+    .transition.traceback-skip {
+      stroke: red;
+      stroke-width: 3px;
+      stroke-dasharray: 8,4;
+      opacity: 0.7;
     }
     .axis text {
       font-family: sans-serif;
@@ -354,7 +421,7 @@ def generate_svg(seeds, transitions, output_path):
        * Compute 1:1 aspect ratio domains, create xScale/yScale/colorScale.
        */
       #setupScales() {
-        const seeds = this.data.seeds;
+        const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== null);
         const margin = {top: 40, right: 40, bottom: 60, left: 80};
         const svgWidth = 1200;
         const svgHeight = 800;
@@ -364,8 +431,8 @@ def generate_svg(seeds, transitions, output_path):
         const width = this._width;
         const height = this._height;
 
-        let xExtent = d3.extent(seeds, d => d.ref_pos);
-        let yExtent = d3.extent(seeds, d => d.read_pos);
+        let xExtent = d3.extent(onRefSeeds, d => d.ref_pos);
+        let yExtent = d3.extent(onRefSeeds, d => d.read_pos);
         if (xExtent[0] === undefined) xExtent = [0, 1000];
         if (yExtent[0] === undefined) yExtent = [0, 1000];
 
@@ -472,13 +539,13 @@ def generate_svg(seeds, transitions, output_path):
        */
       #setupSeeds() {
         const viz = this;
-        const seeds = this.data.seeds;
+        const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== null);
 
-        /// D3 selection of all seed <circle> elements; stored so interaction
-        /// methods can restyle seeds (e.g. classed 'on-traceback') without
-        /// re-selecting.
+        /// D3 selection of all on-reference seed <circle> elements; stored so
+        /// interaction methods can restyle seeds (e.g. classed 'on-traceback')
+        /// without re-selecting.
         this.seedCircles = this.seedLayer.selectAll('.seed')
-          .data(seeds)
+          .data(onRefSeeds)
           .enter()
           .append('circle')
           .attr('class', 'seed')
@@ -559,17 +626,18 @@ def generate_svg(seeds, transitions, output_path):
        * Find best seed, select it, show traceback, mark best chain, zoom to fit.
        */
       #initialize() {
-        const seeds = this.data.seeds;
-        const bestSeed = seeds.reduce((best, s) => (s.max_score > best.max_score ? s : best), seeds[0]);
+        const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== null);
+        if (onRefSeeds.length === 0) return;
+        const bestSeed = onRefSeeds.reduce((best, s) => (s.max_score > best.max_score ? s : best), onRefSeeds[0]);
         if (bestSeed && bestSeed.max_score > 0) {
           this.selectedSeed = bestSeed;
           this.seedCircles.filter(s => s.index === bestSeed.index).classed('selected', true);
           this.#showTraceback(bestSeed.index);
           const bestChainSeedIndices = new Set(this.tracebackSeedIndices);
           this.seedCircles.classed('on-best-chain', d => bestChainSeedIndices.has(d.index));
-          this.#zoomToFit(seeds.filter(s => this.tracebackSeedIndices.has(s.index)), 0.05);
+          this.#zoomToFit(onRefSeeds.filter(s => this.tracebackSeedIndices.has(s.index)), 0.05);
         } else {
-          this.#zoomToFit(seeds, 0.05);
+          this.#zoomToFit(onRefSeeds, 0.05);
         }
       }
 
@@ -644,34 +712,76 @@ def generate_svg(seeds, transitions, output_path):
       }
 
       /**
-       * Display the traceback path from seedIndex as red lines.
+       * Flatten a traceback path into the linear reference space: collapse
+       * runs of off-reference seeds into single skip edges connecting the
+       * on-reference seeds that bracket them.
+       *
+       * Returns an array of display edges, each with source_index,
+       * dest_index, and skip (boolean).
+       */
+      #flattenTraceback(path, startSeedIndex) {
+        const seeds = this.data.seeds;
+        const displayEdges = [];
+
+        // The traceback starts at startSeedIndex (the dest of path[0]).
+        let lastOnRefIndex = seeds[startSeedIndex].ref_pos !== null
+            ? startSeedIndex : null;
+        let skippedOffRef = seeds[startSeedIndex].ref_pos === null;
+
+        for (const t of path) {
+          const sourceSeed = seeds[t.source_index];
+          if (sourceSeed.ref_pos !== null) {
+            if (lastOnRefIndex !== null) {
+              displayEdges.push({
+                source_index: t.source_index,
+                dest_index: lastOnRefIndex,
+                skip: skippedOffRef,
+                score: skippedOffRef ? undefined : t.score,
+                fraction: skippedOffRef ? undefined : t.fraction
+              });
+            }
+            lastOnRefIndex = t.source_index;
+            skippedOffRef = false;
+          } else {
+            skippedOffRef = true;
+          }
+        }
+
+        return displayEdges;
+      }
+
+      /**
+       * Display the traceback path from seedIndex as red lines, with
+       * dashed skip edges where the traceback crosses off-reference seeds.
        */
       #showTraceback(seedIndex) {
         const path = this.#computeTraceback(seedIndex);
+        const displayEdges = this.#flattenTraceback(path, seedIndex);
+
         this.tracebackSeedIndices.clear();
-        path.forEach(t => {
-          this.tracebackSeedIndices.add(t.source_index);
-          this.tracebackSeedIndices.add(t.dest_index);
+        displayEdges.forEach(e => {
+          this.tracebackSeedIndices.add(e.source_index);
+          this.tracebackSeedIndices.add(e.dest_index);
         });
 
         const tracebackSet = this.tracebackSeedIndices;
         this.seedCircles.classed('on-traceback', d => tracebackSet.has(d.index) && d.index !== seedIndex);
 
-        const lines = this.tracebackLayer.selectAll('.traceback')
-          .data(path, d => d.source_name + '->' + d.dest_name);
+        const lines = this.tracebackLayer.selectAll('.traceback, .traceback-skip')
+          .data(displayEdges, d => d.source_index + '->' + d.dest_index);
 
         lines.enter()
           .append('line')
-          .attr('class', 'transition traceback')
+          .attr('class', d => d.skip ? 'transition traceback-skip' : 'transition traceback')
           .call(this.#positionLinesFn())
           .append('title')
-          .text(d => this.#transitionTooltipText(d));
+          .text(d => d.skip ? 'Traceback crosses off-reference seeds' : this.#transitionTooltipText(d));
 
         lines.exit().remove();
       }
 
       #hideTraceback() {
-        this.tracebackLayer.selectAll('.traceback').remove();
+        this.tracebackLayer.selectAll('.traceback, .traceback-skip').remove();
         this.tracebackSeedIndices.clear();
         this.seedCircles.classed('on-traceback', false);
       }

--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -36,6 +36,9 @@ def parse_seeds_file(filepath):
                 'ref_name': parts[1] or None,
                 'ref_pos': int(parts[2]) if parts[2] else None,
                 'strand': parts[3] or None,
+                # This is the seed number among all seeds in all
+                # problems/trees, NOT the anchor number that will appear in the
+                # chaining liks with #123 notation.
                 'seed_num': int(parts[4]),
                 'seed_name': parts[5]
             })
@@ -663,7 +666,7 @@ def generate_svg(seeds, transitions, output_path):
        * Base tooltip text for a seed.
        */
       #seedTooltipText(d) {
-        return `Seed #${d.seed_num} (${d.strand})\\nName: ${d.seed_name}\\nRead: ${d.read_pos}\\nRef: ${d.ref_pos}\\nMax score: ${d.max_score}`;
+        return `Seed S${d.seed_num} (${d.strand})\\nName: ${d.seed_name}\\nRead: ${d.read_pos}\\nRef: ${d.ref_pos}\\nMax score: ${d.max_score}`;
       }
 
       /**

--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -38,7 +38,7 @@ def parse_seeds_file(filepath):
                 'strand': parts[3] or None,
                 # This is the seed number among all seeds in all
                 # problems/trees, NOT the anchor number that will appear in the
-                # chaining liks with #123 notation.
+                # chaining like with #123 notation.
                 'seed_num': int(parts[4]),
                 'seed_name': parts[5]
             })

--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -79,19 +79,25 @@ def find_all_chaindump_files(data_dir):
     return glob.glob(pattern)
 
 
-def compute_winning_traceback(max_score_by_dest, best_transition_to):
+def compute_winning_traceback(max_score_by_dest, best_transition_to, seed_names):
     """
-    Compute the winning chain traceback on the full transition graph.
+    Compute the winning chain traceback on the full transition graph,
+    starting from the highest-scoring seed in seed_names.
 
     Returns an ordered list of seed names from the highest-scoring seed
-    backward to the chain start.
+    backward to the chain start.  The traceback can pass through seeds
+    not in seed_names (off-reference seeds reachable via transitions).
     """
-    
 
     if not max_score_by_dest:
         return []
 
-    best_seed_name = max(max_score_by_dest, key=max_score_by_dest.get)
+    # Start from the best seed that actually belongs to this chain.
+    candidates = [(max_score_by_dest.get(n, 0), n) for n in seed_names
+                  if max_score_by_dest.get(n, 0) > 0]
+    if not candidates:
+        return []
+    best_seed_name = max(candidates)[1]
 
     traceback = []
     visited = set()
@@ -124,7 +130,8 @@ def generate_svg(seeds, transitions, output_path):
     # Compute the winning traceback on the complete, unfiltered graph so that
     # the visualization can show the real best chain even when it passes
     # through seeds that don't lie on the displayed linear reference.
-    winning_traceback = compute_winning_traceback(max_score_by_dest, best_transition_to)
+    seed_names = {s['seed_name'] for s in seeds}
+    winning_traceback = compute_winning_traceback(max_score_by_dest, best_transition_to, seed_names)
     traceback_name_set = set(winning_traceback)
 
     # Find the most common linear reference among the seeds.
@@ -163,8 +170,11 @@ def generate_svg(seeds, transitions, output_path):
 
     # Make sure we haven't lost any score from our overall best traceback
     for seed_name in winning_traceback:
-        assert max_score_by_index[seed_index[seed_name]] == max_score_by_dest.get(seed_name, float('-inf'))
-    assert max(max_score_by_index) == max(max_score_by_dest.values())
+        assert max_score_by_index[seed_index[seed_name]] == max_score_by_dest.get(seed_name, float('-inf')), \
+            f"Score mismatch for {seed_name}: index={max_score_by_index[seed_index[seed_name]]}, dest={max_score_by_dest.get(seed_name, float('-inf'))}"
+    if winning_traceback:
+        tb_best = max(max_score_by_dest.get(n, 0) for n in winning_traceback)
+        assert max(max_score_by_index) >= tb_best
 
     # Build seeds data with score info
     seeds_data = []
@@ -400,6 +410,9 @@ def generate_svg(seeds, transitions, output_path):
         /// Set of seed indices along the current traceback path. Used both
         /// for styling and as the seed set for #zoomToFit on startup.
         this.tracebackSeedIndices = new Set();
+        /// Closures that reposition off-reference indicator lines and
+        /// their gradients; called on every zoom event.
+        this._offRefIndicatorRepositioners = [];
 
         this.#setupScales();
         this.#setupSVG();
@@ -612,6 +625,7 @@ def generate_svg(seeds, transitions, output_path):
               .attr('cx', d => viz.currentXScale(d.ref_pos))
               .attr('cy', d => viz.currentYScale(d.read_pos));
             viz.zoomG.selectAll('.transition').call(viz.#positionLinesFn());
+            viz.#repositionOffRefIndicators();
           });
 
         this.svg.call(this.zoom);
@@ -728,6 +742,10 @@ def generate_svg(seeds, transitions, output_path):
             ? startSeedIndex : null;
         let skippedOffRef = seeds[startSeedIndex].ref_pos === null;
 
+        // Track whether the traceback extends off-reference beyond the
+        // outermost on-reference seeds.
+        let leadingOffRef = skippedOffRef;
+
         for (const t of path) {
           const sourceSeed = seeds[t.source_index];
           if (sourceSeed.ref_pos !== null) {
@@ -747,7 +765,9 @@ def generate_svg(seeds, transitions, output_path):
           }
         }
 
-        return displayEdges;
+        // skippedOffRef is true if the traceback ended on off-ref seeds
+        // after the last on-ref seed.
+        return {edges: displayEdges, leadingOffRef, trailingOffRef: skippedOffRef};
       }
 
       /**
@@ -756,7 +776,12 @@ def generate_svg(seeds, transitions, output_path):
        */
       #showTraceback(seedIndex) {
         const path = this.#computeTraceback(seedIndex);
-        const displayEdges = this.#flattenTraceback(path, seedIndex);
+        const {edges: displayEdges, leadingOffRef, trailingOffRef} =
+            this.#flattenTraceback(path, seedIndex);
+
+        this.tracebackLayer.selectAll('.traceback-offref-indicator').remove();
+        this.svg.selectAll('defs linearGradient[id^="offref-grad-"]').remove();
+        this._offRefIndicatorRepositioners = [];
 
         this.tracebackSeedIndices.clear();
         displayEdges.forEach(e => {
@@ -778,10 +803,81 @@ def generate_svg(seeds, transitions, output_path):
           .text(d => d.skip ? 'Traceback crosses off-reference seeds' : this.#transitionTooltipText(d));
 
         lines.exit().remove();
+
+        // Draw fading diagonal indicators where the traceback extends
+        // off-reference beyond the outermost on-reference seeds.
+        this.tracebackLayer.selectAll('.traceback-offref-indicator').remove();
+        if (displayEdges.length > 0) {
+          const seeds = this.data.seeds;
+          // "leading" = high-read-pos end (dest of first edge),
+          // "trailing" = low-read-pos end (source of last edge).
+          if (leadingOffRef) {
+            const tipSeed = seeds[displayEdges[0].dest_index];
+            this.#drawOffRefIndicator(tipSeed, +1);
+          }
+          if (trailingOffRef) {
+            const tipSeed = seeds[displayEdges[displayEdges.length - 1].source_index];
+            this.#drawOffRefIndicator(tipSeed, -1);
+          }
+        }
+      }
+
+      /**
+       * Draw a fading diagonal line from an on-reference seed, indicating
+       * the traceback continues off-reference.  `direction` is +1 to
+       * extend toward increasing read_pos, -1 toward decreasing.
+       */
+      #drawOffRefIndicator(seed, direction) {
+        const viz = this;
+        // Extend a fixed pixel length along the ±1 diagonal matching
+        // the strand, so the indicator is a directional cue rather than
+        // a line aimed at any particular data-space position.
+        const refSign = seed.strand === '+' ? 1 : -1;
+        // Screen-space direction: dx and dy each get ±1/√2 of the
+        // pixel length, giving a 45° line.  The Y axis is inverted in
+        // screen space (increasing Y = decreasing read_pos in the
+        // scale), so negate the read component.
+        const pxLen = 80;
+        const dx = direction * refSign * pxLen / Math.SQRT2;
+        const dy = -direction * pxLen / Math.SQRT2;
+
+        const gradId = 'offref-grad-' + seed.index + '-' + direction;
+        const defs = this.svg.select('defs');
+        const grad = defs.append('linearGradient')
+          .attr('id', gradId)
+          .attr('gradientUnits', 'userSpaceOnUse');
+
+        grad.append('stop').attr('offset', '0%')
+          .attr('stop-color', 'red').attr('stop-opacity', 1);
+        grad.append('stop').attr('offset', '100%')
+          .attr('stop-color', 'red').attr('stop-opacity', 0);
+
+        const line = this.tracebackLayer.append('line')
+          .attr('class', 'traceback-offref-indicator')
+          .attr('stroke', `url(#${gradId})`)
+          .attr('stroke-width', 3);
+
+        function reposition() {
+          const x1 = viz.currentXScale(seed.ref_pos);
+          const y1 = viz.currentYScale(seed.read_pos);
+          const x2 = x1 + dx;
+          const y2 = y1 + dy;
+          line.attr('x1', x1).attr('y1', y1).attr('x2', x2).attr('y2', y2);
+          grad.attr('x1', x1).attr('y1', y1).attr('x2', x2).attr('y2', y2);
+        }
+
+        reposition();
+        this._offRefIndicatorRepositioners.push(reposition);
+      }
+
+      #repositionOffRefIndicators() {
+        for (const fn of this._offRefIndicatorRepositioners) fn();
       }
 
       #hideTraceback() {
-        this.tracebackLayer.selectAll('.traceback, .traceback-skip').remove();
+        this.tracebackLayer.selectAll('.traceback, .traceback-skip, .traceback-offref-indicator').remove();
+        this.svg.selectAll('defs linearGradient[id^="offref-grad-"]').remove();
+        this._offRefIndicatorRepositioners = [];
         this.tracebackSeedIndices.clear();
         this.seedCircles.classed('on-traceback', false);
       }

--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -513,6 +513,7 @@ def generate_svg(seeds, transitions, output_path):
               }
             } else {
               if (prevSelected) {
+                viz.#hideTraceback();
                 viz.seedCircles.filter(s => s.index === prevSelected.index)
                   .classed('selected', false)
                   .classed('hovered', false);

--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -79,22 +79,14 @@ def find_all_chaindump_files(data_dir):
     return glob.glob(pattern)
 
 
-def compute_winning_traceback(seeds, transitions):
+def compute_winning_traceback(max_score_by_dest, best_transition_to):
     """
     Compute the winning chain traceback on the full transition graph.
 
     Returns an ordered list of seed names from the highest-scoring seed
     backward to the chain start.
     """
-    max_score_by_dest = {}
-    best_transition_to = {}
-    for t in transitions:
-        if t['score'] > 0:
-            dest = t['dest_name']
-            prev = max_score_by_dest.get(dest, 0)
-            if t['score'] > prev:
-                max_score_by_dest[dest] = t['score']
-                best_transition_to[dest] = t
+    
 
     if not max_score_by_dest:
         return []
@@ -118,24 +110,22 @@ def compute_winning_traceback(seeds, transitions):
 def generate_svg(seeds, transitions, output_path):
     """Generate an SVG file with embedded D3.js visualization."""
 
+    # Load up the DP graph in terms of seed names.
+    max_score_by_dest = {}
+    best_transition_to = {}
+    for t in transitions:
+        if t['score'] > 0:
+            dest = t['dest_name']
+            prev = max_score_by_dest.get(dest, 0)
+            if t['score'] > prev:
+                max_score_by_dest[dest] = t['score']
+                best_transition_to[dest] = t
+
     # Compute the winning traceback on the complete, unfiltered graph so that
     # the visualization can show the real best chain even when it passes
     # through seeds that don't lie on the displayed linear reference.
-    winning_traceback = compute_winning_traceback(seeds, transitions)
+    winning_traceback = compute_winning_traceback(max_score_by_dest, best_transition_to)
     traceback_name_set = set(winning_traceback)
-
-    print(f"Winning traceback has {len(winning_traceback)} seeds:", file=sys.stderr)
-    for name in winning_traceback:
-        print(f"  {name}", file=sys.stderr)
-
-    # Identify transitions on the winning traceback path.
-    # The traceback list goes [dest, ..., source], so consecutive pairs are
-    # (traceback[i] = dest, traceback[i+1] = source).
-    traceback_edge_set = set()
-    for i in range(len(winning_traceback) - 1):
-        traceback_edge_set.add(
-            (winning_traceback[i + 1], winning_traceback[i])
-        )
 
     # Find the most common linear reference among the seeds.
     ref_name_counts = Counter(s['ref_name'] for s in seeds if s['ref_name'] is not None)
@@ -150,6 +140,10 @@ def generate_svg(seeds, transitions, output_path):
     # visualization, though we still track the "seed number" and human-readable
     # name to display.
     seed_index = {s['seed_name']: i for i, s in enumerate(seeds)}
+
+    print(f"Winning traceback has {len(winning_traceback)} seeds:", file=sys.stderr)
+    for i, name in enumerate(winning_traceback):
+        print(f"  {i} = {seed_index[name]}: {name} score {max_score_by_dest.get(name, 0)}", file=sys.stderr)
 
     # Keep transitions where both endpoints are included seeds.
     translated_transitions = []
@@ -166,15 +160,21 @@ def generate_svg(seeds, transitions, output_path):
     transitions.clear()
 
     # Compute max positive score per destination index
-    max_score_by_dest = [float('-inf')] * len(seeds)
+    max_score_by_index = [float('-inf')] * len(seeds)
     for t in translated_transitions:
-        if t['score'] > 0 and t['score'] > max_score_by_dest[t['dest_index']]:
-            max_score_by_dest[t['dest_index']] = t['score']
+        if t['score'] > 0 and t['score'] > max_score_by_index[t['dest_index']]:
+            max_score_by_index[t['dest_index']] = t['score']
+
+    # Make sure we haven't lost any score form our overall best traceback
+    for seed_name in winning_traceback:
+        assert max_score_by_index[seed_index[seed_name]] == max_score_by_dest.get(seed_name, float('-inf')), f"{seed_name} should have score {max_score_by_dest.get(seed_name, float('-inf'))} but appears to have score {max_score_by_index[seed_index[seed_name]]}"
+    assert max(max_score_by_index) == max(max_score_by_dest.values())
+    print(f"Max score: {max(max_score_by_index)}", file=sys.stderr)
 
     # Build seeds data with score info
     seeds_data = []
     for i, s in enumerate(seeds):
-        max_score = max_score_by_dest[i]
+        max_score = max_score_by_index[i]
         seed_data = dict(
             s,
             index=i,
@@ -187,7 +187,7 @@ def generate_svg(seeds, transitions, output_path):
     # Build transitions data with fraction of max
     transitions_data = []
     for t in translated_transitions:
-        max_score = max_score_by_dest[t['dest_index']]
+        max_score = max_score_by_index[t['dest_index']]
         fraction = max(0, t['score'] / max_score) if max_score > 0 else 0
         transition_data = dict(
             t,
@@ -320,7 +320,7 @@ def generate_svg(seeds, transitions, output_path):
       }
 
       /**
-       * Stores arrays and builds four index Maps.
+       * Save seed and transition arrays and build index Maps over them.
        */
       constructor(seeds, transitions) {
         /// The raw seed array, for looking seeds up by index, and extent
@@ -626,16 +626,22 @@ def generate_svg(seeds, transitions, output_path):
        * Find best seed, select it, show traceback, mark best chain, zoom to fit.
        */
       #initialize() {
+        if (this.data.seeds.length === 0) return;
+        const bestSeed = this.data.seeds.reduce((best, s) => (s.max_score > best.max_score ? s : best), this.data.seeds[0]);
+        console.log(`Best seed score: ${bestSeed.max_score}`);
         const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== null);
-        if (onRefSeeds.length === 0) return;
-        const bestSeed = onRefSeeds.reduce((best, s) => (s.max_score > best.max_score ? s : best), onRefSeeds[0]);
         if (bestSeed && bestSeed.max_score > 0) {
           this.selectedSeed = bestSeed;
           this.seedCircles.filter(s => s.index === bestSeed.index).classed('selected', true);
           this.#showTraceback(bestSeed.index);
           const bestChainSeedIndices = new Set(this.tracebackSeedIndices);
           this.seedCircles.classed('on-best-chain', d => bestChainSeedIndices.has(d.index));
-          this.#zoomToFit(onRefSeeds.filter(s => this.tracebackSeedIndices.has(s.index)), 0.05);
+          const onRefTracebackSeeds = onRefSeeds.filter(s => this.tracebackSeedIndices.has(s.index));
+          if (onRefTracebackSeeds.length !== 0) {
+            this.#zoomToFit(onRefTracebackSeeds, 0.05);
+          } else {
+            this.#zoomToFit(onRefSeeds, 0.05);
+          }
         } else {
           this.#zoomToFit(onRefSeeds, 0.05);
         }
@@ -698,8 +704,12 @@ def generate_svg(seeds, transitions, output_path):
         const path = [];
         const visited = new Set();
         let currentIndex = seedIndex;
+        let i = 0;
+        console.log("Traceback:");
         while (currentIndex !== undefined && !visited.has(currentIndex)) {
           visited.add(currentIndex);
+          console.log(`  ${i} = ${currentIndex}: ${this.data.seeds[currentIndex].seed_name} score ${this.data.seeds[currentIndex].max_score}`);
+          i++;
           const bestTrans = this.data.bestTransitionTo(currentIndex);
           if (bestTrans) {
             path.push(bestTrans);

--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -141,10 +141,6 @@ def generate_svg(seeds, transitions, output_path):
     # name to display.
     seed_index = {s['seed_name']: i for i, s in enumerate(seeds)}
 
-    print(f"Winning traceback has {len(winning_traceback)} seeds:", file=sys.stderr)
-    for i, name in enumerate(winning_traceback):
-        print(f"  {i} = {seed_index[name]}: {name} score {max_score_by_dest.get(name, 0)}", file=sys.stderr)
-
     # Keep transitions where both endpoints are included seeds.
     translated_transitions = []
     for t in transitions:
@@ -165,11 +161,10 @@ def generate_svg(seeds, transitions, output_path):
         if t['score'] > 0 and t['score'] > max_score_by_index[t['dest_index']]:
             max_score_by_index[t['dest_index']] = t['score']
 
-    # Make sure we haven't lost any score form our overall best traceback
+    # Make sure we haven't lost any score from our overall best traceback
     for seed_name in winning_traceback:
-        assert max_score_by_index[seed_index[seed_name]] == max_score_by_dest.get(seed_name, float('-inf')), f"{seed_name} should have score {max_score_by_dest.get(seed_name, float('-inf'))} but appears to have score {max_score_by_index[seed_index[seed_name]]}"
+        assert max_score_by_index[seed_index[seed_name]] == max_score_by_dest.get(seed_name, float('-inf'))
     assert max(max_score_by_index) == max(max_score_by_dest.values())
-    print(f"Max score: {max(max_score_by_index)}", file=sys.stderr)
 
     # Build seeds data with score info
     seeds_data = []
@@ -628,7 +623,6 @@ def generate_svg(seeds, transitions, output_path):
       #initialize() {
         if (this.data.seeds.length === 0) return;
         const bestSeed = this.data.seeds.reduce((best, s) => (s.max_score > best.max_score ? s : best), this.data.seeds[0]);
-        console.log(`Best seed score: ${bestSeed.max_score}`);
         const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== null);
         if (bestSeed && bestSeed.max_score > 0) {
           this.selectedSeed = bestSeed;
@@ -704,12 +698,8 @@ def generate_svg(seeds, transitions, output_path):
         const path = [];
         const visited = new Set();
         let currentIndex = seedIndex;
-        let i = 0;
-        console.log("Traceback:");
         while (currentIndex !== undefined && !visited.has(currentIndex)) {
           visited.add(currentIndex);
-          console.log(`  ${i} = ${currentIndex}: ${this.data.seeds[currentIndex].seed_name} score ${this.data.seeds[currentIndex].max_score}`);
-          i++;
           const bestTrans = this.data.bestTransitionTo(currentIndex);
           if (bestTrans) {
             path.push(bestTrans);

--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -464,7 +464,7 @@ def generate_svg(seeds, transitions, output_path):
         this.tracebackLayer = this.zoomG.append('g');
         this.secondaryTransitionLayer = this.zoomG.append('g');
         this.hoveredToSelectedLayer = this.zoomG.append('g');
-        this._seedLayer = this.zoomG.append('g');
+        this.seedLayer = this.zoomG.append('g');
       }
 
       /**
@@ -477,7 +477,7 @@ def generate_svg(seeds, transitions, output_path):
         /// D3 selection of all seed <circle> elements; stored so interaction
         /// methods can restyle seeds (e.g. classed 'on-traceback') without
         /// re-selecting.
-        this.seedCircles = this._seedLayer.selectAll('.seed')
+        this.seedCircles = this.seedLayer.selectAll('.seed')
           .data(seeds)
           .enter()
           .append('circle')
@@ -489,9 +489,9 @@ def generate_svg(seeds, transitions, output_path):
             viz.hoveredSeed = d;
             if (viz.selectedSeed !== d) {
               d3.select(this).classed('hovered', true);
+              viz.#showSecondaryTransitions(d.index);
             }
             viz.#updateSeedTooltip(d3.select(this), d);
-            viz.#showSecondaryTransitions(d.index);
             viz.#highlightTransitionToSelected(d.index);
           })
           .on('mouseout', function(event, d) {

--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -915,10 +915,13 @@ def generate_svg(seeds, transitions, output_path, target_reference = None):
       #showSecondaryTransitions(seedIndex) {
         const allTrans = this.data.transitionsTo(seedIndex);
         const positiveTrans = allTrans.filter(t => t.score > 0);
+        // Drop those from off-reference seeds
+        // TODO: Show them but show them specially?
+        const onRefTrans = positiveTrans.filter(t => this.data.seeds[t.source_index].ref_pos !== undefined);
         const className = 'secondary-dest-' + seedIndex;
 
         this.secondaryTransitionLayer.selectAll('.' + className)
-          .data(positiveTrans, d => d.source_name + '->' + d.dest_name)
+          .data(onRefTrans, d => d.source_index + '->' + d.dest_index)
           .enter()
           .append('line')
           .attr('class', 'transition secondary ' + className)

--- a/scripts/build-chain-viz.py
+++ b/scripts/build-chain-viz.py
@@ -116,7 +116,7 @@ def compute_winning_traceback(max_score_by_dest, best_transition_to, seed_names)
     return traceback
 
 
-def generate_svg(seeds, transitions, output_path):
+def generate_svg(seeds, transitions, output_path, target_reference = None):
     """Generate an SVG file with embedded D3.js visualization."""
 
     # Load up the DP graph in terms of seed names.
@@ -136,20 +136,33 @@ def generate_svg(seeds, transitions, output_path):
     seed_names = {s['seed_name'] for s in seeds}
     winning_traceback = compute_winning_traceback(max_score_by_dest, best_transition_to, seed_names)
     traceback_name_set = set(winning_traceback)
-
-    # Find the most common linear reference among the seeds.
-    ref_name_counts = Counter(s['ref_name'] for s in seeds if s['ref_name'] is not None)
-    best_ref_name = ref_name_counts.most_common(1)[0][0] if ref_name_counts else None
+    
+    if target_reference is None:
+        # Find the most common linear reference among the seeds.
+        ref_name_counts = Counter(s['ref_name'] for s in seeds if s['ref_name'] is not None)
+        target_reference = ref_name_counts.most_common(1)[0][0] if ref_name_counts else None
+        print(f"Selected target reference: {target_reference}")
 
     # Keep seeds that are on the best reference path, plus any seeds on the
     # winning traceback that aren't.
-    seeds = [s for s in seeds if s['ref_name'] == best_ref_name or s['seed_name'] in traceback_name_set]
+    seeds = [s for s in seeds if s['ref_name'] == target_reference or s['seed_name'] in traceback_name_set]
 
     # Index seeds by name.
     # We use the index in seeds as our main identifier for the seeds in the
     # visualization, though we still track the "seed number" and human-readable
     # name to display.
     seed_index = {s['seed_name']: i for i, s in enumerate(seeds)}
+
+    # Count up how much of our best traceback is and isn't on our selected reference
+    on_target = len([n for n in traceback_name_set if seeds[seed_index[n]]['ref_name'] == target_reference])
+    print(f"{on_target}/{len(traceback_name_set)} seeds in best traceback are on target reference {target_reference}")
+
+    # Count up references again but on the best traceback
+    traceback_ref_name_counts = Counter(seeds[seed_index[n]]['ref_name'] for n in traceback_name_set if seeds[seed_index[n]]['ref_name'] is not None)
+    best_traceback_ref_name = traceback_ref_name_counts.most_common(1)[0][0] if traceback_ref_name_counts else None
+    if best_traceback_ref_name != target_reference:
+        on_traceback_best = len([n for n in traceback_name_set if seeds[seed_index[n]]['ref_name'] == best_traceback_ref_name])
+        print(f"{on_traceback_best}/{len(traceback_name_set)} seeds in best traceback are on competing reference {best_traceback_ref_name}")
 
     # Keep transitions where both endpoints are included seeds.
     translated_transitions = []
@@ -188,6 +201,12 @@ def generate_svg(seeds, transitions, output_path):
             index=i,
             max_score=max_score if max_score > float('-inf') else 0
         )
+        if seed_data['ref_name'] != target_reference:
+            # This seed is off-linear-reference; don't draw it anywhere on the
+            # linear reference
+            del seed_data['ref_pos']
+            del seed_data['strand']
+        # Drop the name either way
         del seed_data['ref_name']
         seeds_data.append(seed_data)
     seeds.clear()
@@ -296,8 +315,13 @@ def generate_svg(seeds, transitions, output_path):
      * Data model and query interface for the chaining problem.
      *
      * Holds the seed and transition arrays plus precomputed indexes for
-     * fast lookup. Seeds are points in (ref_pos, read_pos) space;
-     * transitions represent DP edges between them with cumulative scores.
+     * fast lookup.
+     * 
+     * Seeds are points in (ref_pos, read_pos) space, except that seeds off
+     * the displayed linear reference will not have a ref_pos (it will be
+     * undefined).
+     * 
+     * Transitions represent DP edges between them with cumulative scores.
      * The `fraction` and `is_max` fields on transitions are relative to
      * the best positive score arriving at each destination.
      */
@@ -432,7 +456,7 @@ def generate_svg(seeds, transitions, output_path):
        * Compute 1:1 aspect ratio domains, create xScale/yScale/colorScale.
        */
       #setupScales() {
-        const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== null);
+        const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== undefined);
         const margin = {top: 40, right: 40, bottom: 60, left: 80};
         const svgWidth = 1200;
         const svgHeight = 800;
@@ -550,7 +574,7 @@ def generate_svg(seeds, transitions, output_path):
        */
       #setupSeeds() {
         const viz = this;
-        const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== null);
+        const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== undefined);
 
         /// D3 selection of all on-reference seed <circle> elements; stored so
         /// interaction methods can restyle seeds (e.g. classed 'on-traceback')
@@ -640,7 +664,7 @@ def generate_svg(seeds, transitions, output_path):
       #initialize() {
         if (this.data.seeds.length === 0) return;
         const bestSeed = this.data.seeds.reduce((best, s) => (s.max_score > best.max_score ? s : best), this.data.seeds[0]);
-        const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== null);
+        const onRefSeeds = this.data.seeds.filter(s => s.ref_pos !== undefined);
         if (bestSeed && bestSeed.max_score > 0) {
           this.selectedSeed = bestSeed;
           this.seedCircles.filter(s => s.index === bestSeed.index).classed('selected', true);
@@ -741,9 +765,9 @@ def generate_svg(seeds, transitions, output_path):
         const displayEdges = [];
 
         // The traceback starts at startSeedIndex (the dest of path[0]).
-        let lastOnRefIndex = seeds[startSeedIndex].ref_pos !== null
+        let lastOnRefIndex = seeds[startSeedIndex].ref_pos !== undefined
             ? startSeedIndex : null;
-        let skippedOffRef = seeds[startSeedIndex].ref_pos === null;
+        let skippedOffRef = seeds[startSeedIndex].ref_pos === undefined;
 
         // Track whether the traceback extends off-reference beyond the
         // outermost on-reference seeds.
@@ -751,7 +775,7 @@ def generate_svg(seeds, transitions, output_path):
 
         for (const t of path) {
           const sourceSeed = seeds[t.source_index];
-          if (sourceSeed.ref_pos !== null) {
+          if (sourceSeed.ref_pos !== undefined) {
             if (lastOnRefIndex !== null) {
               displayEdges.push({
                 source_index: t.source_index,
@@ -1000,13 +1024,14 @@ def generate_svg(seeds, transitions, output_path):
 
 
 def main():
-    if len(sys.argv) != 4:
-        print(f"Usage: {sys.argv[0]} <data_directory> <chain_number> <output.svg>", file=sys.stderr)
+    if len(sys.argv) not in (4, 5):
+        print(f"Usage: {sys.argv[0]} <data_directory> <chain_number> <output.svg> [<target_reference>]", file=sys.stderr)
         sys.exit(1)
 
     data_dir = sys.argv[1]
     chain_num = int(sys.argv[2])
     output_path = sys.argv[3]
+    target_reference = sys.argv[4] if len(sys.argv) > 4 else None
 
     if not os.path.isdir(data_dir):
         print(f"Error: {data_dir} is not a directory", file=sys.stderr)
@@ -1035,7 +1060,7 @@ def main():
     print(f"Total transitions: {len(all_transitions)}")
 
     # Generate SVG
-    generate_svg(seeds, all_transitions, output_path)
+    generate_svg(seeds, all_transitions, output_path, target_reference)
     print(f"Generated {output_path}")
 
 

--- a/src/algorithms/alignment_path_offsets.cpp
+++ b/src/algorithms/alignment_path_offsets.cpp
@@ -35,7 +35,7 @@ alignment_path_offsets(const PathPositionHandleGraph& graph,
         // Find the position of this end of this mapping
         pos_t mapping_pos = make_pos_t(mapping.position());
         // Find the positions for this end of this Mapping
-        auto pos_offs = algorithms::nearest_offsets_in_paths(&graph, mapping_pos, nearby ? search_limit : -1, path_filter);
+        auto pos_offs = algorithms::nearest_offsets_in_paths(&graph, mapping_pos, nearby ? search_limit : -1, {PathSense::REFERENCE, PathSense::GENERIC}, path_filter);
         for (auto look_at_end : end) {
             // For the start and the end of the Mapping, as needed
             for (auto& p : pos_offs) {
@@ -84,7 +84,7 @@ multipath_alignment_path_offsets(const PathPositionHandleGraph& graph,
         for (size_t j = 0; j < subpath.path().mapping_size(); ++j) {
             // get the positions on paths that this mapping touches
             pos_t mapping_pos = make_pos_t(subpath.path().mapping(j).position());
-            subpath_search_results[j] = nearest_offsets_in_paths(&graph, mapping_pos, 0, path_filter);
+            subpath_search_results[j] = nearest_offsets_in_paths(&graph, mapping_pos, 0, {PathSense::REFERENCE, PathSense::GENERIC}, path_filter);
             // make sure that offsets are stored in increasing order
             for (pair<const path_handle_t, vector<pair<size_t, bool>>>& search_record : subpath_search_results[j]) {
                 sort(search_record.second.begin(), search_record.second.end());

--- a/src/algorithms/chain_items.cpp
+++ b/src/algorithms/chain_items.cpp
@@ -13,6 +13,7 @@
 
 //#define debug_chaining
 //#define debug_transition
+//#define debug_dp
 
 namespace vg {
 namespace algorithms {
@@ -564,8 +565,10 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
     // We will run this over every transition in a good DP order.
     auto iteratee = [&](const transition_info& transition) {
         if (show_work) {
+#ifdef debug_dp
             cerr << "DP: " << transition.from_anchor << "->" << transition.to_anchor 
                  << " rd " << transition.read_distance << " gd " << transition.graph_distance << endl;
+#endif
         }
         
         crash_unless(chain_scores.size() > transition.to_anchor);
@@ -590,8 +593,10 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
         auto& source = to_chain[transition.from_anchor];
             
         if (show_work) {
+#ifdef debug_dp
             cerr << "\t\tCome from score " << chain_scores[transition.from_anchor]
                 << " across " << source << " to " << here << endl;
+#endif
         }
             
         // How much does it pay (+) or cost (-) to make the jump from there
@@ -608,9 +613,11 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
         size_t possible_match_length = std::min(transition.read_distance, transition.graph_distance);
         
         if (show_work) {
+#ifdef debug_dp
             cerr << "\t\t\tFor read distance " << transition.read_distance << " and graph distance " << transition.graph_distance
                  << " an indel of length " << indel_length
                  << ((transition.read_distance > transition.graph_distance) ? " seems plausible" : " would be required") << endl;
+#endif
         }
 
         if (indel_length > max_indel_bases) {
@@ -661,8 +668,10 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
             chain_scores[transition.to_anchor] = std::max(chain_scores[transition.to_anchor], from_source_score);
                                            
             if (show_work) {
+#ifdef debug_dp
                 cerr << "\t\tWe can reach #" << transition.to_anchor << " with " << source_score << " + " << jump_points
                      << " from transition + " << item_points << " from item = " << from_source_score << endl;
+#endif
             }
             
             if (diagram) {
@@ -692,7 +701,9 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
             }
         } else {
             if (show_work) {
+#ifdef debug_dp
                 cerr << "\t\tTransition is impossible." << endl;
+#endif
             }
         }
     };
@@ -751,7 +762,9 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
         best_score.max_in(chain_scores, to_anchor);
         
         if (show_work) {
+#ifdef debug_dp
             cerr << "\tBest chain end so far: " << best_score << endl;
+#endif
         }
         
     }

--- a/src/algorithms/nearest_offsets_in_paths.cpp
+++ b/src/algorithms/nearest_offsets_in_paths.cpp
@@ -18,6 +18,7 @@ using namespace std;
 path_offset_collection_t nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
                                                   const pos_t& pos,
                                                   int64_t max_search,
+                                                  const std::unordered_set<PathSense>& desired_senses,
                                                   const std::function<bool(const path_handle_t&)>* path_filter) {
     
     // init the return value
@@ -48,7 +49,7 @@ path_offset_collection_t nearest_offsets_in_paths(const PathPositionHandleGraph*
         << " in " << (search_left ? "leftward" : "rightward") << " direction at distance " << dist << endl;
 #endif
        
-        graph->for_each_step_of_sense(here, {PathSense::REFERENCE, PathSense::GENERIC}, [&](const step_handle_t& step) {
+        graph->for_each_step_of_sense(here, desired_senses, [&](const step_handle_t& step) {
             // For each path visit that occurs on this node
 #ifdef debug
             cerr << "handle is on step at path offset " << graph->get_position_of_step(step) << endl;

--- a/src/algorithms/nearest_offsets_in_paths.hpp
+++ b/src/algorithms/nearest_offsets_in_paths.hpp
@@ -33,9 +33,10 @@ using path_offset_collection_t = unordered_map<path_handle_t, vector<pair<size_t
 ///
 /// If path_filter is set, ignores paths for which it returns false.
 ///
-/// Doesn't consider haplotype paths.
+/// Doesn't consider haplotype paths. by default.
 path_offset_collection_t nearest_offsets_in_paths(const PathPositionHandleGraph* graph,
                                                   const pos_t& pos, int64_t max_search,
+                                                  const std::unordered_set<PathSense>& desired_senses = {PathSense::REFERENCE, PathSense::GENERIC},
                                                   const std::function<bool(const path_handle_t&)>* path_filter = nullptr);
     
 /// Wrapper for the above to support some earlier code. Only looks for paths

--- a/src/explainer.cpp
+++ b/src/explainer.cpp
@@ -98,7 +98,10 @@ TSVExplainer::TSVExplainer(bool enabled, const std::string& name) : Explainer(en
     out.open(filename);
 }
 TSVExplainer::~TSVExplainer() {
-    // Nothing to do!
+    if (need_line) {
+        // Newline-terminate the last line before closing.
+        out << std::endl;
+    }
 }
 
 void TSVExplainer::line() {

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -427,6 +427,10 @@ class MinimizerMapper : public AlignerClient {
     /// Track linear reference position for placements in log output.
     static constexpr bool default_track_position = false;
     bool track_position = default_track_position;
+
+    /// Track positions along haplotypes
+    static constexpr bool default_haplotype_positions = false;
+    bool haplotype_positions = default_haplotype_positions;
     
     /// If set, log what the mapper is thinking in its mapping of each read.
     static constexpr bool default_show_work = false;
@@ -1467,7 +1471,8 @@ protected:
                                    const std::vector<std::vector<size_t>>& chains,
                                    const std::vector<std::vector<bool>>& chain_rec_flags,
                                    const std::vector<size_t>& chain_source_tree,
-                                   const PathPositionHandleGraph* path_graph);
+                                   const PathPositionHandleGraph* path_graph,
+                                   bool haplotype_positions);
 
     /// Dump a graph
     static void dump_debug_graph(const HandleGraph& graph);

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -267,19 +267,19 @@ void MinimizerMapper::dump_debug_chains(const ZipCodeForest& zip_code_forest,
                                 ss << seed_anchors.at(seed_num);
                                 seedpos.field(ss.str());
                             }
-                            if (handle_and_positions.second.empty()) {
-                                // The seed doesn't have any linear positions, but might still participate in the winning chain traceback.
-                                // Report it.
-                                seedpos.line();
-                                seedpos.field(seed_anchors.at(seed_num).read_start());
-                                seedpos.field("");
-                                seedpos.field("");
-                                seedpos.field("");
-                                seedpos.field(seed_num);
-                                std::stringstream ss;
-                                ss << seed_anchors.at(seed_num);
-                                seedpos.field(ss.str());
-                            }
+                        }
+                        if (found->second.empty()) {
+                            // The seed doesn't have any linear positions, but might still participate in the winning chain traceback.
+                            // Report it.
+                            seedpos.line();
+                            seedpos.field(seed_anchors.at(seed_num).read_start());
+                            seedpos.field("");
+                            seedpos.field("");
+                            seedpos.field("");
+                            seedpos.field(seed_num);
+                            std::stringstream ss;
+                            ss << seed_anchors.at(seed_num);
+                            seedpos.field(ss.str());
                         }
                     }
                 }

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -267,6 +267,19 @@ void MinimizerMapper::dump_debug_chains(const ZipCodeForest& zip_code_forest,
                                 ss << seed_anchors.at(seed_num);
                                 seedpos.field(ss.str());
                             }
+                            if (handle_and_positions.second.empty()) {
+                                // The seed doesn't have any linear positions, but might still participate in the winning chain traceback.
+                                // Report it.
+                                seedpos.line();
+                                seedpos.field(seed_anchors.at(seed_num).read_start());
+                                seedpos.field("");
+                                seedpos.field("");
+                                seedpos.field("");
+                                seedpos.field(seed_num);
+                                std::stringstream ss;
+                                ss << seed_anchors.at(seed_num);
+                                seedpos.field(ss.str());
+                            }
                         }
                     }
                 }

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -3828,7 +3828,7 @@ algorithms::Anchor MinimizerMapper::to_anchor(const Alignment& aln, const Vector
     // Work out how many points the anchor is.
     // TODO: Always make sequence and quality available for scoring!
     // We're going to score the anchor as the full minimizer, and rely on the margins to stop us from taking overlapping anchors.
-    int score = aligner->score_exact_match(aln, read_start - margin_left, length + margin_right);
+    int score = aligner->score_exact_match(aln, read_start - margin_left, margin_left + length + margin_right);
     return algorithms::Anchor(read_start, graph_start, length, margin_left, margin_right, score, seed_number, &(seed.zipcode), hint_start, source.is_repetitive, paths); 
 }
 

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -194,7 +194,8 @@ void MinimizerMapper::dump_debug_chains(const ZipCodeForest& zip_code_forest,
                                          const std::vector<std::vector<size_t>>& chains,
                                          const std::vector<std::vector<bool>>& chain_rec_flags,
                                          const std::vector<size_t>& chain_source_tree,
-                                         const PathPositionHandleGraph* path_graph) {
+                                         const PathPositionHandleGraph* path_graph,
+                                         bool haplotype_positions) {
     if (!path_graph) {
         // We don't have a path positional graph for this
         return;
@@ -242,6 +243,10 @@ void MinimizerMapper::dump_debug_chains(const ZipCodeForest& zip_code_forest,
 
         // Determine the positions of all the involved seeds.
         std::unordered_map<size_t, algorithms::path_offset_collection_t> seed_positions;
+        std::unordered_set<PathSense> wanted_senses {PathSense::REFERENCE, PathSense::GENERIC};
+        if (haplotype_positions) {
+            wanted_senses.insert(PathSense::HAPLOTYPE);
+        }
         for (auto& kv : seed_sets) {
             for (const std::vector<size_t> included_seeds : kv.second) {
                 for (auto& seed_num : included_seeds) {
@@ -251,7 +256,7 @@ void MinimizerMapper::dump_debug_chains(const ZipCodeForest& zip_code_forest,
                     auto found = seed_positions.find(seed_num);
                     if (found == seed_positions.end()) {
                         // If we don't know the seed's positions yet, get them
-                        found = seed_positions.emplace_hint(found, seed_num, algorithms::nearest_offsets_in_paths(path_graph, seed.pos, 100));
+                        found = seed_positions.emplace_hint(found, seed_num, algorithms::nearest_offsets_in_paths(path_graph, seed.pos, 100, wanted_senses));
                         for (auto& handle_and_positions : found->second) {
                             std::string path_name = path_graph->get_path_name(handle_and_positions.first);
                             for (auto& position : handle_and_positions.second) {
@@ -794,7 +799,7 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
 
     // Dump all chains if requested (do this before alignments, while chains still exist)
     if (show_work && !chains.empty() && this->path_graph != nullptr) {
-        dump_debug_chains(zip_code_forest, seeds, minimizers, seed_anchors, chains, chain_rec_flags, chain_source_tree, this->path_graph);
+        dump_debug_chains(zip_code_forest, seeds, minimizers, seed_anchors, chains, chain_rec_flags, chain_source_tree, this->path_graph, this->haplotype_positions);
     }
 
     if (alignments.size() == 0) {
@@ -1643,9 +1648,13 @@ void MinimizerMapper::do_chaining_on_trees(Alignment& aln, const ZipCodeForest& 
                     // Add position annotations for the good-looking chains.
                     // Should be much faster than full correctness tracking from every seed.
                     crash_unless(this->path_graph);
+                    std::unordered_set<PathSense> wanted_senses {PathSense::REFERENCE, PathSense::GENERIC};
+                    if (haplotype_positions) {
+                        wanted_senses.insert(PathSense::HAPLOTYPE);
+                    }
                     for (auto& boundary : {anchor_view[scored_chain.second.front()].graph_start(), anchor_view[scored_chain.second.back()].graph_end()}) {
                         // For each end of the chain
-                        auto offsets = algorithms::nearest_offsets_in_paths(this->path_graph, boundary, 100);
+                        auto offsets = algorithms::nearest_offsets_in_paths(this->path_graph, boundary, 100, wanted_senses);
                         for (auto& handle_and_positions : offsets) {
                             for (auto& position : handle_and_positions.second) {
                                 // Tell the funnel all the effective positions, ignoring orientation

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -2706,7 +2706,11 @@ Alignment MinimizerMapper::find_chain_alignment(
             #pragma omp critical (cerr)
             {
                 cerr << log_name() << "Need to align graph from " << (*here).graph_end() << " to " << (*next).graph_start()
-                    << " separated by ~" << graph_dist << " bp and sequence \"" << linking_bases << "\"" << endl;
+                    << " separated by ~" << graph_dist << " bp";
+                if (linking_bases.size() < 200) {
+                    cerr << " and sequence \"" << linking_bases << "\"";
+                }
+                cerr << endl;
             }
         }
 #endif
@@ -2894,7 +2898,7 @@ Alignment MinimizerMapper::find_chain_alignment(
         if (show_work) {
             #pragma omp critical (cerr)
             {
-                cerr << log_name() << "Aligned and added link of " << link_length << " bp read and " << link_graph_path_length << " bp graph via " << link_alignment_source << " with score of " << link_score << std::endl;
+                cerr << log_name() << "Aligned and added link to " << *next << " of " << link_length << " bp read and " << link_graph_path_length << " bp graph via " << link_alignment_source << " with score of " << link_score << std::endl;
             }
         }
         

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -735,7 +735,7 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
     }
 #endif
 
-    // Turn all the seeds into anchors. Either we'll fragment them directly or
+    // Turn all the seeds into anchors. Either we'll chain them directly or
     // use them to make gapless extension anchors over them.
     // TODO: Can we only use the seeds that are in trees we keep?
     vector<algorithms::Anchor> seed_anchors = this->to_anchors(aln, minimizers, seeds);

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -839,7 +839,7 @@ int main_giraffe(int argc, char** argv) {
     // Should we log our mapping decision making?
     bool show_work = MinimizerMapper::default_show_work;
     // Should we index all haplotypes for more informative logs and dumps?
-    bool haplotype_positions = false;
+    bool haplotype_positions = MinimizerMapper::default_haplotype_positions;
     // TODO: We could also add machinery to index particular haplotypes for
     // debugging using positions on them.
     
@@ -1946,6 +1946,7 @@ int main_giraffe(int argc, char** argv) {
         report_flag("track-position", track_position);
         minimizer_mapper.track_position = track_position;
         report_flag("haplotype-positions", haplotype_positions);
+        minimizer_mapper.haplotype_positions = haplotype_positions;
         report_flag("show-work", show_work);
         minimizer_mapper.show_work = show_work;
         if (paired) {

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1828,8 +1828,10 @@ int main_giraffe(int argc, char** argv) {
     if (show_work || track_correctness || track_position || set_refpos || hts_output) {
         // Usually we will get our paths from the GBZ
         PathHandleGraph* base_graph = &gbz->graph;
-        // But if an XG is around, we should use that instead. Otherwise, it's not possible to provide paths when using an old GBWT/GBZ that doesn't have them.
-        if (registry.available("XG")) {
+        // But if an XG is around, and we don't need haplotype paths, we should
+        // use that instead. Otherwise, it's not possible to provide paths when
+        // using an old GBWT/GBZ that doesn't have them.
+        if (registry.available("XG") && !haplotype_positions) {
             if (show_progress) {
                 logger.info() << "Loading XG Graph" << endl;
             }

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -908,7 +908,6 @@ int main_giraffe(int argc, char** argv) {
         // This is always on in the non-chaining codepath right now, but just to be sure...
         .add_entry<bool>("explored-cap", true);
     
-    --chain-score-threshold 234 --min-chains 2 --min-chain-score-per-base 0.24 --max-min-chain-score 46 --max-chains-per-tree 3 --item-bonus 2 --gap-scale 0.27579
     presets["hifi"]
         .add_entry<bool>("align-from-chains", true)
         .add_entry<bool>("explored-cap", false)

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -908,6 +908,7 @@ int main_giraffe(int argc, char** argv) {
         // This is always on in the non-chaining codepath right now, but just to be sure...
         .add_entry<bool>("explored-cap", true);
     
+    --chain-score-threshold 234 --min-chains 2 --min-chain-score-per-base 0.24 --max-min-chain-score 46 --max-chains-per-tree 3 --item-bonus 2 --gap-scale 0.27579
     presets["hifi"]
         .add_entry<bool>("align-from-chains", true)
         .add_entry<bool>("explored-cap", false)
@@ -935,14 +936,14 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("max-graph-lookback-bases-per-base", 0.10501002120802233)
         .add_entry<size_t>("max-indel-bases", 5000)
         .add_entry<double>("max-indel-bases-per-base", 2.45)
-        .add_entry<int>("item-bonus", 20)
+        .add_entry<int>("item-bonus", 2)
         .add_entry<double>("item-scale", 1.0)
-        .add_entry<double>("gap-scale", 0.2)
-        .add_entry<double>("chain-score-threshold", 200.0)
+        .add_entry<double>("gap-scale", 0.27579)
+        .add_entry<double>("chain-score-threshold", 234.0)
         .add_entry<int>("min-chains", 2)
-        .add_entry<double>("min-chain-score-per-base", 0.1)
+        .add_entry<double>("min-chain-score-per-base", 0.24)
         .add_entry<size_t>("max-chains-per-tree", 3)
-        .add_entry<int>("max-min-chain-score", 100)
+        .add_entry<int>("max-min-chain-score", 46)
         .add_entry<size_t>("max-skipped-bases", 1000)
         .add_entry<size_t>("max-alignments", 3)
         .add_entry<size_t>("max-chain-connection", 233)

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1945,7 +1945,7 @@ int main_giraffe(int argc, char** argv) {
         minimizer_mapper.track_correctness = track_correctness;
         report_flag("track-position", track_position);
         minimizer_mapper.track_position = track_position;
-        report_flag("haplotype-positions", haplotype-positions);
+        report_flag("haplotype-positions", haplotype_positions);
         report_flag("show-work", show_work);
         minimizer_mapper.show_work = show_work;
         if (paired) {

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -703,6 +703,7 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
              << "      --report-name FILE        write a TSV of output file and mapping speed" << endl
              << "      --show-work               log how the mapper comes to its conclusions" << endl
              << "                                about mapping locations (use one read at a time)" << endl;
+             
     }
 
     if (full_help) {
@@ -723,7 +724,8 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
              << "                                (implies --track-provenance)" << endl
              << "      --track-position          coarsely track linear reference positions of" << endl
              << "                                good intermediate alignment candidates" << endl
-             << "                                (implies --track-provenance)" << endl;
+             << "                                (implies --track-provenance)" << endl
+             << "      --haplotype-positions     index all haplotypes for position reporting" << endl;
              
 
         auto helps = parser.get_help();
@@ -747,24 +749,28 @@ int main_giraffe(int argc, char** argv) {
     constexpr int OPT_OUTPUT_BASENAME = 1000;
     constexpr int OPT_REPORT_NAME = 1001;
     constexpr int OPT_SET_REFPOS = 1002;
-    constexpr int OPT_TRACK_PROVENANCE = 1003;
-    constexpr int OPT_TRACK_CORRECTNESS = 1004;
-    constexpr int OPT_TRACK_POSITION = 1005;
-    constexpr int OPT_FRAGMENT_MEAN = 1006;
-    constexpr int OPT_FRAGMENT_STDEV = 1007;
-    constexpr int OPT_REF_PATHS = 1008;
-    constexpr int OPT_REF_NAME = 1009;
-    constexpr int OPT_SHOW_WORK = 1010;
+    constexpr int OPT_FRAGMENT_MEAN = 1003;
+    constexpr int OPT_FRAGMENT_STDEV = 1004;
+    constexpr int OPT_REF_PATHS = 1005;
+    constexpr int OPT_REF_NAME = 1006;
     constexpr int OPT_NAMED_COORDINATES = 1011;
     constexpr int OPT_ADD_GRAPH_ALIGNMENT = 1012;
     constexpr int OPT_COMMENTS_AS_TAGS = 1013;
     constexpr int OPT_HAPLOTYPE_NAME = 1100;
+
     constexpr int OPT_KFF_NAME = 1101;
     constexpr int OPT_INDEX_BASENAME = 1102;
     constexpr int OPT_SET_REFERENCE = 1103;
     constexpr int OPT_HAPLOTYPE_SAMPLING = 1104;
     constexpr int OPT_NUM_HAPLOTYPES = 1105;
     constexpr int OPT_NO_DIPLOID_SAMPLING = 1106;
+
+    constexpr int OPT_TRACK_PROVENANCE = 1201;
+    constexpr int OPT_TRACK_CORRECTNESS = 1202;
+    constexpr int OPT_TRACK_POSITION = 1203;
+    constexpr int OPT_HAPLOTYPE_POSITIONS = 1204;
+    constexpr int OPT_SHOW_WORK = 1205;
+
 
 
     // initialize parameters with their default options
@@ -832,6 +838,10 @@ int main_giraffe(int argc, char** argv) {
     bool track_position = MinimizerMapper::default_track_position;
     // Should we log our mapping decision making?
     bool show_work = MinimizerMapper::default_show_work;
+    // Should we index all haplotypes for more informative logs and dumps?
+    bool haplotype_positions = false;
+    // TODO: We could also add machinery to index particular haplotypes for
+    // debugging using positions on them.
     
     // Should we throw out our alignments instead of outputting them?
     bool discard_alignments = false;
@@ -1108,6 +1118,7 @@ int main_giraffe(int argc, char** argv) {
         {"track-provenance", no_argument, 0, OPT_TRACK_PROVENANCE},
         {"track-correctness", no_argument, 0, OPT_TRACK_CORRECTNESS},
         {"track-position", no_argument, 0, OPT_TRACK_POSITION},
+        {"haplotype-positions", no_argument, 0, OPT_HAPLOTYPE_POSITIONS},
         {"show-work", no_argument, 0, OPT_SHOW_WORK},
         {"threads", required_argument, 0, 't'},
     };
@@ -1355,6 +1366,10 @@ int main_giraffe(int argc, char** argv) {
             case OPT_TRACK_POSITION:
                 track_provenance = true;
                 track_position = true;
+                break;
+
+            case OPT_HAPLOTYPE_POSITIONS:
+                haplotype_positions = true;
                 break;
                 
             case OPT_SHOW_WORK:
@@ -1805,7 +1820,7 @@ int main_giraffe(int argc, char** argv) {
         // If we want to be able to spit out positions along haplotype paths,
         // for debugging, we need to index them for position queries.
         std::unordered_set<std::string> extra_indexed_paths;
-        if (show_work) {
+        if (haplotype_positions) {
             base_graph->for_each_path_of_sense(PathSense::HAPLOTYPE, [&](const path_handle_t& path) {
                 // Say every haplotype path is in the "extra" path set to
                 // index, so we index everything.
@@ -1926,10 +1941,11 @@ int main_giraffe(int argc, char** argv) {
         minimizer_mapper.set_refpos = set_refpos;
         report_flag("track-provenance", track_provenance);
         minimizer_mapper.track_provenance = track_provenance;
-        report_flag("track-position", track_position);
-        minimizer_mapper.track_position = track_position;
         report_flag("track-correctness", track_correctness);
         minimizer_mapper.track_correctness = track_correctness;
+        report_flag("track-position", track_position);
+        minimizer_mapper.track_position = track_position;
+        report_flag("haplotype-positions", haplotype-positions);
         report_flag("show-work", show_work);
         minimizer_mapper.show_work = show_work;
         if (paired) {

--- a/src/unittest/minimizer_mapper.cpp
+++ b/src/unittest/minimizer_mapper.cpp
@@ -1084,7 +1084,7 @@ TEST_CASE("MinimizerMapper scores anchors the same regardless of node structure"
             std::string node_seq = stick_sequence.substr(node_start, node_size);
 
             handle_t here = graph.create_handle(node_seq);
-            if (nose_start != 0) {
+            if (node_start != 0) {
                 graph.create_edge(last, here);
             }
 
@@ -1092,6 +1092,8 @@ TEST_CASE("MinimizerMapper scores anchors the same regardless of node structure"
                 // Record the positions
                 graph_forward_strand.emplace_back(graph.get_id(here), false, i);
             }
+
+            last = here;
         }
 
         IntegratedSnarlFinder snarl_finder(graph);
@@ -1106,6 +1108,7 @@ TEST_CASE("MinimizerMapper scores anchors the same regardless of node structure"
         size_t min_length = 5;
 
         for (size_t min_start = 0; min_start + min_length < stick_sequence.size(); min_start++) {
+            std::cerr << "Minimizer start: " << min_start << std::endl;
             for (bool min_reverse : {false, true}) {
                 // Consider just one minimizer and one seed at a time, in its own collection.
                 vector<MinimizerMapper::Minimizer> minimizers;
@@ -1118,7 +1121,7 @@ TEST_CASE("MinimizerMapper scores anchors the same regardless of node structure"
                 minimizers.back().value.is_reverse = min_reverse;
 
                 // Find the anchor point in the graph
-                pos_t graph_pos = graph_forward_strand.at(min_reverse ? min_start + min_length - 1 : min_start)
+                pos_t graph_pos = graph_forward_strand.at(min_reverse ? min_start + min_length - 1 : min_start);
 
                 // Give it a seed, but ignore zipcodes.
                 seeds.push_back({ graph_pos, minimizers.size() - 1, {}});

--- a/src/unittest/minimizer_mapper.cpp
+++ b/src/unittest/minimizer_mapper.cpp
@@ -1064,13 +1064,15 @@ TEST_CASE("MinimizerMapper can make correct anchors from minimizers and their zi
 
 TEST_CASE("MinimizerMapper scores anchors the same regardless of node structure", "[giraffe][mapping]") {
 
-    std::string stick_sequence = "GATTACACATTACACGATCGATCGACTGACTCGCAGCTG";
+    std::string stick_sequence = "GATTACACATTAG";
 
     // Make an aligner for scoring
     Aligner aligner;
 
     for (int node_size : {1, 2, 10}) {
+#ifdef debug
         std::cerr << "Node size: " << node_size << std::endl;
+#endif
 
         bdsg::HashGraph graph;
 
@@ -1103,12 +1105,13 @@ TEST_CASE("MinimizerMapper scores anchors the same regardless of node structure"
         Alignment aln;
         aln.set_sequence(stick_sequence);
         
-        
-        
+        // Try 5 base minimizers
         size_t min_length = 5;
 
         for (size_t min_start = 0; min_start + min_length < stick_sequence.size(); min_start++) {
+#ifdef debug
             std::cerr << "Minimizer start: " << min_start << std::endl;
+#endif
             for (bool min_reverse : {false, true}) {
                 // Consider just one minimizer and one seed at a time, in its own collection.
                 vector<MinimizerMapper::Minimizer> minimizers;
@@ -1129,7 +1132,9 @@ TEST_CASE("MinimizerMapper scores anchors the same regardless of node structure"
                 // Make an anchor
                 algorithms::Anchor anchor = TestMinimizerMapper::to_anchor(aln, minimizers, seeds, seeds.size() - 1, graph, &aligner);
 
-                std::cerr << "Made minimizer at read " << minimizers.back().value.offset << " orientation " << minimizers.back().value.is_reverse << " at graph position " << graph_pos << " and anchor " << anchor << " score " << anchor.score() << std::endl; 
+#ifdef debug
+                std::cerr << "Made minimizer at read " << minimizers.back().value.offset << " orientation " << minimizers.back().value.is_reverse << " at graph position " << graph_pos << " and anchor " << anchor << " score " << anchor.score() << std::endl;
+#endif
 
                 REQUIRE(anchor.score() == min_length);
             }

--- a/src/unittest/minimizer_mapper.cpp
+++ b/src/unittest/minimizer_mapper.cpp
@@ -1010,7 +1010,7 @@ TEST_CASE("MinimizerMapper can make correct anchors from minimizers and their zi
                     // Make sure the anchor is right.
                     // It needs to start at the right place in the read.
                     REQUIRE(anchors.back().read_start() == minimizers.at(seeds.at(i).source).forward_offset());
-                    // Sinve the minimizers are all within single nodes here, the anchor should be as long as the minimizer.
+                    // Since the minimizers are all within single nodes here, the anchor should be as long as the minimizer.
                     REQUIRE(anchors.back().length() == minimizers.at(seeds.at(i).source).length);
                 }
 
@@ -1062,6 +1062,77 @@ TEST_CASE("MinimizerMapper can make correct anchors from minimizers and their zi
     }
 }
 
+TEST_CASE("MinimizerMapper scores anchors the same regardless of node structure", "[giraffe][mapping]") {
+
+    std::string stick_sequence = "GATTACACATTACACGATCGATCGACTGACTCGCAGCTG";
+
+    // Make an aligner for scoring
+    Aligner aligner;
+
+    for (int node_size : {1, 2, 10}) {
+        std::cerr << "Node size: " << node_size << std::endl;
+
+        bdsg::HashGraph graph;
+
+        // This has the pos_t of every position along the forward strand of the graph.
+        std::vector<pos_t> graph_forward_strand;
+        graph_forward_strand.reserve(stick_sequence.size());
+
+        handle_t last;
+        for (size_t node_start = 0; node_start < stick_sequence.size(); node_start += node_size) {
+            // Build a stick of this size of node
+            std::string node_seq = stick_sequence.substr(node_start, node_size);
+
+            handle_t here = graph.create_handle(node_seq);
+            if (nose_start != 0) {
+                graph.create_edge(last, here);
+            }
+
+            for (size_t i = 0; i < node_seq.size(); i++) {
+                // Record the positions
+                graph_forward_strand.emplace_back(graph.get_id(here), false, i);
+            }
+        }
+
+        IntegratedSnarlFinder snarl_finder(graph);
+        SnarlDistanceIndex distance_index;
+        fill_in_distance_index(&distance_index, &graph, &snarl_finder);
+
+        Alignment aln;
+        aln.set_sequence(stick_sequence);
+        
+        
+        
+        size_t min_length = 5;
+
+        for (size_t min_start = 0; min_start + min_length < stick_sequence.size(); min_start++) {
+            for (bool min_reverse : {false, true}) {
+                // Consider just one minimizer and one seed at a time, in its own collection.
+                vector<MinimizerMapper::Minimizer> minimizers;
+                vector<SnarlDistanceIndexClusterer::Seed> seeds;
+
+                // Start a minimizer at this start position, on this read strand.
+                minimizers.emplace_back();
+                minimizers.back().length = min_length;
+                minimizers.back().value.offset = min_reverse ? min_start + min_length - 1 : min_start;
+                minimizers.back().value.is_reverse = min_reverse;
+
+                // Find the anchor point in the graph
+                pos_t graph_pos = graph_forward_strand.at(min_reverse ? min_start + min_length - 1 : min_start)
+
+                // Give it a seed, but ignore zipcodes.
+                seeds.push_back({ graph_pos, minimizers.size() - 1, {}});
+                
+                // Make an anchor
+                algorithms::Anchor anchor = TestMinimizerMapper::to_anchor(aln, minimizers, seeds, seeds.size() - 1, graph, &aligner);
+
+                std::cerr << "Made minimizer at read " << minimizers.back().value.offset << " orientation " << minimizers.back().value.is_reverse << " at graph position " << graph_pos << " and anchor " << anchor << " score " << anchor.score() << std::endl; 
+
+                REQUIRE(anchor.score() == min_length);
+            }
+        }
+    }
+}
 
 TEST_CASE("MinimizerMapper can fix up alignments with deletions on the ends", "[giraffe][mapping]") {
     

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 80
+plan tests 82
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -128,6 +128,9 @@ vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.indel.multi.fq --show-work
 # Check that at least some TSV files and directories were created 
 is "$(find explanation_read1 -name 'chain*-dotplot*.tsv' 2>/dev/null | wc -l | tr -d ' ')" "1" "Chain explanation files are created per chain"
 is "$(ls -d explanation_* 2>/dev/null | wc -l | tr -d ' ')" "3" "Explanation directories are created per read"
+is "$(cat explanation_read1/chain0-seeds*.tsv | wc -l | tr -d ' ')" "1" "Chain reports one seed with one position"
+vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.indel.multi.fq --show-work --track-position -b chaining-sr --haplotype-positions > /dev/null 2>&1
+is "$(cat explanation_read1/chain0-seeds*.tsv | wc -l | tr -d ' ')" "3" "Chain reports one seed with three positions when checking haplotypes"
 
 rm -rf explanation_*
 rm -f x.giraffe.gbz wrong.gbz


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe no longer ignores the parts of seeds that extend outside their graph nodes to the left when scoring them. Note that this can **reduce R10 read variant calling accuracy** versus the previous release of vg.
 * Giraffe `hifi` mapping preset has been re-tuned for new seed score distribution.
 * Chain visualizations no longer need to be panned or zoomed to show changes to the traceback.
 * Chain visualizations no longer accumulate more and more transition lines when mousing in and out of a selected node.
 * Giraffe no longer tries to position-index all haplotypes when showing work. If you need all haplotypes position-indexed for debugging chaining against them, use `--haplotype-positions`.

## Description

This fixes a read @faithokamoto reported that came unmapped around when we got rid of two-phase chaining. It turns out we weren't scoring seeds right and, without fragmenting, we preferred to lit off after a well-scored seed acorss a giant gap, instead of collecting a poorly-scored seed.

We still might need to limit transitions' required indels to the length of the longest detectable gap where they occur, to avoid that sort of giant-cheap-chaining-gap-makes-alignment-score-negative behavior in other circumstances. But if we no longer arbitrarily don't credit minimizers for their score points, it should happen less.

We might need to re-tune essentially everything in chaining for the increased average seed score, and we should make sure we weren't leaning on this as a pseudo-heuristic with some acceptance testing before merging.