### PR TITLE
Stop guessing provided GBZ

### DIFF
--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1617,14 +1617,20 @@ int main_giraffe(int argc, char** argv) {
         indexes_and_extensions.emplace(std::string("Short Read Minimizers"), std::vector<std::string>({"shortread.withzip.min","withzip.min", "min"}));
         indexes_and_extensions.emplace(std::string("Short Read Zipcodes"), std::vector<std::string>({"shortread.zipcodes", "zipcodes"}));
     }
+
+    if (!haplotype_sampling && registry.available("GBZ")) {
+        // If we're not doing haplotype sampling and we got a GBZ, it should really be the Giraffe GBZ.
+        // Instead of relying on the alias rule, just provide it again.
+        // TODO: This is a hack. But otherwise, we end up guessing the Giraffe
+        // GBZ path and finding it at the GBZ path, which seems worse.
+        registry.provide("Giraffe GBZ", registry.require("GBZ").at(0));
+    }
+    // TODO: What if you want to add a pre-made GBZ to an existing hap sampling
+    // command line that already included a GBZ? We'd need a different option.
     
     for (auto& completed : registry.completed_indexes()) {
         // Drop anything we already got from the list
         indexes_and_extensions.erase(completed);
-        if (completed == "GBZ") {
-            // Don't try and guess a Giraffe GBZ if we already have a GBZ.
-            indexes_and_extensions.erase("Giraffe GBZ");
-        }
     }
     for (auto index_and_extensions = indexes_and_extensions.begin(); index_and_extensions != indexes_and_extensions.end(); ) {
         // For each index type

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -1621,6 +1621,10 @@ int main_giraffe(int argc, char** argv) {
     for (auto& completed : registry.completed_indexes()) {
         // Drop anything we already got from the list
         indexes_and_extensions.erase(completed);
+        if (completed == "GBZ") {
+            // Don't try and guess a Giraffe GBZ if we already have a GBZ.
+            indexes_and_extensions.erase("Giraffe GBZ");
+        }
     }
     for (auto index_and_extensions = indexes_and_extensions.begin(); index_and_extensions != indexes_and_extensions.end(); ) {
         // For each index type


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Giraffe will no longer claim to be guessing a GBZ file you definitely told it to use

## Description
The single-command haplotype sampling logic still has terrible intuitions. It turns out we've been getting the "Giraffe GBZ" by guessing the same filename as the provided "GBZ", not by actually using the alias rule (which would have us make a file next to it as `.giraffe.gbz` if we *did* use it).

I couldn't figure out how to get the correct behavior to just fall out of the rules, so now if you aren't haplotype sampling and you provide a GBZ we provide it again as the Giraffe GBZ.