### PR TITLE
Add options to left-align indels for HTSLib formats

### DIFF
--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1,4 +1,5 @@
 #include "alignment.hpp"
+#include "longest_overlap.hpp"
 #include "vg/io/gafkluge.hpp"
 #include "annotation.hpp"
 #include <vg/io/stream.hpp>
@@ -1365,7 +1366,7 @@ vector<pair<int, char>> cigar_against_path(const Alignment& alignment, bool on_r
             cigar.front().second = 'S';
         }
     }
-    
+
     simplify_cigar(cigar);
 
     return cigar;
@@ -1502,8 +1503,8 @@ void simplify_cigar(vector<pair<int, char>>& cigar) {
     for (size_t i = 0, j = 0; i < cigar.size(); ++j) {
         if (j == cigar.size() || (cigar[j].second != 'I' && cigar[j].second != 'D')) {
             // this is the end boundary of a runs of I/D operations
-            if (j - i >= 3) {
-                // we have at least 3 adjacent I/D operations, which means they should
+            if (j - i >= 2) {
+                // we have at least 2 adjacent I/D operations, which means they should
                 // be re-consolidated
                 int d_total = 0, i_total = 0;
                 for (size_t k = i - removed, end = j - removed; k < end; ++k) {
@@ -1544,6 +1545,1105 @@ void simplify_cigar(vector<pair<int, char>>& cigar) {
         }
     }
     cigar.resize(cigar.size() - removed);
+}
+
+// #define debug_indel_adjustment
+// this algorithm is a pain to debug without these consistency checks
+// #define debug_indel_adjustment_tombstone
+
+void normalize_indel_adjustment(Alignment& aln, bool adjust_left, const HandleGraph& graph, bool preserve_end_pos) {
+
+    // a simplified Edit that can be shifted more easily
+    struct simple_edit_t {
+        simple_edit_t(int64_t f, int64_t t, bool m) : from_length(f), to_length(t), is_match(m) {}
+        simple_edit_t(const simple_edit_t& other) = default;
+        int64_t from_length = 0;
+        int64_t to_length = 0;
+        bool is_match = false;
+
+#ifdef debug_indel_adjustment_tombstone
+        // ---- tombstone state ----
+        uint32_t _tombstone_generation = 1;
+
+        void _assert_alive() const {
+            assert(_tombstone_generation != 0 && "use-after-erase detected");
+        }
+
+        void _invalidate() {
+            _tombstone_generation = 0;
+        }
+        
+        const simple_edit_t& checked() const {
+            _assert_alive();
+            return *this;
+        }
+
+        simple_edit_t& checked() {
+            _assert_alive();
+            return *this;
+        }
+#else
+        inline const simple_edit_t& checked() const {
+            return *this;
+        }
+
+        inline simple_edit_t& checked() {
+            return *this;
+        }
+#endif
+    };
+
+    auto tombstone_erase = [](list<simple_edit_t>& lst, list<simple_edit_t>::iterator it) -> list<simple_edit_t>::iterator  {
+#ifdef debug_indel_adjustment_tombstone
+        it->_invalidate();
+#endif
+        return lst.erase(it);
+    };
+
+    // copy the alignment path into data structures that facilitate internal edits
+    auto& path = *aln.mutable_path();
+
+    // collect the aligned node sequences and re-format the alignment into modifiable data structs
+    // we also consolidate runs of insertions and deletions so they are a contiguous block of deletion edits
+    // followed by a single insertion edit
+    vector<string> aligned_seqs(path.mapping_size());
+    vector<list<simple_edit_t>> shiftable_aln(path.mapping_size());
+    vector<pos_t> mapping_positions(path.mapping_size());
+    size_t buffered_insertion = 0;
+    for (size_t i = 0; i < path.mapping_size(); ++i) {
+        const auto& mapping = path.mapping(i);
+        auto& shift_mapping = shiftable_aln[i];
+        for (size_t j = 0; j < mapping.edit_size(); ++j) {
+            const auto& edit = mapping.edit(j);
+            if (edit.from_length() == 0 && !(i == 0 && j == 0)) {
+                // non-soft clip insertion
+                buffered_insertion += edit.to_length();
+            }
+            else {
+                if (edit.to_length() != 0 && buffered_insertion != 0) {
+                    // the next edit isn't a deletion, flush the insertion buffer
+                    shift_mapping.emplace_back(0, buffered_insertion, false);
+                    buffered_insertion = 0;
+                }
+                shift_mapping.emplace_back(edit.from_length(), edit.to_length(), edit.from_length() == edit.to_length() && edit.sequence().empty());
+            }
+        }
+        const auto& pos = mapping.position();
+        aligned_seqs[i] = graph.get_subsequence(graph.get_handle(pos.node_id(), pos.is_reverse()), pos.offset(), mapping_from_length(mapping));
+        mapping_positions[i] = make_pos_t(pos);
+    }
+    // flush the insertion buffer a final time
+    if (buffered_insertion) {
+        shiftable_aln.back().emplace_back(0, buffered_insertion, false);
+    }
+
+#ifdef debug_indel_adjustment
+    cerr << "adjusting left? " << adjust_left << " for alignment" << endl;
+    cerr << pb2json(aln) << endl;
+    cerr << "shiftable aln, seq " << aln.sequence() << endl;
+    size_t debug_seq_idx = 0;
+    for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+        size_t debug_node_idx = 0;
+        cerr << i << ": " << mapping_positions[i] << " " << aligned_seqs[i] << endl;
+        for (const auto& edit : shiftable_aln[i])  {
+            cerr << '\t' << edit.from_length << ", " << edit.to_length << ", " << edit.is_match << ", " << debug_seq_idx << ", " << debug_node_idx << endl;
+            debug_node_idx += edit.from_length;
+            debug_seq_idx += edit.to_length;
+        }
+    }
+#endif
+
+    // reverse everything if we're adjusting left instead of right so that everything can be implemented
+    // as adjusting to the right internally
+    string rev_seq;
+    if (adjust_left) {
+        rev_seq.resize(aln.sequence().size(), '\0');
+        reverse_copy(aln.sequence().begin(), aln.sequence().end(), rev_seq.begin());
+        
+        reverse(shiftable_aln.begin(), shiftable_aln.end());
+        for (auto& mapping : shiftable_aln) {
+            mapping.reverse();
+        }
+        reverse(aligned_seqs.begin(), aligned_seqs.end());
+        for (auto& aligned_seq : aligned_seqs) {
+            reverse(aligned_seq.begin(), aligned_seq.end());
+        }
+        reverse(mapping_positions.begin(), mapping_positions.end());
+    }
+    const auto& seq = adjust_left ? rev_seq : aln.sequence();
+
+
+#ifdef debug_indel_adjustment
+    cerr << "after reversals, seq " << seq << endl;
+    debug_seq_idx = 0;
+    for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+        size_t debug_node_idx = 0;
+        cerr << i << ": " << mapping_positions[i] << " " << aligned_seqs[i] << endl;
+        for (const auto& edit : shiftable_aln[i])  {
+            cerr << '\t' << edit.from_length << ", " << edit.to_length << ", " << edit.is_match << ", " << debug_seq_idx << ", " << debug_node_idx << ", " << seq.substr(debug_seq_idx, edit.to_length) << ", " << aligned_seqs[i].substr(debug_node_idx, edit.from_length) << endl;
+            debug_node_idx += edit.from_length;
+            debug_seq_idx += edit.to_length;
+        }
+    }
+#endif
+    
+    // we'll keep track of whether anything changed to determine whether we need to re-construct the Alignment path
+    bool did_a_shift = false;
+
+    // move forward one edit in the shiftable alignment
+    auto advance = [&](size_t& i, list<simple_edit_t>::iterator& edit_it) {
+        ++edit_it;
+        while (i < shiftable_aln.size() && edit_it == shiftable_aln[i].end()) {
+            ++i;
+            if (i < shiftable_aln.size()) {
+                edit_it = shiftable_aln[i].begin();
+            }
+        }
+    };
+
+    // initiate shifting on an interval that contains only deletions or only insertions (although we may switch between
+    // the edit types at the end of the interval)
+    auto dispatch_shift = [&](size_t i, list<simple_edit_t>::iterator edit_it, size_t seq_idx, size_t node_idx, bool deletion_run) {
+#ifdef debug_indel_adjustment
+        cerr  << "dispatch from " << i << ", " << seq_idx << ", " << node_idx << ", " << deletion_run << endl;
+#endif
+
+        // for the current run of insertion/deletions, a buffer of (mapping idx, node seq idx, edit)
+        deque<tuple<size_t, size_t, list<simple_edit_t>::iterator>> curr_indel;
+
+        // if we partially cancel out an indel of the other type, we will switch run type and see if we can move it further
+        bool find_post_cancel_switch = false;
+        bool in_post_cancel_switch = false;
+        size_t prev_i = i;
+        for (; i < shiftable_aln.size(); advance(i, edit_it)) {
+
+#ifdef debug_indel_adjustment
+            cerr << "inner iter i " << i << ", si " << seq_idx << ", ni " << node_idx << ", fl " << edit_it->checked().from_length << ", tl " << edit_it->checked().to_length << ", im? " << edit_it->checked().is_match << endl; 
+#endif
+            
+            if (i != prev_i) {
+                node_idx = 0;
+                if (!curr_indel.empty() && get<2>(curr_indel.front())->checked().from_length == 0) {
+#ifdef debug_indel_adjustment
+                    cerr << "shift current insertion to current node" << endl;
+#endif
+                    // shift the insert from the end of the previous node to the start of this one
+                    shiftable_aln[i].emplace_front(*get<2>(curr_indel.front()));
+                    tombstone_erase(shiftable_aln[i - 1], get<2>(curr_indel.front()));
+                    get<0>(curr_indel.front()) = i;
+                    get<1>(curr_indel.front()) = 0;
+                    get<2>(curr_indel.front()) = shiftable_aln[i].begin();
+                }
+            }
+
+            if ((edit_it->checked().from_length == 0 && deletion_run) || (edit_it->checked().to_length == 0 && !deletion_run)) {
+#ifdef debug_indel_adjustment
+                cerr << "type switch" << endl;
+                cerr << "curr indel:" << endl;
+                for (const auto& r : curr_indel) {
+                    cerr << "\t" << get<0>(r) << '\t' << get<1>(r) << '\t' << get<2>(r)->checked().from_length << '\t' << get<2>(r)->checked().to_length << '\t' << get<2>(r)->checked().is_match << '\t';
+                    for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+                        size_t j = 0;
+                        for (auto it = shiftable_aln[i].begin(); it != shiftable_aln[i].end(); ++it) {
+                            if (std::get<2>(r) == it) {
+                                cerr << i << ',' << j;
+                            }
+                            ++j;
+                        }
+                    }
+                    cerr << endl;
+                }
+#endif
+                // we've left an indel run of one time for the indel run of the other type
+                if (find_post_cancel_switch) {
+                    // we want to try to switch type and try to shift this partially cancelled indel
+                    curr_indel.clear();
+                    deletion_run = !deletion_run;
+                    find_post_cancel_switch = false;
+                    in_post_cancel_switch = true;
+#ifdef debug_indel_adjustment
+                    cerr << "switching run type to " << (deletion_run ? "deletion" : "insertion") << " for post-cancel shift" << endl;
+#endif
+                }
+                else if (curr_indel.empty()) {
+                    // no opportunity to cancel out an insertion and deletion
+#ifdef debug_indel_adjustment
+                    cerr << "type switch without curr indel" << endl;
+#endif
+                    break;
+                }
+                else {
+                    // try to cancel out the insertion and deletion
+
+                    size_t overlap = 0;
+                    for (bool swapped : {false, true}) {
+                        if (swapped) {
+#ifdef debug_indel_adjustment
+                            cerr << "swapping order" << endl;
+#endif
+                            // since the order of an adjacent insertion and deletion is arbitrary, try in the other orientation
+                            if (deletion_run) {
+                                // move insertion before the current deletion
+                                auto swapped_it = shiftable_aln[get<0>(curr_indel.front())].emplace(get<2>(curr_indel.front()), edit_it->checked());
+                                tombstone_erase(shiftable_aln[i], edit_it);
+                                // move trackers to before the deletion but after the insertion
+                                i = get<0>(curr_indel.front());
+                                node_idx = get<1>(curr_indel.front());
+                                edit_it = get<2>(curr_indel.front());
+                                seq_idx += swapped_it->checked().to_length;
+                                // update the indel to be the insertion
+                                curr_indel.clear();
+                                curr_indel.emplace_front(i, node_idx, swapped_it);
+                            }
+                            else {
+                                // remember the current insertion
+                                auto ins_it = get<2>(curr_indel.front());
+                                // walk the deletion and construct the new current indel
+                                curr_indel.clear();
+                                size_t del_i = i;
+                                auto del_it = edit_it;
+                                size_t prev_del_i = del_i;
+                                for (; del_i < shiftable_aln.size(); advance(del_i, del_it)) {
+                                    if (del_i != prev_del_i) {
+                                        node_idx = 0;
+                                    }
+                                    if (del_it->checked().to_length != 0) {
+                                        break;
+                                    }
+                                    curr_indel.emplace_back(del_i, node_idx, del_it);
+                                    node_idx += del_it->checked().from_length;
+                                    prev_del_i = del_i;
+                                }
+                                // swap the insertion to the other side of the deletion
+                                list<simple_edit_t>::iterator swapped_it;
+                                if (del_i == shiftable_aln.size()) {
+                                    swapped_it = shiftable_aln.back().emplace(shiftable_aln.back().end(), ins_it->checked());
+                                }
+                                else {
+                                    swapped_it = shiftable_aln[del_i].emplace(del_it, ins_it->checked());
+                                }
+                                
+                                tombstone_erase(shiftable_aln[i], ins_it);
+
+                                // update the trackers (note: node_idx was already updated)
+                                seq_idx -= swapped_it->checked().to_length;
+                                edit_it = swapped_it;
+                                i = del_i < shiftable_aln.size() ? del_i : del_i - 1;
+                            }
+                            deletion_run = !deletion_run;
+#ifdef debug_indel_adjustment
+                            cerr << "now in " << (deletion_run ? "deletion" : "insertion") << " run with curr indel:" << endl;
+                            for (const auto& r : curr_indel) {
+                                cerr << "\t" << get<0>(r) << '\t' << get<1>(r) << '\t' << get<2>(r)->checked().from_length << '\t' << get<2>(r)->checked().to_length << '\t' << get<2>(r)->checked().is_match << '\t';
+                                for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+                                    size_t j = 0;
+                                    for (auto it = shiftable_aln[i].begin(); it != shiftable_aln[i].end(); ++it) {
+                                        if (std::get<2>(r) == it) {
+                                            cerr << i << ',' << j;
+                                        }
+                                        ++j;
+                                    }
+                                }
+                                cerr << endl;
+                            }
+                            
+                            cerr << "i " << i << ", node idx " << node_idx << ", seq idx " << seq_idx << ", edit " << edit_it->checked().from_length << ", " << edit_it->checked().to_length << ", " << edit_it->checked().is_match << endl;
+#endif
+                        }
+
+                        if (!deletion_run) {
+                            // insertion run
+#ifdef debug_indel_adjustment
+                            cerr << "try to cancel in ins run" << endl;
+                            cerr << "align state before attempting cancellation, seq " << seq << endl;
+                            size_t debug_seq_idx = 0;
+                            for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+                                size_t debug_node_idx = 0;
+                                cerr << i << ": " << mapping_positions[i] << " " << aligned_seqs[i] << endl;
+                                for (auto it = shiftable_aln[i].begin(); it != shiftable_aln[i].end(); ++it)  {
+                                    const auto& edit  = it->checked();
+                                    cerr << '\t' << edit.from_length << ", " << edit.to_length << ", " << edit.is_match << ", " << debug_seq_idx << ", " << debug_node_idx << ", " << seq.substr(debug_seq_idx, edit.to_length) << ", " << aligned_seqs[i].substr(debug_node_idx, edit.from_length) << endl;
+                                    debug_node_idx += edit.from_length;
+                                    debug_seq_idx += edit.to_length;
+                                }
+                            }
+#endif
+
+                            // get the insertion string
+                            string curr_indel_string = std::move(seq.substr(seq_idx - get<2>(curr_indel.front())->checked().to_length, get<2>(curr_indel.front())->checked().to_length));
+                            // get the deletion string
+                            string del_ahead_string;
+                            auto del_it = edit_it;
+                            size_t del_i = i;
+                            size_t prev_del_i = del_i;
+                            size_t del_node_idx = node_idx;
+                            while (del_i != shiftable_aln.size() && del_it->checked().to_length == 0) {
+                                if (del_i != prev_del_i) {
+                                    del_node_idx = 0;
+                                }
+                                del_ahead_string.append(aligned_seqs[del_i].substr(del_node_idx, del_it->checked().from_length));
+                                del_node_idx += del_it->checked().from_length;
+                                prev_del_i = del_i;
+                                advance(del_i, del_it);
+                            }
+
+                            // figure out how much we can cancel out
+                            overlap = longest_overlap(curr_indel_string, del_ahead_string);
+#ifdef debug_indel_adjustment
+                            cerr << "strings: " << curr_indel_string << ", " << del_ahead_string << '\n';
+                            cerr << "overlap: " << overlap << endl;
+#endif
+
+                            if (overlap != 0 && overlap < del_ahead_string.size()) {
+                                // we shortened the deletion ahead, it might be possible to move it now
+                                find_post_cancel_switch = true;
+                                in_post_cancel_switch = false;
+                            }
+
+                            // we're moving this much sequence ahead of where we are now
+                            seq_idx -= overlap;
+
+                            // convert deletions ahead to matches
+                            del_it = edit_it;
+                            del_i = i;
+                            size_t overlap_remaining = overlap;
+                            while (overlap_remaining) {
+#ifdef debug_indel_adjustment
+                                cerr << "have " << overlap_remaining << " overlap remaining at " << del_i << ", " << del_it->checked().from_length << ", " << del_it->checked().to_length << ", " << del_it->checked().is_match << endl;
+#endif
+                                if (overlap_remaining < del_it->checked().from_length) {
+#ifdef debug_indel_adjustment
+                                    cerr << "make new partial edit match" << endl;
+#endif
+                                    auto split_it = shiftable_aln[del_i].emplace(del_it, overlap_remaining, overlap_remaining, true);
+                                    del_it->checked().from_length -= overlap_remaining;
+                                    if (del_it == edit_it) {
+                                        edit_it = split_it;
+                                    }
+                                    break;
+                                }
+                                else {
+                                    // entirely convert to match
+#ifdef debug_indel_adjustment
+                                    cerr << "convert to match" << endl;
+#endif
+                                    del_it->checked().to_length = del_it->checked().from_length;
+                                    del_it->checked().is_match = true;
+                                    overlap_remaining -= del_it->checked().from_length;
+                                }
+                                advance(del_i, del_it);
+                            }
+                            if (overlap != 0 && overlap_remaining == 0 && del_i != shiftable_aln.size() && del_it != shiftable_aln[del_i].begin() && del_it->checked().is_match) {
+                                // we created an adjacency between matches by clearing out the deletion ahead
+                                // note: del_i and del_it now point to the past-the-last position for the deletion 
+#ifdef debug_indel_adjustment
+                                cerr << "created adjacency between match at end of conversion: " << del_i << ", " << del_it->checked().from_length << ", " << del_it->checked().to_length << ", " << del_it->checked().is_match << endl;
+#endif
+                                auto prev_it = del_it;
+                                --prev_it;
+                                prev_it->checked().from_length += del_it->checked().from_length;
+                                prev_it->checked().to_length += del_it->checked().to_length;
+                                tombstone_erase(shiftable_aln[del_i], del_it);
+                            }
+
+                            if (overlap == get<2>(curr_indel.front())->checked().to_length) {
+#ifdef debug_indel_adjustment
+                                cerr << "entirely consumed current insertion" << endl;
+
+#endif
+                                // the entire insertion is consumed
+                                auto next_it = tombstone_erase(shiftable_aln[i], get<2>(curr_indel.front()));
+                                curr_indel.clear();
+
+                                if (next_it != shiftable_aln[i].end() && next_it != shiftable_aln[i].begin()) {
+                                    // we may have created an adjacency between matches by clearing out the insertion
+#ifdef debug_indel_adjustment
+                                    cerr << "created adjacency at beginning of conversion" << endl;
+#endif
+                                    auto prev_it = next_it;
+                                    --prev_it;
+                                    if (next_it->checked().is_match && prev_it->checked().is_match) {
+                                        if (next_it == edit_it) {
+                                            edit_it = prev_it;
+                                            seq_idx -= prev_it->checked().to_length;
+                                            node_idx -= prev_it->checked().from_length;
+                                        }
+                                        prev_it->checked().from_length += next_it->checked().from_length;
+                                        prev_it->checked().to_length += next_it->checked().to_length;
+                                        tombstone_erase(shiftable_aln[i], next_it);
+                                    }
+                                }
+                            }
+                            else if (overlap != 0) {
+#ifdef debug_indel_adjustment
+                                cerr << "current insert is reduced by " << overlap << endl;
+#endif
+                                get<2>(curr_indel.front())->checked().to_length -= overlap;
+                            }
+
+                            if (overlap != 0) {
+                                // don't continue to the swapped order
+                                break;
+                            }
+                        }
+                        else {
+                            // deletion run
+#ifdef debug_indel_adjustment
+                            cerr << "try to cancel in del run" << endl;
+                            cerr << "align state before attempting cancelation, seq " << seq << endl;
+                            size_t debug_seq_idx = 0;
+                            for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+                                size_t debug_node_idx = 0;
+                                cerr << i << ": " << mapping_positions[i] << " " << aligned_seqs[i] << ", " << shiftable_aln[i].size() << " edits" << endl;
+                                for (auto it = shiftable_aln[i].begin(); it != shiftable_aln[i].end(); ++it)  {
+                                    const auto& edit = it->checked();
+                                    cerr << '\t' << edit.from_length << ", " << edit.to_length << ", " << edit.is_match << ", " << debug_seq_idx << ", " << debug_node_idx << ", " << seq.substr(debug_seq_idx, edit.to_length) << ", " << aligned_seqs[i].substr(debug_node_idx, edit.from_length) << endl;
+                                    debug_node_idx += edit.from_length;
+                                    debug_seq_idx += edit.to_length;
+                                }
+                            }
+#endif
+
+                            // get the deletion string
+                            string curr_indel_string;
+                            for (const auto& rec : curr_indel) {
+                                curr_indel_string.append(aligned_seqs[get<0>(rec)].substr(get<1>(rec), get<2>(rec)->checked().from_length));
+                            }
+                            // get the insertion string
+                            string ins_ahead_string = std::move(seq.substr(seq_idx, edit_it->checked().to_length));
+
+                            // figure out how much we can cancel out
+                            overlap = longest_overlap(curr_indel_string, ins_ahead_string);
+#ifdef debug_indel_adjustment
+                            cerr << "overlap " << overlap << ", del string len " << curr_indel_string.size() << endl;
+#endif
+
+                            if (overlap != 0 && overlap < ins_ahead_string.size()) {
+                                // we shortened the insertion ahead, it might be possible to move it now
+                                find_post_cancel_switch = true;
+                                in_post_cancel_switch = false;
+                            }
+                            
+                            // save these so we can access the insertion after retracting the cursor
+                            size_t ins_i = i;
+                            auto ins_it = edit_it;
+
+                            size_t overlap_remaining = overlap;
+                            while (overlap_remaining != 0) {
+                                if (get<0>(curr_indel.back()) != i) {
+                                    i = get<0>(curr_indel.back());
+                                    node_idx = aligned_seqs[i].size();
+                                }
+                                if (get<2>(curr_indel.back())->checked().from_length > overlap_remaining) {
+                                    // split into match and deletion
+                                    auto inserter = get<2>(curr_indel.back());
+                                    ++inserter;
+                                    edit_it = shiftable_aln[get<0>(curr_indel.back())].emplace(inserter, overlap_remaining, overlap_remaining, true);
+                                    node_idx -= overlap_remaining;
+                                    get<2>(curr_indel.back())->checked().from_length -= overlap_remaining;
+                                    break;
+                                }
+                                else {
+                                    // convert to match
+                                    edit_it = get<2>(curr_indel.back());
+                                    overlap_remaining -= edit_it->checked().from_length;
+                                    node_idx -= edit_it->checked().from_length;
+
+                                    edit_it->checked().to_length = edit_it->checked().from_length;
+                                    edit_it->checked().is_match = true;
+
+                                    curr_indel.pop_back();
+                                }
+                            }
+#ifdef debug_indel_adjustment
+                            cerr << "end with overlap remaining: " << overlap_remaining << endl;
+                            cerr << "cursor is at i " << i << ", ni " << node_idx << ", si " << seq_idx << ", edit " << edit_it->checked().from_length << ", " << edit_it->checked().to_length << ", "  << edit_it->checked().is_match << endl;
+#endif
+                            if (overlap != 0 && curr_indel.empty() && edit_it != shiftable_aln[i].begin()) {
+                                // we may have created an adjacency between matches by clearing out the deletion
+#ifdef debug_indel_adjustment
+                                cerr << "check for adjacency at start of match " << i << ", " << edit_it->checked().from_length << ", " << edit_it->checked().to_length << ", " << edit_it->checked().is_match << endl;
+#endif
+                                auto prev_it = edit_it;
+                                --prev_it;
+                                if (prev_it->checked().is_match) {
+#ifdef debug_indel_adjustment
+                                    cerr << "merge at start" << endl;
+#endif
+                                    seq_idx -= prev_it->checked().to_length;
+                                    node_idx -= prev_it->checked().from_length;
+                                    prev_it->checked().from_length += edit_it->checked().from_length;
+                                    prev_it->checked().to_length += edit_it->checked().to_length;
+                                    tombstone_erase(shiftable_aln[i], edit_it);
+                                    edit_it = prev_it;
+                                }
+                            }
+
+                            if (overlap == ins_it->checked().to_length) {
+#ifdef debug_indel_adjustment
+                                cerr << "insert is consumed" << endl;
+#endif
+                                // the neighboring insertion is consumed
+                                ins_it = tombstone_erase(shiftable_aln[ins_i], ins_it);
+
+                                // we may have created adjacencies between matches that can be merged
+                                if (ins_it != shiftable_aln[ins_i].begin() && ins_it != shiftable_aln[ins_i].end()) {
+                                    auto prev_it = ins_it;
+                                    --prev_it;
+                                    if (ins_it->checked().is_match && prev_it->checked().is_match) {
+                                        prev_it->checked().from_length += ins_it->checked().from_length;
+                                        prev_it->checked().to_length += ins_it->checked().to_length;
+                                        tombstone_erase(shiftable_aln[ins_i], ins_it);
+                                    }
+                                }
+                            }
+                            else {
+#ifdef debug_indel_adjustment
+                                cerr << "insert is reduced by " << overlap << endl;
+#endif
+                                // insertion is reduced
+                                ins_it->checked().to_length -= overlap;
+                            }
+
+                            if (overlap != 0) {
+                                // don't continue to the swapped order
+                                break;
+                            }
+                        }
+                    }
+
+                    // count an indel cancellation as a nontrivial shift
+                    did_a_shift = did_a_shift || (overlap != 0);
+                    
+                    if (!find_post_cancel_switch && (curr_indel.empty() || overlap == 0)) {
+                        // either no cancellation or both insert and delete were fully consumed
+#ifdef debug_indel_adjustment
+                        cerr << "non-cancelable type switch from run, exiting dispatch" << endl;
+#endif
+                        break;
+                    }
+#ifdef debug_indel_adjustment
+                    else if (find_post_cancel_switch) {
+                        cerr << "proceeding forward to find potentialy post-cancellation shifts in other run time" << endl;
+                    }
+#endif
+
+#ifdef debug_indel_adjustment
+                    cerr << "align state after cancellation, seq " << seq << endl;
+                    debug_seq_idx = 0;
+                    for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+                        size_t debug_node_idx = 0;
+                        cerr << i << ": " << mapping_positions[i] << " " << aligned_seqs[i] << ", " << shiftable_aln[i].size() << " edits"  << endl;
+                        for (const auto& edit : shiftable_aln[i])  {
+                            cerr << '\t' << edit.from_length << ", " << edit.to_length << ", " << edit.is_match << ", " << debug_seq_idx << ", " << debug_node_idx << ", " << seq.substr(debug_seq_idx, edit.to_length) << ", " << aligned_seqs[i].substr(debug_node_idx, edit.from_length) << endl;
+                            debug_node_idx += edit.from_length;
+                            debug_seq_idx += edit.to_length;
+                        }
+                    }
+
+                    cerr << "continuing from cancellation at i " << i << ", si " << seq_idx << ", ni " << node_idx << ", " << edit_it->checked().from_length << ", " << edit_it->checked().to_length << ", " << edit_it->checked().is_match << ", run type " << (deletion_run ? "del" : "ins") << endl;
+                    cerr << "and curr indel:" << endl;
+                    for (const auto& r : curr_indel) {
+                        cerr << "\t" << get<0>(r) << '\t' << get<1>(r) << '\t' << get<2>(r)->checked().from_length << '\t' << get<2>(r)->checked().to_length << '\t' << get<2>(r)->checked().is_match << '\t';
+                        for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+                            size_t j = 0;
+                            for (auto it = shiftable_aln[i].begin(); it != shiftable_aln[i].end(); ++it) {
+                                if (std::get<2>(r) == it) {
+                                    cerr << i << ',' << j;
+                                }
+                                ++j;
+                            }
+                        }
+                        cerr << endl;
+                    }
+#endif
+                }
+            }
+            
+            // record these before we start messing around with the edits
+            int64_t next_node_idx = node_idx + edit_it->checked().from_length;
+            int64_t next_seq_idx = seq_idx + edit_it->checked().to_length;
+
+            if (!curr_indel.empty() && edit_it->checked().from_length == 0) {
+                // extend the current insertion by merging the edits
+                auto insert = get<2>(curr_indel.front());
+                insert->checked().to_length += edit_it->checked().to_length;
+                tombstone_erase(shiftable_aln[i], edit_it);
+                edit_it = insert;
+            }
+            else if (!curr_indel.empty() && edit_it->checked().to_length == 0) {
+                // extend the current deletion
+                if (get<0>(curr_indel.back()) == i) {
+                    // same node, merge the edits
+                    auto del = get<2>(curr_indel.back());
+                    del->checked().from_length += edit_it->checked().from_length;
+                    tombstone_erase(shiftable_aln[i], edit_it);
+                    edit_it = del;
+                }
+                else {
+                    // different nodes, add the edit to the run
+                    curr_indel.emplace_back(i, node_idx, edit_it);
+                }
+            }
+            else if (!curr_indel.empty() && edit_it->checked().from_length == edit_it->checked().to_length) {
+                // try to shift through a match/mismatch
+
+                if (get<2>(curr_indel.front())->checked().from_length == 0) {
+                    // we're shifting an insertion
+                    
+                    int64_t shift_seq_idx = seq_idx - get<2>(curr_indel.front())->checked().to_length;
+                    while (edit_it->checked().from_length != 0 && (seq[seq_idx] == seq[shift_seq_idx] || !edit_it->checked().is_match)) {
+                        // are we shifting a match or a mismatch
+                        bool is_match = (seq[shift_seq_idx] == aligned_seqs[i][node_idx]);
+                        // get the match/mismatch we'll shift into
+                        auto leftward_aligned_it = get<2>(curr_indel.front());
+                        if (leftward_aligned_it == shiftable_aln[i].begin()) {
+                            // start a new match/mismatch at the beginning of the node
+                            leftward_aligned_it = shiftable_aln[i].emplace(leftward_aligned_it, 0, 0, is_match);
+                        }
+                        else {
+                            --leftward_aligned_it;
+                            if (leftward_aligned_it->checked().from_length != leftward_aligned_it->checked().to_length || 
+                                leftward_aligned_it->checked().is_match != is_match) {
+                                // start a new match/mismatch before the current indel
+                                leftward_aligned_it = shiftable_aln[i].emplace(get<2>(curr_indel.front()), 0, 0, is_match);
+                            }
+                        }
+                        // adjust the indexes
+                        --edit_it->checked().from_length;
+                        --edit_it->checked().to_length;
+                        ++leftward_aligned_it->checked().from_length;
+                        ++leftward_aligned_it->checked().to_length;
+                        ++seq_idx;
+                        ++node_idx;
+                        ++shift_seq_idx;
+                        did_a_shift = true;
+                    }
+                }
+                else {
+                    // we're shifting a deletion
+
+                    // cerr << "i " << i << ", fl " << edit_it->checked().from_length << ", tl " << edit_it->checked().to_length << ", im? " << edit_it->checked().is_match << ", si " << seq_idx << ", ni " << node_idx << ", cmp " << get<0>(curr_indel.front()) << ", " << get<1>(curr_indel.front()) << ", chars " << aligned_seqs[get<0>(curr_indel.front())][get<1>(curr_indel.front())] << " " << aligned_seqs[i][node_idx] << endl;
+                    while (edit_it->checked().from_length != 0 && 
+                           (aligned_seqs[get<0>(curr_indel.front())][get<1>(curr_indel.front())] == aligned_seqs[i][node_idx] || !edit_it->checked().is_match)) {
+                        // are we creating a match or a mismatch
+                        bool is_match = (seq[seq_idx] == aligned_seqs[get<0>(curr_indel.front())][get<1>(curr_indel.front())]);
+                        // get the match/mismatch we'll shift into
+                        // TODO: repetitive with insertions
+                        auto leftward_aligned_it = get<2>(curr_indel.front());
+                        if (leftward_aligned_it == shiftable_aln[get<0>(curr_indel.front())].begin()) {
+                            // start a new match/mismatch at the beginning of the node
+                            leftward_aligned_it = shiftable_aln[get<0>(curr_indel.front())].emplace(leftward_aligned_it, 0, 0, is_match);
+                        }
+                        else {
+                            --leftward_aligned_it;
+                            if (leftward_aligned_it->checked().from_length != leftward_aligned_it->checked().to_length || leftward_aligned_it->checked().is_match != is_match) {
+                                // start a new match/mismatch before the current indel
+                                leftward_aligned_it = shiftable_aln[get<0>(curr_indel.front())].emplace(get<2>(curr_indel.front()), 0, 0, is_match);
+                            }
+                        }
+                        // adjust the indexes
+                        ++seq_idx;
+                        ++node_idx;
+                        --edit_it->checked().from_length;
+                        --edit_it->checked().to_length;
+                        if (get<0>(curr_indel.back()) != i) {
+                            curr_indel.emplace_back(i, 0, shiftable_aln[i].emplace(shiftable_aln[i].begin(), 1, 0, false));
+                        }
+                        else {
+                            ++get<2>(curr_indel.back())->checked().from_length;
+                        }
+                        ++leftward_aligned_it->checked().from_length;
+                        ++leftward_aligned_it->checked().to_length;
+                        ++get<1>(curr_indel.front());
+                        --get<2>(curr_indel.front())->checked().from_length;
+                        
+                        if (get<2>(curr_indel.front())->checked().from_length == 0) {
+                            // we've shifted through the first deletion edit in this run
+                            tombstone_erase(shiftable_aln[get<0>(curr_indel.front())], get<2>(curr_indel.front()));
+                            curr_indel.pop_front();
+                        }
+                        did_a_shift = true;
+                    }
+                }
+
+                if (edit_it->checked().from_length == 0) {
+                    // we cleared out the entire match
+                    tombstone_erase(shiftable_aln[i], edit_it);
+                    edit_it = get<2>(curr_indel.back());
+                }
+                else {
+                    // we've shifted this indel as far as possible
+                    curr_indel.clear();
+                    if (in_post_cancel_switch) {
+                        // this was a partially cancelled indel, so we've shifted the remaining and can quit early
+#ifdef debug_indel_adjustment
+                        cerr << "end post cancel switch due to not clearing out a match" << endl;
+#endif
+                        break;
+                    }
+                }
+            }
+            else {
+                // we can't shift an indel through the next edit because it's not a match
+                if (in_post_cancel_switch && !curr_indel.empty()) {
+                    // this was a partially cancelled indel, so we've shifted the remaining and can quit early
+#ifdef debug_indel_adjustment
+                    cerr << "end post cancel switch due to finding a non-match" << endl;
+#endif
+                    break;
+                }
+                curr_indel.clear();
+
+                auto next_it = edit_it;
+                ++next_it;
+                if ((edit_it->checked().from_length == 0 && 
+                     !(i == 0 && edit_it == shiftable_aln[i].begin()) && !(i + 1 == shiftable_aln.size() && next_it == shiftable_aln[i].end())) ||
+                    edit_it->checked().to_length == 0) {
+                    // the next edit is a non-softclip insertion or deletion
+                    curr_indel.emplace_back(i, node_idx, edit_it);
+                }
+            }
+
+            seq_idx = next_seq_idx;
+            node_idx = next_node_idx; 
+
+            prev_i = i;
+        }
+
+#ifdef debug_indel_adjustment
+        cerr << "align state after completing dispatch, seq " << seq << endl;
+        size_t debug_seq_idx = 0;
+        for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+            size_t debug_node_idx = 0;
+            cerr << i << ": " << mapping_positions[i] << " " << aligned_seqs[i] << endl;
+            for (const auto& edit : shiftable_aln[i])  {
+                cerr << '\t' << edit.from_length << ", " << edit.to_length << ", " << edit.is_match << ", " << debug_seq_idx << ", " << debug_node_idx << ", " << seq.substr(debug_seq_idx, edit.to_length) << ", " << aligned_seqs[i].substr(debug_node_idx, edit.from_length) << endl;
+                debug_node_idx += edit.from_length;
+                debug_seq_idx += edit.to_length;
+            }
+        }
+#endif
+    };
+
+    // leftward outer iteration
+    bool in_deletion_run = false;
+    bool in_insertion_run = false;
+    size_t seq_idx = aln.sequence().size();
+    // TODO: doing this manually is somehow less cumbersome than working around the iterator invalidation on
+    // reverse_iterators
+    auto iter_backward = [](list<simple_edit_t>& l, list<simple_edit_t>::iterator& it) {
+        if (it == l.begin()) {
+            it = l.end();
+        }
+        else {
+            --it;
+        }
+    };
+    auto loop_backward = [&](int64_t& i, list<simple_edit_t>::iterator& it) {
+        iter_backward(shiftable_aln[i], it);
+        while (i >= 0 && it == shiftable_aln[i].end()) {
+            --i;
+            if (i >= 0) {
+                it = shiftable_aln[i].end();
+                iter_backward(shiftable_aln[i], it);
+            }
+        }
+    };
+
+    for (int64_t j = shiftable_aln.size() - 1; j >= 0; --j) {
+
+        size_t node_idx = aligned_seqs[j].size();
+
+        auto it = shiftable_aln[j].end();
+        --it;
+        for (; it != shiftable_aln[j].end(); iter_backward(shiftable_aln[j], it)) {
+
+#ifdef debug_indel_adjustment
+            cerr << "outer iter j " << j << ", si " << seq_idx << ", ni " << node_idx << ", fl " << it->checked().from_length << ", tl " << it->checked().to_length << ", im? " << it->checked().is_match << endl;
+#endif
+            
+            auto next_it = it;
+            ++next_it;
+            if (it->checked().from_length == 0) {
+                // insertion
+
+                if (in_deletion_run) {
+                    // see if we can swap a deletion from the other side of this insertion into this deletion run
+
+                    // look back one position
+                    int64_t s = j;
+                    auto s_it = it;
+                    loop_backward(s, s_it);
+                    // find the end of the deletion (if any)
+                    bool found = false;
+                    while (s >= 0) {
+#ifdef debug_indel_adjustment
+                        cerr << "check " << s << ", " << s_it->checked().from_length << ", " << s_it->checked().to_length << ", " << s_it->checked().is_match << " for a boundary deletion to swap into run" << endl;
+#endif
+                        if (s_it->checked().to_length == 0) {
+                            found = true;
+                        }
+                        else {
+                            break;
+                        }
+                        loop_backward(s, s_it);
+                    }
+                    if (found) {
+                        // there's a deletion preceding this insertion
+#ifdef debug_indel_adjustment
+                        cerr << "found swappable deletion" << endl;
+#endif
+
+                        // navigate back to the first edit of the deletion
+                        if (s < 0) {
+                            s = 0;
+                            s_it = shiftable_aln.front().begin();
+                        }
+                        else {
+                            // TODO: annoying type conversion
+                            size_t s_us = s;
+                            advance(s_us, s_it);
+                            s = s_us;
+                        }
+
+                        // update the node seq index
+                        // note: we only walked through deletions, so we don't need to worry about updating seq_idx
+                        node_idx = (s == j) ? node_idx : aligned_seqs[s].size();
+                        size_t t = s;
+                        auto t_it = s_it;
+                        while (t_it != it && t == s) {
+                            node_idx -= t_it->checked().from_length;
+                            advance(t, t_it);
+                        }
+
+                        // move the insertion to the beginning of the deletion
+                        auto ins_it = shiftable_aln[s].emplace(s_it, it->checked());
+                        tombstone_erase(shiftable_aln[j], it);
+
+                        // update the iteration pointer to the new location
+                        it = ins_it;
+                        j = s;
+
+#ifdef debug_indel_adjustment
+                        cerr << "align state after swapping into run" << endl;
+                        size_t debug_seq_idx = 0;
+                        for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+                            size_t debug_node_idx = 0;
+                            cerr << i << ": " << mapping_positions[i] << " " << aligned_seqs[i] << endl;
+                            for (const auto& edit : shiftable_aln[i])  {
+                                cerr << '\t' << edit.from_length << ", " << edit.to_length << ", " << edit.is_match << ", " << debug_seq_idx << ", " << debug_node_idx << ", " << seq.substr(debug_seq_idx, edit.to_length) << ", " << aligned_seqs[i].substr(debug_node_idx, edit.from_length) << endl;
+                                debug_node_idx += edit.from_length;
+                                debug_seq_idx += edit.to_length;
+                            }
+                        }
+                        cerr << "j " << j << ", ni " << node_idx << ", si " << seq_idx << ", ed " << it->checked().from_length << ", " << it->checked().to_length << ", "  << it->checked().is_match << endl;
+#endif
+                    }
+
+                    // move back into the deletion run and dispatch a right shift inside it
+                    size_t i = j;
+                    auto edit_it = it;
+                    advance(i, edit_it);
+                    dispatch_shift(i, edit_it, seq_idx, i == j ? node_idx : 0, true);
+                    in_deletion_run = false;
+                }
+                
+                if (!(j == 0 && it == shiftable_aln[j].begin()) && !(j + 1 == shiftable_aln.size() && next_it == shiftable_aln.back().end())) {
+                    in_insertion_run = true;
+                }
+            }
+            else if (it->checked().to_length == 0) {
+                // deletion
+
+                if (in_insertion_run) {
+                    // see if we can find an insertion on the other side of this deletion to swap into this run
+
+                    // traverse the deletion
+                    int64_t s = j;
+                    auto s_it = it;
+                    loop_backward(s, s_it);
+                    while (s >= 0 && s_it->checked().to_length == 0) {
+#ifdef debug_indel_adjustment
+                        cerr << "check " << s << ", " << s_it->checked().from_length << ", " << s_it->checked().to_length << ", " << s_it->checked().is_match << " for a boundary insertion to swap into run" << endl;
+#endif
+                        loop_backward(s, s_it);
+                    }
+                    if (s >= 0 && s_it->checked().from_length == 0 && !(s_it == shiftable_aln.front().begin())) {
+                        // there's a non-soft-clip insertion on this boundary
+
+#ifdef debug_indel_adjustment
+                        cerr << "found swappable insertion" << endl;
+                        cerr << aln.name() << endl;
+#endif
+
+                        // update the sequence to being in front of the cursor
+                        seq_idx -= s_it->checked().to_length;
+
+                        // move the insertion ahead of the cursor
+                        auto t_it = it;
+                        ++t_it;
+                        shiftable_aln[j].emplace(t_it, s_it->checked());
+                        tombstone_erase(shiftable_aln[s], s_it);
+
+#ifdef debug_indel_adjustment
+                        cerr << "align state after swapping into run" << endl;
+                        size_t debug_seq_idx = 0;
+                        for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+                            size_t debug_node_idx = 0;
+                            cerr << i << ": " << mapping_positions[i] << " " << aligned_seqs[i] << endl;
+                            for (const auto& edit : shiftable_aln[i])  {
+                                cerr << '\t' << edit.from_length << ", " << edit.to_length << ", " << edit.is_match << ", " << debug_seq_idx << ", " << debug_node_idx << ", " << seq.substr(debug_seq_idx, edit.to_length) << ", " << aligned_seqs[i].substr(debug_node_idx, edit.from_length) << endl;
+                                debug_node_idx += edit.from_length;
+                                debug_seq_idx += edit.to_length;
+                            }
+                        }
+                        cerr << "j " << j << ", ni " << node_idx << ", si " << seq_idx << ", ed " << it->checked().from_length << ", " << it->checked().to_length << ", "  << it->checked().is_match << endl;
+#endif
+                    }
+
+                    // move back to insertion run and dispatch a right shift
+                    size_t i = j;
+                    auto edit_it = it;
+                    advance(i, edit_it);
+                    dispatch_shift(i, edit_it, seq_idx, i == j ? node_idx : 0, false);
+                    in_insertion_run = false;
+                }
+
+                in_deletion_run = true;
+            }
+
+            seq_idx -= it->checked().to_length;
+            node_idx -= it->checked().from_length;
+        }
+    }
+
+    if (in_deletion_run || in_insertion_run) {
+        // dispatch the last run that wasn't triggered by an alternation in type
+#ifdef debug_indel_adjustment
+        cerr << "final dispatch" << endl;
+#endif
+        dispatch_shift(0, shiftable_aln.front().begin(), 0, 0, in_deletion_run);
+    }
+
+    if (!did_a_shift) {
+        // no need to re-translate the path
+        return;
+    }
+
+    // indels may have moved to the end of the alignment, which can mess up softclipping and position semantics
+    {
+        // find a non-empty mapping
+        int64_t i = shiftable_aln.size() - 1;
+        auto it = shiftable_aln[i].end();
+        while (it == shiftable_aln[i].begin()) {
+            --i;
+            it = shiftable_aln[i].end();
+        }
+        // look at the final edit
+        --it;
+        size_t softclip_len = 0;
+#ifdef debug_indel_adjustment
+        cerr << "found non-empty mapping at " << i << ", fl " << it->checked().from_length << ", tl " << it->checked().to_length << ", im? " << it->checked().is_match << endl;
+#endif
+        if (it->checked().from_length == 0) {
+            // there is a softclip, erase it so we can make sure it gets added back in the right place
+            softclip_len = it->checked().to_length;
+            auto clip = it;
+            if (it == shiftable_aln[i].begin()) {
+                --i;
+                it = shiftable_aln[i].end();
+            }
+            --it;
+#ifdef debug_indel_adjustment
+            cerr << "erasing clip" << endl;
+#endif
+            //shiftable_aln[i].erase(clip);
+            tombstone_erase(shiftable_aln[i], clip);
+        }
+        while (true) {
+#ifdef debug_indel_adjustment
+            cerr << "check for hanging deletions on " << i << ", " << it->checked().from_length << ", tl " << it->checked().to_length << ", im? " << it->checked().is_match << endl;
+#endif
+            if (it->checked().from_length == it->checked().to_length || (preserve_end_pos && it->checked().from_length != 0)) {
+                // we found an aligned base, reposition the softclip if necessary
+#ifdef debug_indel_adjustment
+                cerr << "match" << endl;
+#endif
+                if (softclip_len > 0) {
+                    shiftable_aln[i].emplace_back(0, softclip_len, false);
+                }
+                break;
+            }
+            else if (it->checked().to_length == 0) {
+#ifdef debug_indel_adjustment
+                cerr << "deletion length " << it->checked().from_length << endl;
+#endif
+                if (adjust_left) {
+                    // we're removing reference bases, which will affect the position
+                    get_offset(mapping_positions[i]) += it->checked().from_length;
+                }
+            }
+            else {
+                // we will accumulate this insertion into the softclip
+#ifdef debug_indel_adjustment
+                cerr << "extra softclip" << endl;
+#endif
+                softclip_len += it->checked().to_length;
+            }
+            auto eraser = it;
+            int64_t e = i;
+#ifdef debug_indel_adjustment
+            cerr << "erase " << i << ", " << eraser->from_length << ", " << eraser->to_length << ", " << eraser->is_match << endl;
+#endif  
+            if (it == shiftable_aln[i].begin()) {
+                --i;
+                it = shiftable_aln[i].end();
+            }
+            --it;
+            tombstone_erase(shiftable_aln[e], eraser);
+        }
+    }
+
+#ifdef debug_indel_adjustment
+    cerr << "finished handling clips" << endl;
+#endif
+
+    if (adjust_left) {
+        // un-reverse the alignment for reconstruction
+        reverse(shiftable_aln.begin(), shiftable_aln.end());
+        for (auto& mapping : shiftable_aln) {
+            mapping.reverse();
+        }
+        reverse(mapping_positions.begin(), mapping_positions.end());
+    }
+
+    // clear out the old alignment path
+    path.Clear();
+    // replace it by reconstructing the shifted path
+    seq_idx = 0;
+    for (size_t i = 0; i < shiftable_aln.size(); ++i) {
+        if (shiftable_aln[i].empty()) {
+            continue;
+        }
+        auto mapping = path.add_mapping();
+        mapping->set_rank(path.mapping_size());
+        auto position = mapping->mutable_position();
+        const auto& shift_pos = mapping_positions[i];
+        position->set_node_id(id(shift_pos));
+        position->set_is_reverse(is_rev(shift_pos));
+        position->set_offset(offset(shift_pos));
+
+        for (const auto& shift_edit : shiftable_aln[i]) {
+            auto edit = mapping->add_edit();
+            edit->set_from_length(shift_edit.from_length);
+            edit->set_to_length(shift_edit.to_length);
+            if (shift_edit.from_length == 0 || !shift_edit.is_match) {
+                edit->set_sequence(aln.sequence().substr(seq_idx, shift_edit.to_length));
+            }
+            seq_idx += shift_edit.to_length;
+        }
+    }
 }
 
 vector<pair<int, char>> graph_cigar(const Alignment& aln, bool rev_strand) {

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -252,6 +252,10 @@ vector<pair<int, char>> spliced_cigar_against_path(const Alignment& aln, const P
 /// operations, and merge adjacent operations of the same type
 void simplify_cigar(vector<pair<int, char>>& cigar);
 
+/// Normalize the adjustment of indels in an alignment to left or right
+/// Optionally: don't allow the ending positions of the alignment to change
+/// even if that requires the alignment to end in a deletion
+void normalize_indel_adjustment(Alignment& aln, bool adjust_left, const HandleGraph& graph, bool preserve_end_pos = false);
 
 /// Translate the CIGAR in the given BAM record into mappings in the given
 /// Alignment against the given path in the given graph.

--- a/src/hts_alignment_emitter.cpp
+++ b/src/hts_alignment_emitter.cpp
@@ -62,7 +62,8 @@ unique_ptr<AlignmentEmitter> get_alignment_emitter(const string& filename, const
             emitter = make_unique<SurjectingAlignmentEmitter>(path_graph, target_paths, std::move(emitter),
                 flags & ALIGNMENT_EMITTER_FLAG_HTS_PRUNE_SUSPICIOUS_ANCHORS,
                 flags & ALIGNMENT_EMITTER_FLAG_HTS_ADD_GRAPH_ALIGNMENT_TAG,
-                flags & ALIGNMENT_EMITTER_FLAG_HTS_SUPPLEMENTARY);
+                flags & ALIGNMENT_EMITTER_FLAG_HTS_SUPPLEMENTARY,
+                flags & ALIGNMENT_EMITTER_FLAG_HTS_LEFT_ALIGN);
         }
     
     } else {

--- a/src/hts_alignment_emitter.hpp
+++ b/src/hts_alignment_emitter.hpp
@@ -49,7 +49,9 @@ enum alignment_emitter_flags_t {
     /// expresses the alignment in graph space in the "GR" tag
     ALIGNMENT_EMITTER_FLAG_HTS_ADD_GRAPH_ALIGNMENT_TAG = 16,
     /// When surjecting, produce and report supplementary alignments
-    ALIGNMENT_EMITTER_FLAG_HTS_SUPPLEMENTARY = 32
+    ALIGNMENT_EMITTER_FLAG_HTS_SUPPLEMENTARY = 32,
+    /// When surjecting, attempt to left align
+    ALIGNMENT_EMITTER_FLAG_HTS_LEFT_ALIGN = 64
 };
 
 /// Represents a path or subpath's sequence dictionary information. Holds

--- a/src/longest_overlap.hpp
+++ b/src/longest_overlap.hpp
@@ -1,0 +1,99 @@
+#ifndef VG_LONGEST_OVERLAP_HPP_INCLUDED
+#define VG_LONGEST_OVERLAP_HPP_INCLUDED
+
+// longest_overlap.hpp: longest overlap between two strings with Z algorithm
+
+#include <vector>
+#include <algorithm>
+#include <cstdint>
+
+namespace vg {
+
+using namespace std;
+
+/*
+ * Return the length of the longest match of a suffix of str1 with a prefix of str2
+ */
+template<class StringLike>
+size_t longest_overlap(const StringLike& str1, const StringLike& str2);
+
+/*
+ * Return the Z array
+ */
+template<class StringLike>
+vector<int64_t> z_algorithm(const StringLike& str);
+
+
+
+/************
+ * Template implementations
+ ************/
+
+template<class StringLike>
+vector<int64_t> z_algorithm(const StringLike& str) {
+
+    vector<int64_t> Z(str.size(), 0);
+
+    int64_t right = 0, left = 0;
+    for (int64_t i = 1; i < Z.size(); ++i) {
+        if (i <= right) {
+            Z[i] = min(right - i + 1, Z[i - left]);
+        }
+        while (i + Z[i] < Z.size() && str[Z[i]] == str[i + Z[i]]) {
+            ++Z[i];
+        }
+        if (i + Z[i] - 1 > right) {
+            left = i;
+            right = i + Z[i] - 1;
+        }
+    }
+
+    return Z;
+}
+
+template<class StringLike>
+size_t longest_overlap(const StringLike& str1, const StringLike& str2) {
+
+    if (str1.size() == 0 || str2.size() == 0) {
+        return 0;
+    }
+
+    // string-like wrapper for concatenated string with a 0-valued sentinel separating
+    class ConcatString {
+    public:
+        ConcatString(const StringLike& str1, const StringLike& str2) : str1(&str1), str2(&str2) {}
+        size_t size() const {
+            return str1->size() + str2->size() + 1;
+        }
+        const typename StringLike::value_type operator[](size_t i) const {
+            if (i < str1->size()) {
+                return (*str1)[i];
+            }
+            else if (i == str1->size()) {
+                return typename StringLike::value_type(0);
+            }
+            else {
+                return (*str2)[i - str1->size() - 1];
+            }
+        }
+
+    private:
+        const StringLike* str1 = nullptr;
+        const StringLike* str2 = nullptr;
+    };
+
+    ConcatString concat(str2, str1);
+    auto Z = z_algorithm(concat);
+
+    for (size_t i = str1.size(); i != 0; --i) {
+        if (Z[Z.size() - i] == i) {
+            return i;
+        }
+    }
+    return 0;
+}
+
+
+}
+
+#endif

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -693,6 +693,7 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
          << "      --named-coordinates       make GAM/GAF output in named-segment (GFA) space" << endl;
     if (full_help) {
         cerr << "      --add-graph-aln           annotate linear formats with graph alignment" << endl
+             << "      --left-align              attempt to left-align indels in linear formats" << endl
              << "                                in the GR tag as a cs-style difference string" << endl
              << "  -n, --discard                 discard all output alignments (for profiling)" << endl
              << "      --output-basename NAME    write output to a GAM file with the given prefix" << endl
@@ -758,6 +759,7 @@ int main_giraffe(int argc, char** argv) {
     constexpr int OPT_NAMED_COORDINATES = 1011;
     constexpr int OPT_ADD_GRAPH_ALIGNMENT = 1012;
     constexpr int OPT_COMMENTS_AS_TAGS = 1013;
+    constexpr int OPT_LEFT_ALIGN = 1014;
     constexpr int OPT_HAPLOTYPE_NAME = 1100;
     constexpr int OPT_KFF_NAME = 1101;
     constexpr int OPT_INDEX_BASENAME = 1102;
@@ -850,6 +852,9 @@ int main_giraffe(int argc, char** argv) {
     std::unordered_set<std::string> reference_assembly_names;
     // When surjecting, should we annotate the reads with the graph alignment?
     bool add_graph_alignment = false;
+
+    // When surjecting, should we attempt to left-align relative to the reference?
+    bool left_align = false;
     
     // For GAM format, should we report in named-segment space instead of node ID space?
     bool named_coordinates = false;
@@ -1095,6 +1100,7 @@ int main_giraffe(int argc, char** argv) {
         {"ref-paths", required_argument, 0, OPT_REF_PATHS},
         {"ref-name", required_argument, 0, OPT_REF_NAME},
         {"add-graph-aln", no_argument, 0, OPT_ADD_GRAPH_ALIGNMENT},
+        {"left-align", no_argument, 0, OPT_LEFT_ALIGN},
         {"named-coordinates", no_argument, 0, OPT_NAMED_COORDINATES},
         {"discard", no_argument, 0, 'n'},
         {"output-basename", required_argument, 0, OPT_OUTPUT_BASENAME},
@@ -1280,6 +1286,10 @@ int main_giraffe(int argc, char** argv) {
                 
             case OPT_ADD_GRAPH_ALIGNMENT:
                 add_graph_alignment = true;
+                break;
+                
+            case OPT_LEFT_ALIGN:
+                left_align = true;
                 break;
                 
             case 'n':
@@ -1932,6 +1942,7 @@ int main_giraffe(int argc, char** argv) {
 
         report_flag("interleaved", interleaved);
         report_flag("add-graph-aln", add_graph_alignment);
+        report_flag("left-align", left_align);
         report_flag("set-refpos", set_refpos);
         minimizer_mapper.set_refpos = set_refpos;
         report_flag("track-provenance", track_provenance);
@@ -2062,6 +2073,10 @@ int main_giraffe(int argc, char** argv) {
                 if (minimizer_mapper.find_supplementaries) {
                     // When surjecting, also report supplementary alignments
                     flags |= ALIGNMENT_EMITTER_FLAG_HTS_SUPPLEMENTARY;
+                }
+                if (left_align) {
+                    // When surjecting, attempt to left align
+                    flags |= ALIGNMENT_EMITTER_FLAG_HTS_LEFT_ALIGN;
                 }
                 
                 // We send along the positional graph when we have it, and otherwise we send the GBWTGraph which is sufficient for GAF output.

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -56,6 +56,7 @@ void help_surject(char** argv) {
          << "  -b, --bam-output          write BAM instead of GAM to stdout" << endl
          << "  -s, --sam-output          write SAM instead of GAM to stdout" << endl
          << "  -u, --supplementary       divide into supplementary alignments as necessary" << endl
+         << "  -B, --left-align          attempt to left-align indels" << endl
          << "  -l, --subpath-local       let the multipath mapping surjection produce local" << endl
          << "                            (rather than global) alignments" << endl
          << "  -T, --max-tail-len N      only align up to N bases of read tails [10000]" << endl
@@ -181,6 +182,7 @@ int main_surject(int argc, char** argv) {
     bool multimap = false;
     bool validate = true;
     bool show_progress = false;
+    bool left_align = false;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -206,6 +208,7 @@ int main_surject(int argc, char** argv) {
             {"bam-output", no_argument, 0, 'b'},
             {"sam-output", no_argument, 0, 's'},
             {"supplementary", no_argument, 0, 'u'},
+            {"left-align", no_argument, 0, 'B'},
             {"read-length", required_argument, 0, 'D'},
             {"spliced", no_argument, 0, 'S'},
             {"prune-low-cplx", no_argument, 0, 'P'},
@@ -227,7 +230,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuN:R:f:C:t:D:SPI:a:AE:LHMVw:r",
+        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuBN:R:f:C:t:D:SPI:a:AE:LHMVw:r",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -296,6 +299,10 @@ int main_surject(int argc, char** argv) {
 
         case 'u':
             report_supplementary = true;
+            break;
+
+        case 'B':
+            left_align = true;
             break;
                 
         case 'D':
@@ -485,6 +492,7 @@ int main_surject(int argc, char** argv) {
     }
     surjector.choose_band_padding = algorithms::pad_band_min_random_walk(1.0, 2000, 16);
     surjector.report_supplementary = report_supplementary;
+    surjector.left_align = left_align;
     surjector.multimap_to_all_paths = multimap;
 
     // Count our threads

--- a/src/surjecting_alignment_emitter.cpp
+++ b/src/surjecting_alignment_emitter.cpp
@@ -14,12 +14,13 @@ namespace vg {
 using namespace std;
 
 SurjectingAlignmentEmitter::SurjectingAlignmentEmitter(const PathPositionHandleGraph* graph, unordered_set<path_handle_t> paths,
-    unique_ptr<AlignmentEmitter>&& backing, bool prune_suspicious_anchors, bool add_graph_alignment_tag, bool report_supplementary) : surjector(graph), paths(paths), backing(std::move(backing)) {
+    unique_ptr<AlignmentEmitter>&& backing, bool prune_suspicious_anchors, bool add_graph_alignment_tag, bool report_supplementary, bool left_align) : surjector(graph), paths(paths), backing(std::move(backing)) {
     
     // Configure the surjector
     surjector.prune_suspicious_anchors = prune_suspicious_anchors;
     surjector.annotate_with_graph_alignment = add_graph_alignment_tag;
     surjector.report_supplementary = report_supplementary;
+    surjector.left_align = left_align;
 }
 
 void SurjectingAlignmentEmitter::surject_alignments_in_place(vector<Alignment>& alns) const {

--- a/src/surjecting_alignment_emitter.hpp
+++ b/src/surjecting_alignment_emitter.hpp
@@ -36,7 +36,7 @@ public:
     SurjectingAlignmentEmitter(const PathPositionHandleGraph* graph,
         unordered_set<path_handle_t> paths, unique_ptr<AlignmentEmitter>&& backing,
         bool prune_suspicious_anchors = false, bool add_graph_alignment_tag = false,
-        bool report_supplementary = false);
+        bool report_supplementary = false, bool left_align = false);
    
     ///  Force full length alignment in surjection resolution 
     bool surject_subpath_global = true;

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -225,7 +225,6 @@ using namespace std;
                                      vector<tuple<string, int64_t, bool>>& positions_out,
                                      bool allow_negative_scores, bool preserve_deletions) const {
 
-        
         // we need one and only one data type: Alignment or multipath_alignment_t
         assert(!(source_aln && source_mp_aln));
         assert((source_aln && alns_out) || (source_mp_aln && mp_alns_out));
@@ -3707,7 +3706,7 @@ using namespace std;
             }
         }
         
-            // transfer applicable metadata (including data that doesn't transit through multipath_alignment_t)
+        // transfer applicable metadata (including data that doesn't transit through multipath_alignment_t)
         for (auto& surj : surjected) {
             surj.first.set_name(source.name());
             surj.first.set_read_group(source.read_group());
@@ -3722,6 +3721,47 @@ using namespace std;
             }
             if (source.has_annotation()) {
                 *surj.first.mutable_annotation() = source.annotation();
+            }
+        }
+
+        if (left_align) {
+            for (size_t i = 0; i < surjected.size(); ++i) {
+
+                auto& surj = surjected[i];
+
+                // remember how many nodes the alignment visits before left-alignment
+                size_t num_mappings = surj.first.path().mapping_size();
+
+                // do left alignment relative to the strand
+                if (rev_strand) {
+                    normalize_indel_adjustment(surj.first, false, *path_position_graph, sinks_are_anchors);
+                }
+                else {
+                    normalize_indel_adjustment(surj.first, true, *path_position_graph, sources_are_anchors);
+                }
+
+                surj.first.set_score(get_aligner(!source.quality().empty())->score_contiguous_alignment(source));
+
+                // pinch in the step ranges if left-aligning caused us to shift the alignment off of the first node
+                for (size_t j = 0, n = num_mappings - surj.first.path().mapping_size(); j < n; ++j) {
+
+                    if (rev_strand) {
+                        surj.second.second = path_position_graph->get_next_step(surj.second.second);
+                    }
+                    else {
+                        surj.second.first = path_position_graph->get_next_step(surj.second.first);
+                    }
+                    if (all_path_ranges_out) {
+                        for (auto& path_range : (*all_path_ranges_out)[i]) {
+                            if (rev_strand) {
+                                path_range.second = path_position_graph->get_next_step(path_range.second);
+                            }
+                            else {
+                                path_range.first = path_position_graph->get_next_step(path_range.first);
+                            }
+                        }
+                    }
+                }
             }
         }
         

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -158,6 +158,9 @@ using namespace std;
         
         // A function for computing band padding
         std::function<size_t(const Alignment&, const HandleGraph&)> choose_band_padding;
+
+        /// Attempt to left-align indels relative to the forward strand of the surjection path
+        bool left_align = false;
         
         /// How many anchors (per path) will we use when surjecting using
         /// anchors?
@@ -177,6 +180,7 @@ using namespace std;
         
         bool annotate_with_all_path_scores = false;
         bool annotate_with_graph_alignment = false;
+        
         
     protected:
 

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -779,5 +779,1959 @@ TEST_CASE("Unaligned sequences survive round-trip to GAF", "[alignment][gaf]") {
     }
 }
 
+TEST_CASE("Alignments can be left/right-aligned", "[alignment]") {
+
+    auto paths_equivalent = [](const Path& path1, const Path& path2) {
+        REQUIRE(path1.mapping_size() == path2.mapping_size());
+        for (size_t i = 0; i < path1.mapping_size(); ++i) {
+            const auto& mapping1 = path1.mapping(i);
+            const auto& mapping2 = path2.mapping(i);
+            REQUIRE(mapping1.position().node_id() == mapping2.position().node_id());
+            REQUIRE(mapping1.position().is_reverse() == mapping2.position().is_reverse());
+            REQUIRE(mapping1.position().offset() == mapping2.position().offset());
+            REQUIRE(mapping1.edit_size() == mapping2.edit_size());
+            for (size_t j = 0; j < mapping1.edit_size(); ++j) {
+                const auto& edit1 = mapping1.edit(j);
+                const auto& edit2 = mapping2.edit(j);
+                REQUIRE(edit1.from_length() == edit2.from_length());
+                REQUIRE(edit1.to_length() == edit2.to_length());
+                REQUIRE(edit1.sequence() == edit2.sequence());
+            }
+        }
+    };
+
+    auto check_left_right_adj_consistency = [&](const Alignment& aln, const HandleGraph& graph) {
+        
+        auto get_length = [&](nid_t node_id) -> int64_t { return graph.get_length(graph.get_handle(node_id)); };
+
+        for (bool left_adj : {true, false}) {
+
+            auto fwd = aln;
+            auto rev = reverse_complement_alignment(fwd, get_length);
+            
+            normalize_indel_adjustment(fwd, left_adj, graph);
+            normalize_indel_adjustment(rev, !left_adj, graph);
+
+            reverse_complement_alignment_in_place(&rev, get_length);
+
+            paths_equivalent(fwd.path(), rev.path());
+        }
+    };
+
+    SECTION("Within a single node") {
+
+        bdsg::HashGraph graph;
+
+        auto h = graph.create_handle("TACACACT");
+
+        Alignment aln;
+        aln.set_sequence("TACACT");
+        auto path = aln.mutable_path();
+
+        auto m = path->add_mapping();
+        auto p = m->mutable_position();
+        p->set_node_id(graph.get_id(h));
+        p->set_is_reverse(false);
+        p->set_offset(0);
+
+        auto e1 = m->add_edit();
+        e1->set_from_length(3);
+        e1->set_to_length(3);
+
+        auto e2 = m->add_edit();
+        e2->set_from_length(2);
+        e2->set_to_length(0);
+
+        auto e3 = m->add_edit();
+        e3->set_from_length(3);
+        e3->set_to_length(3);
+
+        SECTION("Consistency") {
+            check_left_right_adj_consistency(aln, graph);
+        }
+
+        SECTION("Deletion, left"){
+
+            normalize_indel_adjustment(aln, true, graph);
+
+            const auto& path = aln.path();
+            REQUIRE(path.mapping_size() == 1);
+            const auto& mapping = path.mapping(0);
+            REQUIRE(mapping.edit_size() == 3);
+            REQUIRE(make_pos_t(mapping.position()) == make_pos_t(graph.get_id(h), false, 0));
+            REQUIRE(mapping.edit(0).from_length() == 1);
+            REQUIRE(mapping.edit(0).to_length() == 1);
+            REQUIRE(mapping.edit(0).sequence().empty());
+            REQUIRE(mapping.edit(1).from_length() == 2);
+            REQUIRE(mapping.edit(1).to_length() == 0);
+            REQUIRE(mapping.edit(1).sequence().empty());
+            REQUIRE(mapping.edit(2).from_length() == 5);
+            REQUIRE(mapping.edit(2).to_length() == 5);
+            REQUIRE(mapping.edit(2).sequence().empty());
+        }
+
+        SECTION("Deletion, right") {
+
+            normalize_indel_adjustment(aln, false, graph);
+
+            const auto& path = aln.path();
+            REQUIRE(path.mapping_size() == 1);
+            const auto& mapping = path.mapping(0);
+            REQUIRE(mapping.edit_size() == 3);
+            REQUIRE(make_pos_t(mapping.position()) == make_pos_t(graph.get_id(h), false, 0));
+            REQUIRE(mapping.edit(0).from_length() == 5);
+            REQUIRE(mapping.edit(0).to_length() == 5);
+            REQUIRE(mapping.edit(0).sequence().empty());
+            REQUIRE(mapping.edit(1).from_length() == 2);
+            REQUIRE(mapping.edit(1).to_length() == 0);
+            REQUIRE(mapping.edit(1).sequence().empty());
+            REQUIRE(mapping.edit(2).from_length() == 1);
+            REQUIRE(mapping.edit(2).to_length() == 1);
+            REQUIRE(mapping.edit(2).sequence().empty());
+        }
+
+        // switch to insertion
+        aln.set_sequence("TACACACACT");
+
+        e1->set_from_length(5);
+        e1->set_to_length(5);
+
+        e2->set_from_length(0);
+        e2->set_to_length(2);
+        e2->set_sequence("AC");
+
+        SECTION("Consistency") {
+            check_left_right_adj_consistency(aln, graph);
+        }
+
+        SECTION("Insertion, left"){
+
+            
+
+            normalize_indel_adjustment(aln, true, graph);
+
+            const auto& path = aln.path();
+            REQUIRE(path.mapping_size() == 1);
+            const auto& mapping = path.mapping(0);
+            REQUIRE(mapping.edit_size() == 3);
+            REQUIRE(make_pos_t(mapping.position()) == make_pos_t(graph.get_id(h), false, 0));
+            REQUIRE(mapping.edit(0).from_length() == 1);
+            REQUIRE(mapping.edit(0).to_length() == 1);
+            REQUIRE(mapping.edit(0).sequence().empty());
+            REQUIRE(mapping.edit(1).from_length() == 0);
+            REQUIRE(mapping.edit(1).to_length() == 2);
+            REQUIRE(mapping.edit(1).sequence() == "AC");
+            REQUIRE(mapping.edit(2).from_length() == 7);
+            REQUIRE(mapping.edit(2).to_length() == 7);
+            REQUIRE(mapping.edit(2).sequence().empty());
+        }
+
+        SECTION("Insertion, right"){
+
+            normalize_indel_adjustment(aln, false, graph);
+
+            const auto& path = aln.path();
+            REQUIRE(path.mapping_size() == 1);
+            const auto& mapping = path.mapping(0);
+            REQUIRE(mapping.edit_size() == 3);
+            REQUIRE(make_pos_t(mapping.position()) == make_pos_t(graph.get_id(h), false, 0));
+            REQUIRE(mapping.edit(0).from_length() == 7);
+            REQUIRE(mapping.edit(0).to_length() == 7);
+            REQUIRE(mapping.edit(0).sequence().empty());
+            REQUIRE(mapping.edit(1).from_length() == 0);
+            REQUIRE(mapping.edit(1).to_length() == 2);
+            REQUIRE(mapping.edit(1).sequence() == "AC");
+            REQUIRE(mapping.edit(2).from_length() == 1);
+            REQUIRE(mapping.edit(2).to_length() == 1);
+            REQUIRE(mapping.edit(2).sequence().empty());
+        }
+    }
+
+    SECTION("Across multiple nodes") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("TTTTACGACGACG");
+        auto h2 = graph.create_handle("A");
+        auto h3 = graph.create_handle("CG");
+        auto h4 = graph.create_handle("AC");
+        auto h5 = graph.create_handle("GAC");
+        auto h6 = graph.create_handle("G");
+        auto h7 = graph.create_handle("ACGTTTT");
+
+        graph.create_edge(h1, h2);
+        graph.create_edge(h2, h3);
+        graph.create_edge(h3, h4);
+        graph.create_edge(h4, h5);
+        graph.create_edge(h5, h6);
+        graph.create_edge(h6, h7);
+
+        SECTION("Insertion"){
+
+            Alignment aln;
+            aln.set_sequence("TTACGACGACGACGACGACGACGACGACGTT");
+
+            auto path = aln.mutable_path();
+
+            auto m1 = path->add_mapping();
+            auto p1 = m1->mutable_position();
+            p1->set_node_id(graph.get_id(h1));
+            p1->set_is_reverse(false);
+            p1->set_offset(2);
+            auto e11 = m1->add_edit();
+            e11->set_from_length(5);
+            e11->set_to_length(5);
+            auto e12 = m1->add_edit();
+            e12->set_from_length(0);
+            e12->set_to_length(6);
+            auto e13 = m1->add_edit();
+            e13->set_from_length(6);
+            e13->set_to_length(6);
+
+            auto m2 = path->add_mapping();
+            auto p2 = m2->mutable_position();
+            p2->set_node_id(graph.get_id(h2));
+            p2->set_is_reverse(false);
+            p2->set_offset(0);
+            auto e2 = m2->add_edit();
+            e2->set_from_length(1);
+            e2->set_to_length(1);
+
+            auto m3 = path->add_mapping();
+            auto p3 = m3->mutable_position();
+            p3->set_node_id(graph.get_id(h3));
+            p3->set_is_reverse(false);
+            p3->set_offset(0);
+            auto e3 = m3->add_edit();
+            e3->set_from_length(2);
+            e3->set_to_length(2);
+
+            auto m4 = path->add_mapping();
+            auto p4 = m4->mutable_position();
+            p4->set_node_id(graph.get_id(h4));
+            p4->set_is_reverse(false);
+            p4->set_offset(0);
+            auto e4 = m4->add_edit();
+            e4->set_from_length(2);
+            e4->set_to_length(2);
+
+            auto m5 = path->add_mapping();
+            auto p5 = m5->mutable_position();
+            p5->set_node_id(graph.get_id(h5));
+            p5->set_is_reverse(false);
+            p5->set_offset(0);
+            auto e5 = m5->add_edit();
+            e5->set_from_length(3);
+            e5->set_to_length(3);
+
+            auto m6 = path->add_mapping();
+            auto p6 = m6->mutable_position();
+            p6->set_node_id(graph.get_id(h6));
+            p6->set_is_reverse(false);
+            p6->set_offset(0);
+            auto e6 = m6->add_edit();
+            e6->set_from_length(1);
+            e6->set_to_length(1);
+
+            auto m7 = path->add_mapping();
+            auto p7 = m7->mutable_position();
+            p7->set_node_id(graph.get_id(h7));
+            p7->set_is_reverse(false);
+            p7->set_offset(0);
+            auto e7 = m7->add_edit();
+            e7->set_from_length(5);
+            e7->set_to_length(5);
+
+            SECTION("Consistency") {
+                check_left_right_adj_consistency(aln, graph);
+            }
+
+            normalize_indel_adjustment(aln, false, graph);
+
+            REQUIRE(path->mapping_size() == 7);
+
+            REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h1), false, 2));
+            REQUIRE(path->mapping(0).edit_size() == 1);
+            REQUIRE(path->mapping(0).edit(0).from_length() == 11);
+            REQUIRE(path->mapping(0).edit(0).to_length() == 11);
+            REQUIRE(path->mapping(0).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(1).position()) == pos_t(graph.get_id(h2), false, 0));
+            REQUIRE(path->mapping(1).edit_size() == 1);
+            REQUIRE(path->mapping(1).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(1).edit(0).to_length() == 1);
+            REQUIRE(path->mapping(1).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(2).position()) == pos_t(graph.get_id(h3), false, 0));
+            REQUIRE(path->mapping(2).edit_size() == 1);
+            REQUIRE(path->mapping(2).edit(0).from_length() == 2);
+            REQUIRE(path->mapping(2).edit(0).to_length() == 2);
+            REQUIRE(path->mapping(2).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(3).position()) == pos_t(graph.get_id(h4), false, 0));
+            REQUIRE(path->mapping(3).edit_size() == 1);
+            REQUIRE(path->mapping(3).edit(0).from_length() == 2);
+            REQUIRE(path->mapping(3).edit(0).to_length() == 2);
+            REQUIRE(path->mapping(3).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(4).position()) == pos_t(graph.get_id(h5), false, 0));
+            REQUIRE(path->mapping(4).edit_size() == 1);
+            REQUIRE(path->mapping(4).edit(0).from_length() == 3);
+            REQUIRE(path->mapping(4).edit(0).to_length() == 3);
+            REQUIRE(path->mapping(4).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(5).position()) == pos_t(graph.get_id(h6), false, 0));
+            REQUIRE(path->mapping(5).edit_size() == 1);
+            REQUIRE(path->mapping(5).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(5).edit(0).to_length() == 1);
+            REQUIRE(path->mapping(5).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(6).position()) == pos_t(graph.get_id(h7), false, 0));
+            REQUIRE(path->mapping(6).edit_size() == 3);
+            REQUIRE(path->mapping(6).edit(0).from_length() == 3);
+            REQUIRE(path->mapping(6).edit(0).to_length() == 3);
+            REQUIRE(path->mapping(6).edit(0).sequence().empty());
+            REQUIRE(path->mapping(6).edit(1).from_length() == 0);
+            REQUIRE(path->mapping(6).edit(1).to_length() == 6);
+            REQUIRE(path->mapping(6).edit(1).sequence() == "ACGACG");
+            REQUIRE(path->mapping(6).edit(2).from_length() == 2);
+            REQUIRE(path->mapping(6).edit(2).to_length() == 2);
+            REQUIRE(path->mapping(6).edit(2).sequence().empty());
+
+            
+        }
+
+        SECTION("Deletion") {
+            
+            Alignment aln;
+            aln.set_sequence("TTACGACGACGACGACGTT");
+
+            auto path = aln.mutable_path();
+
+            auto m1 = path->add_mapping();
+            auto p1 = m1->mutable_position();
+            p1->set_node_id(graph.get_id(h1));
+            p1->set_is_reverse(false);
+            p1->set_offset(2);
+            auto e11 = m1->add_edit();
+            e11->set_from_length(3);
+            e11->set_to_length(3);
+            auto e12 = m1->add_edit();
+            e12->set_from_length(6);
+            e12->set_to_length(0);
+            auto e13 = m1->add_edit();
+            e13->set_from_length(2);
+            e13->set_to_length(2);
+
+            auto m2 = path->add_mapping();
+            auto p2 = m2->mutable_position();
+            p2->set_node_id(graph.get_id(h2));
+            p2->set_is_reverse(false);
+            p2->set_offset(0);
+            auto e2 = m2->add_edit();
+            e2->set_from_length(1);
+            e2->set_to_length(1);
+
+            auto m3 = path->add_mapping();
+            auto p3 = m3->mutable_position();
+            p3->set_node_id(graph.get_id(h3));
+            p3->set_is_reverse(false);
+            p3->set_offset(0);
+            auto e3 = m3->add_edit();
+            e3->set_from_length(2);
+            e3->set_to_length(2);
+
+            auto m4 = path->add_mapping();
+            auto p4 = m4->mutable_position();
+            p4->set_node_id(graph.get_id(h4));
+            p4->set_is_reverse(false);
+            p4->set_offset(0);
+            auto e4 = m4->add_edit();
+            e4->set_from_length(2);
+            e4->set_to_length(2);
+
+            auto m5 = path->add_mapping();
+            auto p5 = m5->mutable_position();
+            p5->set_node_id(graph.get_id(h5));
+            p5->set_is_reverse(false);
+            p5->set_offset(0);
+            auto e5 = m5->add_edit();
+            e5->set_from_length(3);
+            e5->set_to_length(3);
+
+            auto m6 = path->add_mapping();
+            auto p6 = m6->mutable_position();
+            p6->set_node_id(graph.get_id(h6));
+            p6->set_is_reverse(false);
+            p6->set_offset(0);
+            auto e6 = m6->add_edit();
+            e6->set_from_length(1);
+            e6->set_to_length(1);
+
+            auto m7 = path->add_mapping();
+            auto p7 = m7->mutable_position();
+            p7->set_node_id(graph.get_id(h7));
+            p7->set_is_reverse(false);
+            p7->set_offset(0);
+            auto e7 = m7->add_edit();
+            e7->set_from_length(5);
+            e7->set_to_length(5);
+
+            SECTION("Consistency") {
+                check_left_right_adj_consistency(aln, graph);
+            }
+
+            normalize_indel_adjustment(aln, false, graph);
+
+            REQUIRE(path->mapping_size() == 7);
+
+            REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h1), false, 2));
+            REQUIRE(path->mapping(0).edit_size() == 1);
+            REQUIRE(path->mapping(0).edit(0).from_length() == 11);
+            REQUIRE(path->mapping(0).edit(0).to_length() == 11);
+            REQUIRE(path->mapping(0).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(1).position()) == pos_t(graph.get_id(h2), false, 0));
+            REQUIRE(path->mapping(1).edit_size() == 1);
+            REQUIRE(path->mapping(1).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(1).edit(0).to_length() == 1);
+            REQUIRE(path->mapping(1).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(2).position()) == pos_t(graph.get_id(h3), false, 0));
+            REQUIRE(path->mapping(2).edit_size() == 1);
+            REQUIRE(path->mapping(2).edit(0).from_length() == 2);
+            REQUIRE(path->mapping(2).edit(0).to_length() == 2);
+            REQUIRE(path->mapping(2).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(3).position()) == pos_t(graph.get_id(h4), false, 0));
+            REQUIRE(path->mapping(3).edit_size() == 1);
+            REQUIRE(path->mapping(3).edit(0).from_length() == 2);
+            REQUIRE(path->mapping(3).edit(0).to_length() == 2);
+            REQUIRE(path->mapping(3).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(4).position()) == pos_t(graph.get_id(h5), false, 0));
+            REQUIRE(path->mapping(4).edit_size() == 2);
+            REQUIRE(path->mapping(4).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(4).edit(0).to_length() == 1);
+            REQUIRE(path->mapping(4).edit(1).from_length() == 2);
+            REQUIRE(path->mapping(4).edit(1).to_length() == 0);
+            REQUIRE(path->mapping(4).edit(1).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(5).position()) == pos_t(graph.get_id(h6), false, 0));
+            REQUIRE(path->mapping(5).edit_size() == 1);
+            REQUIRE(path->mapping(5).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(5).edit(0).to_length() == 0);
+            REQUIRE(path->mapping(5).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(6).position()) == pos_t(graph.get_id(h7), false, 0));
+            REQUIRE(path->mapping(6).edit_size() == 2);
+            REQUIRE(path->mapping(6).edit(0).from_length() == 3);
+            REQUIRE(path->mapping(6).edit(0).to_length() == 0);
+            REQUIRE(path->mapping(6).edit(0).sequence().empty());
+            REQUIRE(path->mapping(6).edit(1).from_length() == 2);
+            REQUIRE(path->mapping(6).edit(1).to_length() == 2);
+            REQUIRE(path->mapping(6).edit(1).sequence().empty());
+        }
+    }
+
+    SECTION("Does not perform incorrect shifts") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("ACGTACGTACGT");
+
+        SECTION("Unmovable deletion"){
+
+            Alignment aln;
+            aln.set_sequence("ACGTCGTACGT");
+
+            auto path = aln.mutable_path();
+            auto m = path->add_mapping();
+            auto p = m->mutable_position();
+            p->set_node_id(graph.get_id(h1));
+            p->set_is_reverse(false);
+            p->set_offset(0);
+            auto e1 = m->add_edit();
+            e1->set_from_length(4);
+            e1->set_to_length(4);
+            auto e2 = m->add_edit();
+            e2->set_from_length(1);
+            e2->set_to_length(0);
+            auto e3 = m->add_edit();
+            e3->set_from_length(7);
+            e3->set_to_length(7);
+
+            auto aln_copy = aln;
+
+            for (bool left : {true, false}) {
+                normalize_indel_adjustment(aln, left, graph);
+                paths_equivalent(aln.path(), aln_copy.path());
+            }
+        }
+
+        SECTION("Unmovable insertion"){
+
+            Alignment aln;
+            aln.set_sequence("ACGTACGATACGT");
+
+            auto path = aln.mutable_path();
+            auto m = path->add_mapping();
+            auto p = m->mutable_position();
+            p->set_node_id(graph.get_id(h1));
+            p->set_is_reverse(false);
+            p->set_offset(0);
+            auto e1 = m->add_edit();
+            e1->set_from_length(7);
+            e1->set_to_length(7);
+            auto e2 = m->add_edit();
+            e2->set_from_length(0);
+            e2->set_to_length(1);
+            e2->set_sequence("A");
+            auto e3 = m->add_edit();
+            e3->set_from_length(5);
+            e3->set_to_length(5);
+
+            auto aln_copy = aln;
+
+            for (bool left : {true, false}) {
+                normalize_indel_adjustment(aln, left, graph);
+                paths_equivalent(aln.path(), aln_copy.path());
+            }
+        }        
+    }
+
+    SECTION("Merge insertions/deletions as adjusting") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("TTTTACGACGACG");
+        auto h2 = graph.create_handle("A");
+        auto h3 = graph.create_handle("CG");
+        auto h4 = graph.create_handle("AC");
+        auto h5 = graph.create_handle("GAC");
+        auto h6 = graph.create_handle("G");
+        auto h7 = graph.create_handle("ACGTTTT");
+
+        graph.create_edge(h1, h2);
+        graph.create_edge(h2, h3);
+        graph.create_edge(h3, h4);
+        graph.create_edge(h4, h5);
+        graph.create_edge(h5, h6);
+        graph.create_edge(h6, h7);
+
+        SECTION("Insertion"){
+
+            Alignment aln;
+            aln.set_sequence("TTACGACGACGACGACGACGACGACGACGTT");
+
+            auto path = aln.mutable_path();
+
+            auto m1 = path->add_mapping();
+            auto p1 = m1->mutable_position();
+            p1->set_node_id(graph.get_id(h1));
+            p1->set_is_reverse(false);
+            p1->set_offset(2);
+            auto e11 = m1->add_edit();
+            e11->set_from_length(5);
+            e11->set_to_length(5);
+            auto e12 = m1->add_edit();
+            e12->set_from_length(0);
+            e12->set_to_length(3);
+            e12->set_sequence("ACG");
+            auto e13 = m1->add_edit();
+            e13->set_from_length(6);
+            e13->set_to_length(6);
+
+            auto m2 = path->add_mapping();
+            auto p2 = m2->mutable_position();
+            p2->set_node_id(graph.get_id(h2));
+            p2->set_is_reverse(false);
+            p2->set_offset(0);
+            auto e2 = m2->add_edit();
+            e2->set_from_length(1);
+            e2->set_to_length(1);
+
+            auto m3 = path->add_mapping();
+            auto p3 = m3->mutable_position();
+            p3->set_node_id(graph.get_id(h3));
+            p3->set_is_reverse(false);
+            p3->set_offset(0);
+            auto e31 = m3->add_edit();
+            e31->set_from_length(2);
+            e31->set_to_length(2);
+            auto e32 = m3->add_edit();
+            e32->set_from_length(0);
+            e32->set_to_length(3);
+            e32->set_sequence("ACG");
+
+            auto m4 = path->add_mapping();
+            auto p4 = m4->mutable_position();
+            p4->set_node_id(graph.get_id(h4));
+            p4->set_is_reverse(false);
+            p4->set_offset(0);
+            auto e4 = m4->add_edit();
+            e4->set_from_length(2);
+            e4->set_to_length(2);
+
+            auto m5 = path->add_mapping();
+            auto p5 = m5->mutable_position();
+            p5->set_node_id(graph.get_id(h5));
+            p5->set_is_reverse(false);
+            p5->set_offset(0);
+            auto e5 = m5->add_edit();
+            e5->set_from_length(3);
+            e5->set_to_length(3);
+
+            auto m6 = path->add_mapping();
+            auto p6 = m6->mutable_position();
+            p6->set_node_id(graph.get_id(h6));
+            p6->set_is_reverse(false);
+            p6->set_offset(0);
+            auto e6 = m6->add_edit();
+            e6->set_from_length(1);
+            e6->set_to_length(1);
+
+            auto m7 = path->add_mapping();
+            auto p7 = m7->mutable_position();
+            p7->set_node_id(graph.get_id(h7));
+            p7->set_is_reverse(false);
+            p7->set_offset(0);
+            auto e7 = m7->add_edit();
+            e7->set_from_length(5);
+            e7->set_to_length(5);
+
+            auto aln_copy = aln;
+
+            normalize_indel_adjustment(aln, false, graph);
+
+            REQUIRE(path->mapping_size() == 7);
+
+            REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h1), false, 2));
+            REQUIRE(path->mapping(0).edit_size() == 1);
+            REQUIRE(path->mapping(0).edit(0).from_length() == 11);
+            REQUIRE(path->mapping(0).edit(0).to_length() == 11);
+            REQUIRE(path->mapping(0).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(1).position()) == pos_t(graph.get_id(h2), false, 0));
+            REQUIRE(path->mapping(1).edit_size() == 1);
+            REQUIRE(path->mapping(1).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(1).edit(0).to_length() == 1);
+            REQUIRE(path->mapping(1).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(2).position()) == pos_t(graph.get_id(h3), false, 0));
+            REQUIRE(path->mapping(2).edit_size() == 1);
+            REQUIRE(path->mapping(2).edit(0).from_length() == 2);
+            REQUIRE(path->mapping(2).edit(0).to_length() == 2);
+            REQUIRE(path->mapping(2).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(3).position()) == pos_t(graph.get_id(h4), false, 0));
+            REQUIRE(path->mapping(3).edit_size() == 1);
+            REQUIRE(path->mapping(3).edit(0).from_length() == 2);
+            REQUIRE(path->mapping(3).edit(0).to_length() == 2);
+            REQUIRE(path->mapping(3).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(4).position()) == pos_t(graph.get_id(h5), false, 0));
+            REQUIRE(path->mapping(4).edit_size() == 1);
+            REQUIRE(path->mapping(4).edit(0).from_length() == 3);
+            REQUIRE(path->mapping(4).edit(0).to_length() == 3);
+            REQUIRE(path->mapping(4).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(5).position()) == pos_t(graph.get_id(h6), false, 0));
+            REQUIRE(path->mapping(5).edit_size() == 1);
+            REQUIRE(path->mapping(5).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(5).edit(0).to_length() == 1);
+            REQUIRE(path->mapping(5).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(6).position()) == pos_t(graph.get_id(h7), false, 0));
+            REQUIRE(path->mapping(6).edit_size() == 3);
+            REQUIRE(path->mapping(6).edit(0).from_length() == 3);
+            REQUIRE(path->mapping(6).edit(0).to_length() == 3);
+            REQUIRE(path->mapping(6).edit(0).sequence().empty());
+            REQUIRE(path->mapping(6).edit(1).from_length() == 0);
+            REQUIRE(path->mapping(6).edit(1).to_length() == 6);
+            REQUIRE(path->mapping(6).edit(1).sequence() == "ACGACG");
+            REQUIRE(path->mapping(6).edit(2).from_length() == 2);
+            REQUIRE(path->mapping(6).edit(2).to_length() == 2);
+            REQUIRE(path->mapping(6).edit(2).sequence().empty());
+
+            {
+                // move the insert to the start of a node
+                aln_copy.mutable_path()->mutable_mapping(2)->mutable_edit()->RemoveLast();
+                auto e41 = aln_copy.mutable_path()->mutable_mapping(3)->mutable_edit(0);
+                auto e42 = aln_copy.mutable_path()->mutable_mapping(3)->add_edit();
+                *e42 = *e41;
+                e41->set_to_length(3);
+                e41->set_from_length(0);
+                e41->set_sequence("ACG");
+
+                normalize_indel_adjustment(aln_copy, false, graph);
+
+                paths_equivalent(aln.path(), aln_copy.path());
+            }
+        }
+
+        SECTION("Deletion") {
+            
+            Alignment aln;
+            aln.set_sequence("TTACGACGACGACGACGTT");
+
+            auto path = aln.mutable_path();
+
+            auto m1 = path->add_mapping();
+            auto p1 = m1->mutable_position();
+            p1->set_node_id(graph.get_id(h1));
+            p1->set_is_reverse(false);
+            p1->set_offset(2);
+            auto e11 = m1->add_edit();
+            e11->set_from_length(9);
+            e11->set_to_length(9);
+            auto e12 = m1->add_edit();
+            e12->set_from_length(2);
+            e12->set_to_length(0);
+
+            auto m2 = path->add_mapping();
+            auto p2 = m2->mutable_position();
+            p2->set_node_id(graph.get_id(h2));
+            p2->set_is_reverse(false);
+            p2->set_offset(0);
+            auto e2 = m2->add_edit();
+            e2->set_from_length(1);
+            e2->set_to_length(0);
+
+            auto m3 = path->add_mapping();
+            auto p3 = m3->mutable_position();
+            p3->set_node_id(graph.get_id(h3));
+            p3->set_is_reverse(false);
+            p3->set_offset(0);
+            auto e3 = m3->add_edit();
+            e3->set_from_length(2);
+            e3->set_to_length(2);
+
+            auto m4 = path->add_mapping();
+            auto p4 = m4->mutable_position();
+            p4->set_node_id(graph.get_id(h4));
+            p4->set_is_reverse(false);
+            p4->set_offset(0);
+            auto e4 = m4->add_edit();
+            e4->set_from_length(2);
+            e4->set_to_length(2);
+
+            auto m5 = path->add_mapping();
+            auto p5 = m5->mutable_position();
+            p5->set_node_id(graph.get_id(h5));
+            p5->set_is_reverse(false);
+            p5->set_offset(0);
+            auto e51 = m5->add_edit();
+            e51->set_from_length(2);
+            e51->set_to_length(2);
+            auto e52 = m5->add_edit();
+            e52->set_from_length(1);
+            e52->set_to_length(0);
+
+            auto m6 = path->add_mapping();
+            auto p6 = m6->mutable_position();
+            p6->set_node_id(graph.get_id(h6));
+            p6->set_is_reverse(false);
+            p6->set_offset(0);
+            auto e6 = m6->add_edit();
+            e6->set_from_length(1);
+            e6->set_to_length(0);
+
+            auto m7 = path->add_mapping();
+            auto p7 = m7->mutable_position();
+            p7->set_node_id(graph.get_id(h7));
+            p7->set_is_reverse(false);
+            p7->set_offset(0);
+            auto e71 = m7->add_edit();
+            e71->set_from_length(1);
+            e71->set_to_length(0);
+            auto e72 = m7->add_edit();
+            e72->set_from_length(4);
+            e72->set_to_length(4);
+
+            normalize_indel_adjustment(aln, false, graph);
+
+            REQUIRE(path->mapping_size() == 7);
+
+            REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h1), false, 2));
+            REQUIRE(path->mapping(0).edit_size() == 1);
+            REQUIRE(path->mapping(0).edit(0).from_length() == 11);
+            REQUIRE(path->mapping(0).edit(0).to_length() == 11);
+            REQUIRE(path->mapping(0).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(1).position()) == pos_t(graph.get_id(h2), false, 0));
+            REQUIRE(path->mapping(1).edit_size() == 1);
+            REQUIRE(path->mapping(1).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(1).edit(0).to_length() == 1);
+            REQUIRE(path->mapping(1).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(2).position()) == pos_t(graph.get_id(h3), false, 0));
+            REQUIRE(path->mapping(2).edit_size() == 1);
+            REQUIRE(path->mapping(2).edit(0).from_length() == 2);
+            REQUIRE(path->mapping(2).edit(0).to_length() == 2);
+            REQUIRE(path->mapping(2).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(3).position()) == pos_t(graph.get_id(h4), false, 0));
+            REQUIRE(path->mapping(3).edit_size() == 1);
+            REQUIRE(path->mapping(3).edit(0).from_length() == 2);
+            REQUIRE(path->mapping(3).edit(0).to_length() == 2);
+            REQUIRE(path->mapping(3).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(4).position()) == pos_t(graph.get_id(h5), false, 0));
+            REQUIRE(path->mapping(4).edit_size() == 2);
+            REQUIRE(path->mapping(4).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(4).edit(0).to_length() == 1);
+            REQUIRE(path->mapping(4).edit(1).from_length() == 2);
+            REQUIRE(path->mapping(4).edit(1).to_length() == 0);
+            REQUIRE(path->mapping(4).edit(1).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(5).position()) == pos_t(graph.get_id(h6), false, 0));
+            REQUIRE(path->mapping(5).edit_size() == 1);
+            REQUIRE(path->mapping(5).edit(0).from_length() == 1);
+            REQUIRE(path->mapping(5).edit(0).to_length() == 0);
+            REQUIRE(path->mapping(5).edit(0).sequence().empty());
+
+            REQUIRE(make_pos_t(path->mapping(6).position()) == pos_t(graph.get_id(h7), false, 0));
+            REQUIRE(path->mapping(6).edit_size() == 2);
+            REQUIRE(path->mapping(6).edit(0).from_length() == 3);
+            REQUIRE(path->mapping(6).edit(0).to_length() == 0);
+            REQUIRE(path->mapping(6).edit(0).sequence().empty());
+            REQUIRE(path->mapping(6).edit(1).from_length() == 2);
+            REQUIRE(path->mapping(6).edit(1).to_length() == 2);
+            REQUIRE(path->mapping(6).edit(1).sequence().empty());
+        }
+    }
+
+    SECTION("Insertions and deletions can cancel each other out") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("TTTTACGACGACG");
+        auto h2 = graph.create_handle("A");
+        auto h3 = graph.create_handle("CG");
+        auto h4 = graph.create_handle("AC");
+        auto h5 = graph.create_handle("GAC");
+        auto h6 = graph.create_handle("G");
+        auto h7 = graph.create_handle("ACGTTTT");
+
+        graph.create_edge(h1, h2);
+        graph.create_edge(h2, h3);
+        graph.create_edge(h3, h4);
+        graph.create_edge(h4, h5);
+        graph.create_edge(h5, h6);
+        graph.create_edge(h6, h7);
+
+        Alignment aln;
+        aln.set_sequence("TTACGACGACGACGACGACGACGTT");
+
+        auto path = aln.mutable_path();
+
+        auto m1 = path->add_mapping();
+        auto p1 = m1->mutable_position();
+        p1->set_node_id(graph.get_id(h1));
+        p1->set_is_reverse(false);
+        p1->set_offset(2);
+        auto e11 = m1->add_edit();
+        e11->set_from_length(5);
+        e11->set_to_length(5);
+        auto e12 = m1->add_edit();
+        e12->set_from_length(6);
+        e12->set_to_length(0);
+
+        auto m2 = path->add_mapping();
+        auto p2 = m2->mutable_position();
+        p2->set_node_id(graph.get_id(h2));
+        p2->set_is_reverse(false);
+        p2->set_offset(0);
+        auto e2 = m2->add_edit();
+        e2->set_from_length(1);
+        e2->set_to_length(1);
+
+        auto m3 = path->add_mapping();
+        auto p3 = m3->mutable_position();
+        p3->set_node_id(graph.get_id(h3));
+        p3->set_is_reverse(false);
+        p3->set_offset(0);
+        auto e3 = m3->add_edit();
+        e3->set_from_length(2);
+        e3->set_to_length(2);
+
+        auto m4 = path->add_mapping();
+        auto p4 = m4->mutable_position();
+        p4->set_node_id(graph.get_id(h4));
+        p4->set_is_reverse(false);
+        p4->set_offset(0);
+        auto e4 = m4->add_edit();
+        e4->set_from_length(2);
+        e4->set_to_length(2);
+
+        auto m5 = path->add_mapping();
+        auto p5 = m5->mutable_position();
+        p5->set_node_id(graph.get_id(h5));
+        p5->set_is_reverse(false);
+        p5->set_offset(0);
+        auto e51 = m5->add_edit();
+        e51->set_from_length(0);
+        e51->set_to_length(6);
+        e51->set_sequence("GACGAC");
+        auto e52 = m5->add_edit();
+        e52->set_from_length(3);
+        e52->set_to_length(3);
+
+        auto m6 = path->add_mapping();
+        auto p6 = m6->mutable_position();
+        p6->set_node_id(graph.get_id(h6));
+        p6->set_is_reverse(false);
+        p6->set_offset(0);
+        auto e6 = m6->add_edit();
+        e6->set_from_length(1);
+        e6->set_to_length(1);
+
+        auto m7 = path->add_mapping();
+        auto p7 = m7->mutable_position();
+        p7->set_node_id(graph.get_id(h7));
+        p7->set_is_reverse(false);
+        p7->set_offset(0);
+        auto e7 = m7->add_edit();
+        e7->set_from_length(5);
+        e7->set_to_length(5);
+
+        check_left_right_adj_consistency(aln, graph);
+
+        normalize_indel_adjustment(aln, false, graph);
+
+        REQUIRE(path->mapping_size() == 7);
+
+        REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h1), false, 2));
+        REQUIRE(path->mapping(0).edit_size() == 1);
+        REQUIRE(path->mapping(0).edit(0).from_length() == 11);
+        REQUIRE(path->mapping(0).edit(0).to_length() == 11);
+        REQUIRE(path->mapping(0).edit(0).sequence().empty());
+
+        REQUIRE(make_pos_t(path->mapping(1).position()) == pos_t(graph.get_id(h2), false, 0));
+        REQUIRE(path->mapping(1).edit_size() == 1);
+        REQUIRE(path->mapping(1).edit(0).from_length() == 1);
+        REQUIRE(path->mapping(1).edit(0).to_length() == 1);
+        REQUIRE(path->mapping(1).edit(0).sequence().empty());
+
+        REQUIRE(make_pos_t(path->mapping(2).position()) == pos_t(graph.get_id(h3), false, 0));
+        REQUIRE(path->mapping(2).edit_size() == 1);
+        REQUIRE(path->mapping(2).edit(0).from_length() == 2);
+        REQUIRE(path->mapping(2).edit(0).to_length() == 2);
+        REQUIRE(path->mapping(2).edit(0).sequence().empty());
+
+        REQUIRE(make_pos_t(path->mapping(3).position()) == pos_t(graph.get_id(h4), false, 0));
+        REQUIRE(path->mapping(3).edit_size() == 1);
+        REQUIRE(path->mapping(3).edit(0).from_length() == 2);
+        REQUIRE(path->mapping(3).edit(0).to_length() == 2);
+        REQUIRE(path->mapping(3).edit(0).sequence().empty());
+
+        REQUIRE(make_pos_t(path->mapping(4).position()) == pos_t(graph.get_id(h5), false, 0));
+        REQUIRE(path->mapping(4).edit_size() == 1);
+        REQUIRE(path->mapping(4).edit(0).from_length() == 3);
+        REQUIRE(path->mapping(4).edit(0).to_length() == 3);
+        REQUIRE(path->mapping(4).edit(0).sequence().empty());
+
+        REQUIRE(make_pos_t(path->mapping(5).position()) == pos_t(graph.get_id(h6), false, 0));
+        REQUIRE(path->mapping(5).edit_size() == 1);
+        REQUIRE(path->mapping(5).edit(0).from_length() == 1);
+        REQUIRE(path->mapping(5).edit(0).to_length() == 1);
+        REQUIRE(path->mapping(5).edit(0).sequence().empty());
+
+        REQUIRE(make_pos_t(path->mapping(6).position()) == pos_t(graph.get_id(h7), false, 0));
+        REQUIRE(path->mapping(6).edit_size() == 1);
+        REQUIRE(path->mapping(6).edit(0).from_length() == 5);
+        REQUIRE(path->mapping(6).edit(0).to_length() == 5);
+        REQUIRE(path->mapping(6).edit(0).sequence().empty());
+    }
+
+    SECTION("Left/right-aligning indels shifting appropriately handles softclips") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("TTAAAAAATT");
+        auto h2 = graph.create_handle("TTAC");
+        auto h3 = graph.create_handle("ACAC");
+        auto h4 = graph.create_handle("ACTT");
+
+        graph.create_edge(h2, h3);
+        graph.create_edge(h3, h4);
+
+        Alignment aln;
+
+        aln.set_sequence("GGGAAAAAAAAGGG");
+
+        auto path = aln.mutable_path();
+
+        auto m = path->add_mapping();
+        auto p = m->mutable_position();
+        p->set_node_id(graph.get_id(h1));
+        p->set_is_reverse(false);
+        p->set_offset(2);
+
+        auto e1 = m->add_edit();
+        e1->set_from_length(0);
+        e1->set_to_length(3);
+        e1->set_sequence("GGG");
+
+        auto e2 = m->add_edit();
+        e2->set_from_length(3);
+        e2->set_to_length(3);
+
+        auto e3 = m->add_edit();
+        e3->set_from_length(0);
+        e3->set_to_length(2);
+        e3->set_sequence("AA");
+
+        auto e4 = m->add_edit();
+        e4->set_from_length(3);
+        e4->set_to_length(3);
+
+        auto e5 = m->add_edit();
+        e5->set_from_length(0);
+        e5->set_to_length(3);
+        e5->set_sequence("GGG");
+
+        SECTION("Shift insertion right") {
+
+            normalize_indel_adjustment(aln, false, graph);
+
+            REQUIRE(path->mapping_size() == 1);
+
+            REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h1), false, 2));
+            REQUIRE(path->mapping(0).edit_size() == 3);
+
+            REQUIRE(path->mapping(0).edit(0).from_length() == 0);
+            REQUIRE(path->mapping(0).edit(0).to_length() == 3);
+            REQUIRE(path->mapping(0).edit(0).sequence() == "GGG");
+
+            REQUIRE(path->mapping(0).edit(1).from_length() == 6);
+            REQUIRE(path->mapping(0).edit(1).to_length() == 6);
+            REQUIRE(path->mapping(0).edit(1).sequence().empty());
+
+            REQUIRE(path->mapping(0).edit(2).from_length() == 0);
+            REQUIRE(path->mapping(0).edit(2).to_length() == 5);
+            REQUIRE(path->mapping(0).edit(2).sequence() == "AAGGG");
+        }
+
+        SECTION("Shift insertion left") {
+
+            normalize_indel_adjustment(aln, true, graph);
+
+            REQUIRE(path->mapping_size() == 1);
+
+            REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h1), false, 2));
+            REQUIRE(path->mapping(0).edit_size() == 3);
+
+            REQUIRE(path->mapping(0).edit(0).from_length() == 0);
+            REQUIRE(path->mapping(0).edit(0).to_length() == 5);
+            REQUIRE(path->mapping(0).edit(0).sequence() == "GGGAA");
+
+            REQUIRE(path->mapping(0).edit(1).from_length() == 6);
+            REQUIRE(path->mapping(0).edit(1).to_length() == 6);
+            REQUIRE(path->mapping(0).edit(1).sequence().empty());
+
+            REQUIRE(path->mapping(0).edit(2).from_length() == 0);
+            REQUIRE(path->mapping(0).edit(2).to_length() == 3);
+            REQUIRE(path->mapping(0).edit(2).sequence() == "GGG");
+        }
+
+        // convert to a deletino
+        aln.set_sequence("GGGAAAAGGG");
+
+        e2->set_from_length(2);
+        e2->set_to_length(2);
+
+        e3->set_from_length(2);
+        e3->set_to_length(0);
+        e3->set_sequence("");
+
+        e4->set_from_length(2);
+        e4->set_to_length(2);
+
+        SECTION("Shift deletion to the right") {
+
+            normalize_indel_adjustment(aln, false, graph);
+
+            REQUIRE(path->mapping_size() == 1);
+
+            REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h1), false, 2));
+            REQUIRE(path->mapping(0).edit_size() == 3);
+
+            REQUIRE(path->mapping(0).edit(0).from_length() == 0);
+            REQUIRE(path->mapping(0).edit(0).to_length() == 3);
+            REQUIRE(path->mapping(0).edit(0).sequence() == "GGG");
+
+            REQUIRE(path->mapping(0).edit(1).from_length() == 4);
+            REQUIRE(path->mapping(0).edit(1).to_length() == 4);
+            REQUIRE(path->mapping(0).edit(1).sequence().empty());
+
+            REQUIRE(path->mapping(0).edit(2).from_length() == 0);
+            REQUIRE(path->mapping(0).edit(2).to_length() == 3);
+            REQUIRE(path->mapping(0).edit(2).sequence() == "GGG");
+        } 
+
+        SECTION("Shift deletion to the left") {
+
+            normalize_indel_adjustment(aln, true, graph);
+
+            REQUIRE(path->mapping_size() == 1);
+
+            REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h1), false, 4));
+            REQUIRE(path->mapping(0).edit_size() == 3);
+
+            REQUIRE(path->mapping(0).edit(0).from_length() == 0);
+            REQUIRE(path->mapping(0).edit(0).to_length() == 3);
+            REQUIRE(path->mapping(0).edit(0).sequence() == "GGG");
+
+            REQUIRE(path->mapping(0).edit(1).from_length() == 4);
+            REQUIRE(path->mapping(0).edit(1).to_length() == 4);
+            REQUIRE(path->mapping(0).edit(1).sequence().empty());
+
+            REQUIRE(path->mapping(0).edit(2).from_length() == 0);
+            REQUIRE(path->mapping(0).edit(2).to_length() == 3);
+            REQUIRE(path->mapping(0).edit(2).sequence() == "GGG");
+        }
+
+        SECTION("Shifting deletion over multiple nodes") {
+
+            Alignment aln;
+
+            aln.set_sequence("GGGACACGGG");
+
+            auto path = aln.mutable_path();
+
+            auto m1 = path->add_mapping();
+            auto p1 = m1->mutable_position();
+            p1->set_node_id(graph.get_id(h2));
+            p1->set_is_reverse(false);
+            p1->set_offset(2);
+
+            auto e11 = m1->add_edit();
+            e11->set_from_length(0);
+            e11->set_to_length(3);
+            e11->set_sequence("GGG");
+
+            auto e12 = m1->add_edit();
+            e12->set_from_length(2);
+            e12->set_to_length(2);
+
+            auto m2 = path->add_mapping();
+            auto p2 = m2->mutable_position();
+            p2->set_node_id(graph.get_id(h3));
+            p2->set_is_reverse(false);
+            p2->set_offset(0);
+
+            auto e2 = m2->add_edit();
+            e2->set_from_length(4);
+            e2->set_to_length(0);
+
+            auto m3 = path->add_mapping();
+            auto p3 = m3->mutable_position();
+            p3->set_node_id(graph.get_id(h4));
+            p3->set_is_reverse(false);
+            p3->set_offset(0);
+
+            auto e31 = m3->add_edit();
+            e31->set_from_length(2);
+            e31->set_to_length(2);
+
+            auto e32 = m3->add_edit();
+            e32->set_from_length(0);
+            e32->set_to_length(3);
+            e32->set_sequence("GGG");
+
+            SECTION("To the right") {
+
+                normalize_indel_adjustment(aln, false, graph);
+
+                REQUIRE(path->mapping_size() == 2);
+
+                REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h2), false, 2));
+                REQUIRE(path->mapping(0).edit_size() == 2);
+
+                REQUIRE(path->mapping(0).edit(0).from_length() == 0);
+                REQUIRE(path->mapping(0).edit(0).to_length() == 3);
+                REQUIRE(path->mapping(0).edit(0).sequence() == "GGG");
+
+                REQUIRE(path->mapping(0).edit(1).from_length() == 2);
+                REQUIRE(path->mapping(0).edit(1).to_length() == 2);
+                REQUIRE(path->mapping(0).edit(1).sequence().empty());
+
+                REQUIRE(make_pos_t(path->mapping(1).position()) == pos_t(graph.get_id(h3), false, 0));
+                REQUIRE(path->mapping(1).edit_size() == 2);
+
+                REQUIRE(path->mapping(1).edit(0).from_length() == 2);
+                REQUIRE(path->mapping(1).edit(0).to_length() == 2);
+
+                REQUIRE(path->mapping(1).edit(1).from_length() == 0);
+                REQUIRE(path->mapping(1).edit(1).to_length() == 3);
+                REQUIRE(path->mapping(1).edit(1).sequence() == "GGG");
+            }
+
+            SECTION("To the left") {
+
+                normalize_indel_adjustment(aln, true, graph);
+
+                REQUIRE(path->mapping_size() == 2);
+
+                REQUIRE(make_pos_t(path->mapping(0).position()) == pos_t(graph.get_id(h3), false, 2));
+                REQUIRE(path->mapping(0).edit_size() == 2);
+
+                REQUIRE(path->mapping(0).edit(0).from_length() == 0);
+                REQUIRE(path->mapping(0).edit(0).to_length() == 3);
+                REQUIRE(path->mapping(0).edit(0).sequence() == "GGG");
+
+                REQUIRE(path->mapping(0).edit(1).from_length() == 2);
+                REQUIRE(path->mapping(0).edit(1).to_length() == 2);
+                REQUIRE(path->mapping(0).edit(1).sequence().empty());
+
+                REQUIRE(make_pos_t(path->mapping(1).position()) == pos_t(graph.get_id(h4), false, 0));
+                REQUIRE(path->mapping(1).edit_size() == 2);
+
+                REQUIRE(path->mapping(1).edit(0).from_length() == 2);
+                REQUIRE(path->mapping(1).edit(0).to_length() == 2);
+
+                REQUIRE(path->mapping(1).edit(1).from_length() == 0);
+                REQUIRE(path->mapping(1).edit(1).to_length() == 3);
+                REQUIRE(path->mapping(1).edit(1).sequence() == "GGG");
+            }
+        }
+    }
+}
+
+TEST_CASE("Left alignment properly handles cases involving adjacent insertions and deletions") {
+
+    SECTION("Runs are consolidated before shifting") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("GGAG");
+
+        Alignment aln;
+
+        aln.set_sequence("GGTTAG");
+
+        auto path = aln.mutable_path();
+
+        auto m = path->add_mapping();
+        auto p = m->mutable_position();
+        p->set_node_id(graph.get_id(h1));
+        p->set_is_reverse(false);
+        p->set_offset(0);
+
+        auto e1 = m->add_edit();
+        e1->set_from_length(2);
+        e1->set_to_length(2);
+
+        auto e2 = m->add_edit();
+        e2->set_from_length(0);
+        e2->set_to_length(1);
+        e2->set_sequence("T");
+
+        auto e3 = m->add_edit();
+        e3->set_from_length(1);
+        e3->set_to_length(0);
+
+        auto e4 = m->add_edit();
+        e4->set_from_length(0);
+        e4->set_to_length(2);
+        e4->set_sequence("TA");
+
+        auto e5 = m->add_edit();
+        e5->set_from_length(1);
+        e5->set_to_length(1);
+
+        normalize_indel_adjustment(aln, false, graph);
+
+        REQUIRE(m->edit_size() == 3);
+        REQUIRE(m->edit(0).from_length() == 2);
+        REQUIRE(m->edit(0).to_length() == 2);
+        REQUIRE(m->edit(0).sequence() == "");
+        REQUIRE(m->edit(1).from_length() == 0);
+        REQUIRE(m->edit(1).to_length() == 2);
+        REQUIRE(m->edit(1).sequence() == "TT");
+        REQUIRE(m->edit(2).from_length() == 2);
+        REQUIRE(m->edit(2).to_length() == 2);
+        REQUIRE(m->edit(2).sequence() == "");
+    }
+
+    SECTION("Runs are consolidated before shifting with opposite configuration") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("GGTTAG");
+
+        Alignment aln;
+
+        aln.set_sequence("GGAG");
+
+        auto path = aln.mutable_path();
+
+        auto m = path->add_mapping();
+        auto p = m->mutable_position();
+        p->set_node_id(graph.get_id(h1));
+        p->set_is_reverse(false);
+        p->set_offset(0);
+
+        auto e1 = m->add_edit();
+        e1->set_from_length(2);
+        e1->set_to_length(2);
+
+        auto e2 = m->add_edit();
+        e2->set_from_length(1);
+        e2->set_to_length(0);
+
+        auto e3 = m->add_edit();
+        e3->set_from_length(0);
+        e3->set_to_length(1);
+        e3->set_sequence("A");
+
+        auto e4 = m->add_edit();
+        e4->set_from_length(2);
+        e4->set_to_length(0);
+
+        auto e5 = m->add_edit();
+        e5->set_from_length(1);
+        e5->set_to_length(1);
+
+        normalize_indel_adjustment(aln, false, graph);
+
+        REQUIRE(m->edit_size() == 3);
+        REQUIRE(m->edit(0).from_length() == 2);
+        REQUIRE(m->edit(0).to_length() == 2);
+        REQUIRE(m->edit(0).sequence() == "");
+        REQUIRE(m->edit(1).from_length() == 2);
+        REQUIRE(m->edit(1).to_length() == 0);
+        REQUIRE(m->edit(1).sequence() == "");
+        REQUIRE(m->edit(2).from_length() == 2);
+        REQUIRE(m->edit(2).to_length() == 2);
+        REQUIRE(m->edit(2).sequence() == "");
+    }
+
+
+    SECTION("Left alignment can continue a released shift after cancellation") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("ATGTGGG");
+
+        Alignment aln;
+
+        aln.set_sequence("ATGTGG");
+
+        auto path = aln.mutable_path();
+
+        auto m = path->add_mapping();
+        auto p = m->mutable_position();
+        p->set_node_id(graph.get_id(h1));
+        p->set_is_reverse(false);
+        p->set_offset(0);
+
+        auto e1 = m->add_edit();
+        e1->set_from_length(1);
+        e1->set_to_length(1);
+
+        auto e2 = m->add_edit();
+        e2->set_from_length(2);
+        e2->set_to_length(0);
+
+        auto e3 = m->add_edit();
+        e3->set_from_length(2);
+        e3->set_to_length(2);
+
+        auto e4 = m->add_edit();
+        e4->set_from_length(0);
+        e4->set_to_length(1);
+        e4->set_sequence("T");
+
+        auto e5 = m->add_edit();
+        e5->set_from_length(2);
+        e5->set_to_length(2);
+
+        normalize_indel_adjustment(aln, false, graph);
+
+        REQUIRE(m->edit_size() == 1);
+        REQUIRE(m->edit(0).from_length() == 6);
+        REQUIRE(m->edit(0).to_length() == 6);
+        REQUIRE(m->edit(0).sequence() == "");
+    }
+}
+
+TEST_CASE("Left alignment produces valid results on difficult cases") {
+
+    SECTION("Empirical case 1") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("T", 38183332);
+        auto h2 = graph.create_handle("TC", 38183333);
+        auto h3 = graph.create_handle("C", 38183334);
+        auto h4 = graph.create_handle("A", 38183335);
+        auto h5 = graph.create_handle("T", 38183337);
+        auto h6 = graph.create_handle("T", 38183338);
+        auto h7 = graph.create_handle("C", 38183339);
+        auto h8 = graph.create_handle("C", 38183340);
+        auto h9 = graph.create_handle("A", 38183341);
+        auto h10 = graph.create_handle("T", 38183343);
+        auto h11 = graph.create_handle("TC", 38183344);
+        auto h12 = graph.create_handle("C", 38183345);
+        auto h13 = graph.create_handle("A", 38183347);
+        auto h14 = graph.create_handle("T", 38183348);
+        auto h15 = graph.create_handle("TCC", 38183349);
+        auto h16 = graph.create_handle("A", 38183350);
+        auto h17 = graph.create_handle("T", 38183353);
+        auto h18 = graph.create_handle("T", 38183355);
+        auto h19 = graph.create_handle("C", 38183356);
+        auto h20 = graph.create_handle("C", 38183357);
+        auto h21 = graph.create_handle("ATT", 38183359);
+        auto h22 = graph.create_handle("C", 38183360);
+        auto h23 = graph.create_handle("C", 38183361);
+        auto h24 = graph.create_handle("A", 38183362);
+        auto h25 = graph.create_handle("TTC", 38183364);
+        auto h26 = graph.create_handle("C", 38183365);
+        auto h27 = graph.create_handle("A", 38183366);
+        auto h28 = graph.create_handle("TT", 38183368);
+        auto h29 = graph.create_handle("C", 38183369);
+        auto h30 = graph.create_handle("CA", 38183371);
+        auto h31 = graph.create_handle("C", 38183372);
+        auto h32 = graph.create_handle("T", 38183374);
+        auto h33 = graph.create_handle("C", 38183375);
+        auto h34 = graph.create_handle("G", 38183379);
+        auto h35 = graph.create_handle("GG", 38183380);
+        auto h36 = graph.create_handle("T", 38183381);
+        auto h37 = graph.create_handle("T", 38183382);
+        auto h38 = graph.create_handle("G", 38183385);
+        auto h39 = graph.create_handle("A", 38183387);
+        auto h40 = graph.create_handle("T", 38183388);
+        auto h41 = graph.create_handle("T", 38183389);
+        auto h42 = graph.create_handle("C", 38183390);
+        auto h43 = graph.create_handle("C", 38183391);
+        auto h44 = graph.create_handle("A", 38183392);
+        auto h45 = graph.create_handle("T", 38183393);
+        auto h46 = graph.create_handle("T", 38183395);
+        auto h47 = graph.create_handle("C", 38183396);
+        auto h48 = graph.create_handle("C", 38183398);
+        auto h49 = graph.create_handle("A", 38183400);
+        auto h50 = graph.create_handle("T", 38183401);
+        auto h51 = graph.create_handle("T", 38183403);
+        auto h52 = graph.create_handle("C", 38183404);
+        auto h53 = graph.create_handle("A", 38183405);
+        auto h54 = graph.create_handle("A", 38183409);
+        auto h55 = graph.create_handle("TTC", 38183410);
+        auto h56 = graph.create_handle("C", 38183411);
+        auto h57 = graph.create_handle("G", 38183412);
+        auto h58 = graph.create_handle("T", 38183414);
+        auto h59 = graph.create_handle("T", 38183415);
+        auto h60 = graph.create_handle("C", 38183416);
+        auto h61 = graph.create_handle("C", 38183417);
+        auto h62 = graph.create_handle("G", 38183421);
+        auto h63 = graph.create_handle("T", 38183423);
+        auto h64 = graph.create_handle("T", 38183424);
+        auto h65 = graph.create_handle("CC", 38183425);
+        auto h66 = graph.create_handle("G", 38183426);
+        auto h67 = graph.create_handle("TT", 38183428);
+        auto h68 = graph.create_handle("CC", 38183429);
+        auto h69 = graph.create_handle("G", 38183430);
+        auto h70 = graph.create_handle("T", 38183432);
+        auto h71 = graph.create_handle("T", 38183433);
+        auto h72 = graph.create_handle("C", 38183434);
+        auto h73 = graph.create_handle("C", 38183435);
+        auto h74 = graph.create_handle("A", 38183437);
+        auto h75 = graph.create_handle("T", 38183438);
+        auto h76 = graph.create_handle("T", 38183439);
+        auto h77 = graph.create_handle("C", 38183440);
+        auto h78 = graph.create_handle("C", 38183442);
+        auto h79 = graph.create_handle("A", 38183443);
+        auto h80 = graph.create_handle("T", 38183444);
+        auto h81 = graph.create_handle("T", 38183445);
+        auto h82 = graph.create_handle("C", 38183446);
+        auto h83 = graph.create_handle("C", 38183449);
+        auto h84 = graph.create_handle("A", 38183451);
+        auto h85 = graph.create_handle("TT", 38183452);
+        auto h86 = graph.create_handle("C", 38183453);
+        auto h87 = graph.create_handle("C", 38183454);
+        auto h88 = graph.create_handle("A", 38183455);
+        auto h89 = graph.create_handle("T", 38183457);
+        auto h90 = graph.create_handle("T", 38183458);
+        auto h91 = graph.create_handle("T", 38183459);
+        auto h92 = graph.create_handle("C", 38183462);
+        auto h93 = graph.create_handle("AT", 38183463);
+        auto h94 = graph.create_handle("T", 38183464);
+        auto h95 = graph.create_handle("C", 38183466);
+        auto h96 = graph.create_handle("C", 38183467);
+        auto h97 = graph.create_handle("A", 38183469);
+        auto h98 = graph.create_handle("T", 38183470);
+        auto h99 = graph.create_handle("T", 38183472);
+        auto h100 = graph.create_handle("G", 38183473);
+        auto h101 = graph.create_handle("CA", 38183475);
+        auto h102 = graph.create_handle("TTC", 38183476);
+        auto h103 = graph.create_handle("C", 38183477);
+        auto h104 = graph.create_handle("A", 38183479);
+        auto h105 = graph.create_handle("C", 38183480);
+        auto h106 = graph.create_handle("T", 38183482);
+        auto h107 = graph.create_handle("C", 38183483);
+        auto h108 = graph.create_handle("G", 38183485);
+        auto h109 = graph.create_handle("G", 38183486);
+        auto h110 = graph.create_handle("G", 38183487);
+        auto h111 = graph.create_handle("T", 38183488);
+        auto h112 = graph.create_handle("TG", 38183489);
+        auto h113 = graph.create_handle("A", 38183490);
+        auto h114 = graph.create_handle("T", 38183491);
+        auto h115 = graph.create_handle("T", 38183492);
+        auto h116 = graph.create_handle("CC", 38183493);
+        auto h117 = graph.create_handle("A", 38183494);
+        auto h118 = graph.create_handle("A", 38183496);
+        auto h119 = graph.create_handle("A", 38183497);
+        auto h120 = graph.create_handle("G", 38183498);
+        auto h121 = graph.create_handle("C", 38183499);
+        auto h122 = graph.create_handle("A", 38183500);
+        auto h123 = graph.create_handle("T", 38183503);
+        auto h124 = graph.create_handle("T", 38183504);
+        auto h125 = graph.create_handle("C", 38183506);
+        auto h126 = graph.create_handle("C", 38183507);
+        auto h127 = graph.create_handle("A", 38183509);
+        auto h128 = graph.create_handle("T", 38183510);
+        auto h129 = graph.create_handle("TC", 38183518);
+        auto h130 = graph.create_handle("C", 38183519);
+        auto h131 = graph.create_handle("A", 38183521);
+        auto h132 = graph.create_handle("T", 38183522);
+        auto h133 = graph.create_handle("T", 38183523);
+        auto h134 = graph.create_handle("CC", 38183524);
+        auto h135 = graph.create_handle("A", 38183525);
+        auto h136 = graph.create_handle("T", 38183526);
+        auto h137 = graph.create_handle("T", 38183527);
+        auto h138 = graph.create_handle("CC", 38183528);
+        auto h139 = graph.create_handle("A", 38183529);
+        auto h140 = graph.create_handle("T", 38183530);
+        auto h141 = graph.create_handle("T", 38183532);
+        auto h142 = graph.create_handle("C", 38183533);
+        auto h143 = graph.create_handle("C", 38183541);
+        auto h144 = graph.create_handle("A", 38183543);
+        auto h145 = graph.create_handle("T", 38183544);
+        auto h146 = graph.create_handle("T", 38183546);
+        auto h147 = graph.create_handle("C", 38183547);
+        auto h148 = graph.create_handle("C", 38183548);
+        auto h149 = graph.create_handle("A", 38183549);
+        auto h150 = graph.create_handle("TT", 38183550);
+        auto h151 = graph.create_handle("C", 38183551);
+        auto h152 = graph.create_handle("C", 38183552);
+        auto h153 = graph.create_handle("A", 38183553);
+        auto h154 = graph.create_handle("T", 38183555);
+        auto h155 = graph.create_handle("T", 38183558);
+        auto h156 = graph.create_handle("C", 38183559);
+        auto h157 = graph.create_handle("CATTC", 38183560);
+        auto h158 = graph.create_handle("C", 38183561);
+        auto h159 = graph.create_handle("A", 38183563);
+        auto h160 = graph.create_handle("C", 38183564);
+        auto h161 = graph.create_handle("T", 38183567);
+        auto h162 = graph.create_handle("C", 38183568);
+        auto h163 = graph.create_handle("G", 38183569);
+        auto h164 = graph.create_handle("G", 38183572);
+        auto h165 = graph.create_handle("G", 38183574);
+        auto h166 = graph.create_handle("T", 38183575);
+        auto h167 = graph.create_handle("T", 38183576);
+        auto h168 = graph.create_handle("G", 38183578);
+        auto h169 = graph.create_handle("ATT", 38183579);
+        auto h170 = graph.create_handle("C", 38183588);
+        auto h171 = graph.create_handle("C", 38183593);
+        auto h172 = graph.create_handle("A", 38183594);
+        auto h173 = graph.create_handle("T", 38183595);
+        auto h174 = graph.create_handle("T", 38183596);
+        auto h175 = graph.create_handle("C", 38183598);
+        auto h176 = graph.create_handle("C", 38183599);
+        auto h177 = graph.create_handle("AT", 38183601);
+        auto h178 = graph.create_handle("T", 38183602);
+        auto h179 = graph.create_handle("C", 38183603);
+        auto h180 = graph.create_handle("C", 38183604);
+        auto h181 = graph.create_handle("A", 38183605);
+        auto h182 = graph.create_handle("T", 38183606);
+        auto h183 = graph.create_handle("TCC", 38183607);
+        auto h184 = graph.create_handle("A", 38183608);
+        auto h185 = graph.create_handle("T", 38183609);
+        auto h186 = graph.create_handle("T", 38183610);
+        auto h187 = graph.create_handle("C", 38183612);
+        auto h188 = graph.create_handle("TG", 38183613);
+        auto h189 = graph.create_handle("GAA", 38183614);
+        auto h190 = graph.create_handle("C", 38183617);
+        auto h191 = graph.create_handle("AAT", 38183618);
+        auto h192 = graph.create_handle("C", 38183619);
+        auto h193 = graph.create_handle("C", 38183620);
+        auto h194 = graph.create_handle("A", 38183621);
+        auto h195 = graph.create_handle("T", 38183622);
+        auto h196 = graph.create_handle("TCC", 38183623);
+        auto h197 = graph.create_handle("A", 38183624);
+        auto h198 = graph.create_handle("T", 38183625);
+        auto h199 = graph.create_handle("TC", 38183626);
+        auto h200 = graph.create_handle("C", 38183627);
+        auto h201 = graph.create_handle("AT", 38183628);
+        auto h202 = graph.create_handle("T", 38183629);
+        auto h203 = graph.create_handle("C", 38183631);
+        auto h204 = graph.create_handle("C", 38183634);
+        auto h205 = graph.create_handle("A", 38183635);
+        auto h206 = graph.create_handle("T", 38183637);
+        auto h207 = graph.create_handle("T", 38183638);
+        auto h208 = graph.create_handle("C", 38183639);
+        auto h209 = graph.create_handle("C", 38183640);
+        auto h210 = graph.create_handle("A", 38183642);
+        auto h211 = graph.create_handle("C", 38183643);
+        auto h212 = graph.create_handle("T", 38183646);
+        auto h213 = graph.create_handle("C", 38183647);
+        auto h214 = graph.create_handle("CATT", 38183673);
+        auto h215 = graph.create_handle("C", 38183674);
+        auto h216 = graph.create_handle("C", 38183679);
+        auto h217 = graph.create_handle("A", 38183680);
+        auto h218 = graph.create_handle("T", 38183682);
+        auto h219 = graph.create_handle("T", 38183683);
+        auto h220 = graph.create_handle("C", 38183684);
+        auto h221 = graph.create_handle("C", 38183686);
+        auto h222 = graph.create_handle("A", 38183687);
+        auto h223 = graph.create_handle("A", 38183689);
+        auto h224 = graph.create_handle("T", 38183691);
+        auto h225 = graph.create_handle("C", 38183692);
+        auto h226 = graph.create_handle("C", 38183693);
+
+        graph.create_edge(h1, h2);
+        graph.create_edge(h2, h3);
+        graph.create_edge(h3, h4);
+        graph.create_edge(h4, h5);
+        graph.create_edge(h5, h6);
+        graph.create_edge(h6, h7);
+        graph.create_edge(h7, h8);
+        graph.create_edge(h8, h9);
+        graph.create_edge(h9, h10);
+        graph.create_edge(h10, h11);
+        graph.create_edge(h11, h12);
+        graph.create_edge(h12, h13);
+        graph.create_edge(h13, h14);
+        graph.create_edge(h14, h15);
+        graph.create_edge(h15, h16);
+        graph.create_edge(h16, h17);
+        graph.create_edge(h17, h18);
+        graph.create_edge(h18, h19);
+        graph.create_edge(h19, h20);
+        graph.create_edge(h20, h21);
+        graph.create_edge(h21, h22);
+        graph.create_edge(h22, h23);
+        graph.create_edge(h23, h24);
+        graph.create_edge(h24, h25);
+        graph.create_edge(h25, h26);
+        graph.create_edge(h26, h27);
+        graph.create_edge(h27, h28);
+        graph.create_edge(h28, h29);
+        graph.create_edge(h29, h30);
+        graph.create_edge(h30, h31);
+        graph.create_edge(h31, h32);
+        graph.create_edge(h32, h33);
+        graph.create_edge(h33, h34);
+        graph.create_edge(h34, h35);
+        graph.create_edge(h35, h36);
+        graph.create_edge(h36, h37);
+        graph.create_edge(h37, h38);
+        graph.create_edge(h38, h39);
+        graph.create_edge(h39, h40);
+        graph.create_edge(h40, h41);
+        graph.create_edge(h41, h42);
+        graph.create_edge(h42, h43);
+        graph.create_edge(h43, h44);
+        graph.create_edge(h44, h45);
+        graph.create_edge(h45, h46);
+        graph.create_edge(h46, h47);
+        graph.create_edge(h47, h48);
+        graph.create_edge(h48, h49);
+        graph.create_edge(h49, h50);
+        graph.create_edge(h50, h51);
+        graph.create_edge(h51, h52);
+        graph.create_edge(h52, h53);
+        graph.create_edge(h53, h54);
+        graph.create_edge(h54, h55);
+        graph.create_edge(h55, h56);
+        graph.create_edge(h56, h57);
+        graph.create_edge(h57, h58);
+        graph.create_edge(h58, h59);
+        graph.create_edge(h59, h60);
+        graph.create_edge(h60, h61);
+        graph.create_edge(h61, h62);
+        graph.create_edge(h62, h63);
+        graph.create_edge(h63, h64);
+        graph.create_edge(h64, h65);
+        graph.create_edge(h65, h66);
+        graph.create_edge(h66, h67);
+        graph.create_edge(h67, h68);
+        graph.create_edge(h68, h69);
+        graph.create_edge(h69, h70);
+        graph.create_edge(h70, h71);
+        graph.create_edge(h71, h72);
+        graph.create_edge(h72, h73);
+        graph.create_edge(h73, h74);
+        graph.create_edge(h74, h75);
+        graph.create_edge(h75, h76);
+        graph.create_edge(h76, h77);
+        graph.create_edge(h77, h78);
+        graph.create_edge(h78, h79);
+        graph.create_edge(h79, h80);
+        graph.create_edge(h80, h81);
+        graph.create_edge(h81, h82);
+        graph.create_edge(h82, h83);
+        graph.create_edge(h83, h84);
+        graph.create_edge(h84, h85);
+        graph.create_edge(h85, h86);
+        graph.create_edge(h86, h87);
+        graph.create_edge(h87, h88);
+        graph.create_edge(h88, h89);
+        graph.create_edge(h89, h90);
+        graph.create_edge(h90, h91);
+        graph.create_edge(h91, h92);
+        graph.create_edge(h92, h93);
+        graph.create_edge(h93, h94);
+        graph.create_edge(h94, h95);
+        graph.create_edge(h95, h96);
+        graph.create_edge(h96, h97);
+        graph.create_edge(h97, h98);
+        graph.create_edge(h98, h99);
+        graph.create_edge(h99, h100);
+        graph.create_edge(h100, h101);
+        graph.create_edge(h101, h102);
+        graph.create_edge(h102, h103);
+        graph.create_edge(h103, h104);
+        graph.create_edge(h104, h105);
+        graph.create_edge(h105, h106);
+        graph.create_edge(h106, h107);
+        graph.create_edge(h107, h108);
+        graph.create_edge(h108, h109);
+        graph.create_edge(h109, h110);
+        graph.create_edge(h110, h111);
+        graph.create_edge(h111, h112);
+        graph.create_edge(h112, h113);
+        graph.create_edge(h113, h114);
+        graph.create_edge(h114, h115);
+        graph.create_edge(h115, h116);
+        graph.create_edge(h116, h117);
+        graph.create_edge(h117, h118);
+        graph.create_edge(h118, h119);
+        graph.create_edge(h119, h120);
+        graph.create_edge(h120, h121);
+        graph.create_edge(h121, h122);
+        graph.create_edge(h122, h123);
+        graph.create_edge(h123, h124);
+        graph.create_edge(h124, h125);
+        graph.create_edge(h125, h126);
+        graph.create_edge(h126, h127);
+        graph.create_edge(h127, h128);
+        graph.create_edge(h128, h129);
+        graph.create_edge(h129, h130);
+        graph.create_edge(h130, h131);
+        graph.create_edge(h131, h132);
+        graph.create_edge(h132, h133);
+        graph.create_edge(h133, h134);
+        graph.create_edge(h134, h135);
+        graph.create_edge(h135, h136);
+        graph.create_edge(h136, h137);
+        graph.create_edge(h137, h138);
+        graph.create_edge(h138, h139);
+        graph.create_edge(h139, h140);
+        graph.create_edge(h140, h141);
+        graph.create_edge(h141, h142);
+        graph.create_edge(h142, h143);
+        graph.create_edge(h143, h144);
+        graph.create_edge(h144, h145);
+        graph.create_edge(h145, h146);
+        graph.create_edge(h146, h147);
+        graph.create_edge(h147, h148);
+        graph.create_edge(h148, h149);
+        graph.create_edge(h149, h150);
+        graph.create_edge(h150, h151);
+        graph.create_edge(h151, h152);
+        graph.create_edge(h152, h153);
+        graph.create_edge(h153, h154);
+        graph.create_edge(h154, h155);
+        graph.create_edge(h155, h156);
+        graph.create_edge(h156, h157);
+        graph.create_edge(h157, h158);
+        graph.create_edge(h158, h159);
+        graph.create_edge(h159, h160);
+        graph.create_edge(h160, h161);
+        graph.create_edge(h161, h162);
+        graph.create_edge(h162, h163);
+        graph.create_edge(h163, h164);
+        graph.create_edge(h164, h165);
+        graph.create_edge(h165, h166);
+        graph.create_edge(h166, h167);
+        graph.create_edge(h167, h168);
+        graph.create_edge(h168, h169);
+        graph.create_edge(h169, h170);
+        graph.create_edge(h170, h171);
+        graph.create_edge(h171, h172);
+        graph.create_edge(h172, h173);
+        graph.create_edge(h173, h174);
+        graph.create_edge(h174, h175);
+        graph.create_edge(h175, h176);
+        graph.create_edge(h176, h177);
+        graph.create_edge(h177, h178);
+        graph.create_edge(h178, h179);
+        graph.create_edge(h179, h180);
+        graph.create_edge(h180, h181);
+        graph.create_edge(h181, h182);
+        graph.create_edge(h182, h183);
+        graph.create_edge(h183, h184);
+        graph.create_edge(h184, h185);
+        graph.create_edge(h185, h186);
+        graph.create_edge(h186, h187);
+        graph.create_edge(h187, h188);
+        graph.create_edge(h188, h189);
+        graph.create_edge(h189, h190);
+        graph.create_edge(h190, h191);
+        graph.create_edge(h191, h192);
+        graph.create_edge(h192, h193);
+        graph.create_edge(h193, h194);
+        graph.create_edge(h194, h195);
+        graph.create_edge(h195, h196);
+        graph.create_edge(h196, h197);
+        graph.create_edge(h197, h198);
+        graph.create_edge(h198, h199);
+        graph.create_edge(h199, h200);
+        graph.create_edge(h200, h201);
+        graph.create_edge(h201, h202);
+        graph.create_edge(h202, h203);
+        graph.create_edge(h203, h204);
+        graph.create_edge(h204, h205);
+        graph.create_edge(h205, h206);
+        graph.create_edge(h206, h207);
+        graph.create_edge(h207, h208);
+        graph.create_edge(h208, h209);
+        graph.create_edge(h209, h210);
+        graph.create_edge(h210, h211);
+        graph.create_edge(h211, h212);
+        graph.create_edge(h212, h213);
+        graph.create_edge(h213, h214);
+        graph.create_edge(h214, h215);
+        graph.create_edge(h215, h216);
+        graph.create_edge(h216, h217);
+        graph.create_edge(h217, h218);
+        graph.create_edge(h218, h219);
+        graph.create_edge(h219, h220);
+        graph.create_edge(h220, h221);
+        graph.create_edge(h221, h222);
+        graph.create_edge(h222, h223);
+        graph.create_edge(h223, h224);
+        graph.create_edge(h224, h225);
+        graph.create_edge(h225, h226);
+
+
+        string alignment_string = R"({"path": {"mapping": [{"edit": [{"sequence": "CGAGTGCTGGGGAATGTAAT", "to_length": 20}, {"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183693"}, "rank": "1"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183692"}, "rank": "2"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183691"}, "rank": "3"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "38183689"}, "rank": "4"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183687"}, "rank": "5"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183686"}, "rank": "6"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183684"}, "rank": "7"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183683"}, "rank": "8"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183682"}, "rank": "9"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183680"}, "rank": "10"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183679"}, "rank": "11"}, {"edit": [{"from_length": 1, "sequence": "C", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183674"}, "rank": "12"}, {"edit": [{"from_length": 4, "to_length": 4}], "position": {"is_reverse": true, "node_id": "38183673"}, "rank": "13"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183647"}, "rank": "14"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183646"}, "rank": "15"}, {"edit": [{"from_length": 1, "sequence": "A", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183643"}, "rank": "16"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183642"}, "rank": "17"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183640"}, "rank": "18"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183639"}, "rank": "19"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183638"}, "rank": "20"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183637"}, "rank": "21"}, {"edit": [{"from_length": 1, "to_length": 1}, {"sequence": "CATCC", "to_length": 5}], "position": {"is_reverse": true, "node_id": "38183635"}, "rank": "22"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183634"}, "rank": "1"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183631"}, "rank": "2"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183629"}, "rank": "3"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183628"}, "rank": "4"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183627"}, "rank": "5"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183626"}, "rank": "6"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183625"}, "rank": "7"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183624"}, "rank": "8"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"is_reverse": true, "node_id": "38183623"}, "rank": "9"}, {"edit": [{"from_length": 1, "sequence": "G", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183622"}, "rank": "10"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183621"}, "rank": "11"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183620"}, "rank": "12"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183619"}, "rank": "13"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"node_id": "38183618"}, "rank": "14"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183617"}, "rank": "15"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"node_id": "38183614"}, "rank": "16"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"node_id": "38183613"}, "rank": "17"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183612"}, "rank": "18"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183610"}, "rank": "19"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183609"}, "rank": "20"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183608"}, "rank": "21"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"is_reverse": true, "node_id": "38183607"}, "rank": "22"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183606"}, "rank": "23"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183605"}, "rank": "24"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183604"}, "rank": "25"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183603"}, "rank": "26"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183602"}, "rank": "27"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183601"}, "rank": "28"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183599"}, "rank": "29"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183598"}, "rank": "30"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183596"}, "rank": "31"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183595"}, "rank": "32"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183594"}, "rank": "33"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183593"}, "rank": "34"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183588"}, "rank": "35"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"is_reverse": true, "node_id": "38183579"}, "rank": "36"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183578"}, "rank": "37"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183576"}, "rank": "38"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183575"}, "rank": "39"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183574"}, "rank": "40"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183572"}, "rank": "41"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183569"}, "rank": "42"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183568"}, "rank": "43"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183567"}, "rank": "44"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183564"}, "rank": "45"}, {"edit": [{"from_length": 1, "sequence": "C", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183563"}, "rank": "46"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183561"}, "rank": "47"}, {"edit": [{"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 4, "to_length": 4}], "position": {"is_reverse": true, "node_id": "38183560"}, "rank": "48"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183559"}, "rank": "49"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183558"}, "rank": "50"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183555"}, "rank": "51"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183553"}, "rank": "52"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183552"}, "rank": "53"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183551"}, "rank": "54"}, {"edit": [{"from_length": 1, "to_length": 1}, {"from_length": 1, "sequence": "G", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183550"}, "rank": "55"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183549"}, "rank": "56"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183548"}, "rank": "57"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183547"}, "rank": "58"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183546"}, "rank": "59"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183544"}, "rank": "60"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183543"}, "rank": "61"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183541"}, "rank": "62"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183533"}, "rank": "63"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183532"}, "rank": "64"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183530"}, "rank": "65"}, {"edit": [{"from_length": 1, "sequence": "A", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183529"}, "rank": "66"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183528"}, "rank": "67"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183527"}, "rank": "68"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183526"}, "rank": "69"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183525"}, "rank": "70"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183524"}, "rank": "71"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183523"}, "rank": "72"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183522"}, "rank": "73"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183521"}, "rank": "74"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183519"}, "rank": "75"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183518"}, "rank": "76"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183510"}, "rank": "77"}, {"edit": [{"sequence": "CAACCCGAA", "to_length": 9}, {"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183509"}, "rank": "1"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183507"}, "rank": "2"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183506"}, "rank": "3"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183504"}, "rank": "4"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183503"}, "rank": "5"}, {"edit": [{"from_length": 1, "sequence": "T", "to_length": 1}], "position": {"node_id": "38183500"}, "rank": "6"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183499"}, "rank": "7"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "38183498"}, "rank": "8"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "38183497"}, "rank": "9"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "38183496"}, "rank": "10"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183494"}, "rank": "11"}, {"edit": [{"from_length": 1, "to_length": 1}, {"sequence": "TAATGGAGAGTAAGGGAGTTGAATA", "to_length": 25}, {"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183493"}, "rank": "12"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183492"}, "rank": "13"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183491"}, "rank": "14"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183490"}, "rank": "15"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183489"}, "rank": "16"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183488"}, "rank": "17"}, {"edit": [{"from_length": 1, "sequence": "T", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183487"}, "rank": "18"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183486"}, "rank": "19"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183485"}, "rank": "20"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183483"}, "rank": "21"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183482"}, "rank": "22"}, {"edit": [{"from_length": 1, "sequence": "A", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183480"}, "rank": "23"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183479"}, "rank": "24"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183477"}, "rank": "25"}, {"edit": [{"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183476"}, "rank": "26"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183475"}, "rank": "27"}, {"edit": [{"from_length": 1, "sequence": "G", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183473"}, "rank": "28"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183472"}, "rank": "29"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183470"}, "rank": "30"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183469"}, "rank": "31"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183467"}, "rank": "32"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183466"}, "rank": "33"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183464"}, "rank": "34"}, {"edit": [{"from_length": 1, "to_length": 1}, {"from_length": 1, "sequence": "C", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183463"}, "rank": "35"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183462"}, "rank": "36"}, {"edit": [{"from_length": 1, "sequence": "G", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183459"}, "rank": "37"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183458"}, "rank": "38"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183457"}, "rank": "39"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183455"}, "rank": "40"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183454"}, "rank": "41"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183453"}, "rank": "42"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183452"}, "rank": "43"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183451"}, "rank": "44"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183449"}, "rank": "45"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183446"}, "rank": "46"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183445"}, "rank": "47"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183444"}, "rank": "48"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183443"}, "rank": "49"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183442"}, "rank": "50"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183440"}, "rank": "51"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183439"}, "rank": "52"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183438"}, "rank": "53"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183437"}, "rank": "54"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183435"}, "rank": "55"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183434"}, "rank": "56"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183433"}, "rank": "57"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183432"}, "rank": "58"}, {"edit": [{"from_length": 1, "sequence": "T", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183430"}, "rank": "59"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183429"}, "rank": "60"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183428"}, "rank": "61"}, {"edit": [{"from_length": 1, "sequence": "T", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183426"}, "rank": "62"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183425"}, "rank": "63"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183424"}, "rank": "64"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183423"}, "rank": "65"}, {"edit": [{"from_length": 1, "sequence": "T", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183421"}, "rank": "66"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183417"}, "rank": "67"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183416"}, "rank": "68"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183415"}, "rank": "69"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183414"}, "rank": "70"}, {"edit": [{"from_length": 1, "sequence": "T", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183412"}, "rank": "71"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183411"}, "rank": "72"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"is_reverse": true, "node_id": "38183410"}, "rank": "73"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183409"}, "rank": "74"}, {"edit": [{"from_length": 1, "sequence": "G", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183405"}, "rank": "75"}, {"edit": [{"from_length": 1, "sequence": "C", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183404"}, "rank": "76"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183403"}, "rank": "77"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183401"}, "rank": "78"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183400"}, "rank": "79"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183398"}, "rank": "80"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183396"}, "rank": "81"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183395"}, "rank": "82"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183393"}, "rank": "83"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183392"}, "rank": "84"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183391"}, "rank": "85"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183390"}, "rank": "86"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183389"}, "rank": "87"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183388"}, "rank": "88"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183387"}, "rank": "89"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183385"}, "rank": "90"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183382"}, "rank": "91"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183381"}, "rank": "92"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183380"}, "rank": "93"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183379"}, "rank": "94"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183375"}, "rank": "95"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183374"}, "rank": "96"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183372"}, "rank": "97"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183371"}, "rank": "98"}, {"edit": [{"from_length": 1, "sequence": "C", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183369"}, "rank": "99"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183368"}, "rank": "100"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183366"}, "rank": "101"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183365"}, "rank": "102"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"is_reverse": true, "node_id": "38183364"}, "rank": "103"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183362"}, "rank": "104"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183361"}, "rank": "105"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183360"}, "rank": "106"}, {"edit": [{"from_length": 1, "to_length": 1}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 1, "sequence": "A", "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183359"}, "rank": "107"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183357"}, "rank": "108"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183356"}, "rank": "109"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183355"}, "rank": "110"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183353"}, "rank": "111"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183350"}, "rank": "112"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"is_reverse": true, "node_id": "38183349"}, "rank": "113"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183348"}, "rank": "114"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183347"}, "rank": "115"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183345"}, "rank": "116"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183344"}, "rank": "117"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183343"}, "rank": "118"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183341"}, "rank": "119"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183340"}, "rank": "120"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183339"}, "rank": "121"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183338"}, "rank": "122"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183337"}, "rank": "123"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183335"}, "rank": "124"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "38183334"}, "rank": "125"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"is_reverse": true, "node_id": "38183333"}, "rank": "126"}, {"edit": [{"from_length": 1, "to_length": 1}, {"sequence": "ACTACCCAAATGGAATGGAATGTAATGGACTGTAAAGGAATTGAATAGAATCAATCCGAATGTAATGGAATGGAATGGAACGGAATG", "to_length": 87}], "position": {"is_reverse": true, "node_id": "38183332"}, "rank": "127"}]}, "sequence": "CGAGTGCTGGGGAATGTAATGGAATGGAATGCAATGGAATGGAATCATCCGGAATGGAATGGAGTGGAATGGAATGGAATGGAATGGAATGGAATGGAATCAACCCGAGCGCAATGGAATGGAGTGGAATGGAAAGGAATGGAATGGAACAACCCGAATGGAATGGAATGTAATGGAGAGTAAGGGAGTTGAATAGAATCAATCCGAATGTAATGGAATGGAACGGAATGGAATGGAATGGAATGGAATGGAATGGAATGGAATGGAATGCAATGGAATGGAATCAACCCGAGTGCAATGGAATGGAGAGGAATGGAATGGAATGGAATGGAAACTACCCAAATGGAATGGAATGTAATGGACTGTAAAGGAATTGAATAGAATCAATCCGAATGTAATGGAATGGAATGGAACGGAATG"})";
+
+        Alignment aln;
+        json2pb(aln, alignment_string.c_str(), alignment_string.size());
+
+        for (bool left : {false, true}) {
+            normalize_indel_adjustment(aln, left, graph);
+            auto validity = alignment_is_valid(aln, &graph, true);
+            cerr << validity.bad_mapping_index << ", " << validity.bad_edit_index << ", " << validity.bad_read_position << ", " << validity.message << endl;
+            REQUIRE((bool) validity);
+        }
+    }
+
+    SECTION("Empirical case 2") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("TTCCATTCCATTCCA");
+        auto h2 = graph.create_handle("TTCCATTCCATTCCATTCC");
+        auto h3 = graph.create_handle("ATTC");
+        auto h4 = graph.create_handle("CA");
+        auto h5 = graph.create_handle("G");
+        auto h6 = graph.create_handle("T");
+        auto h7 = graph.create_handle("TG");
+        auto h8 = graph.create_handle("ATTCCATT");
+        auto h9 = graph.create_handle("G");
+        auto h10 = graph.create_handle("CATTCC");
+        auto h11 = graph.create_handle("A");
+        auto h12 = graph.create_handle("TTC");
+        auto h13 = graph.create_handle("C");
+        auto h14 = graph.create_handle("A");
+        auto h15 = graph.create_handle("TTCCAT");
+        auto h16 = graph.create_handle("TCCATTCC");
+        auto h17 = graph.create_handle("G");
+        auto h18 = graph.create_handle("TTCC");
+        auto h19 = graph.create_handle("A");
+        auto h20 = graph.create_handle("TTC");
+        auto h21 = graph.create_handle("G");
+        auto h22 = graph.create_handle("T");
+        auto h23 = graph.create_handle("GAA");
+        auto h24 = graph.create_handle("CATTCCATTC");
+        auto h25 = graph.create_handle("C");
+        auto h26 = graph.create_handle("ATTCCAT");
+        auto h27 = graph.create_handle("TCCAT");
+        auto h28 = graph.create_handle("TCCATTCCTTTCCACTCGGGTTGATTCCATT");
+        auto h29 = graph.create_handle("CCAT");
+        auto h30 = graph.create_handle("TCCATTCCTTTCCATTCCATTCCATTCCGTTCCACTCGGCTTGATTCCATTCCATTCCATTCCATTTTTTCCAATCCACTCGGGTTGATTCCATTCTATTCCATTCCATTCCAGTTG");
+
+        graph.create_edge(h1, h2);
+        graph.create_edge(h2, h3);
+        graph.create_edge(h3, h4);
+        graph.create_edge(h4, h5);
+        graph.create_edge(h5, h6);
+        graph.create_edge(h6, h7);
+        graph.create_edge(h7, h8);
+        graph.create_edge(h8, h9);
+        graph.create_edge(h9, h10);
+        graph.create_edge(h10, h11);
+        graph.create_edge(h11, h12);
+        graph.create_edge(h12, h13);
+        graph.create_edge(h13, h14);
+        graph.create_edge(h14, h15);
+        graph.create_edge(h15, h16);
+        graph.create_edge(h16, h17);
+        graph.create_edge(h17, h18);
+        graph.create_edge(h18, h19);
+        graph.create_edge(h19, h20);
+        graph.create_edge(h20, h21);
+        graph.create_edge(h21, h22);
+        graph.create_edge(h22, h23);
+        graph.create_edge(h23, h24);
+        graph.create_edge(h24, h25);
+        graph.create_edge(h25, h26);
+        graph.create_edge(h26, h27);
+        graph.create_edge(h27, h28);
+        graph.create_edge(h28, h29);
+        graph.create_edge(h29, h30);
+
+
+        string alignment_string = R"({"path": {"mapping": [{"edit": [{"sequence": "ATTCCATTCCACTTGGCGTGATTCA", "to_length": 25}, {"from_length": 9, "to_length": 9}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 1, "to_length": 1}], "position": {"node_id": "1", "offset": "4"}, "rank": "1"}, {"edit": [{"from_length": 6, "to_length": 6}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 11, "to_length": 11}], "position": {"node_id": "2"}, "rank": "2"}, {"edit": [{"from_length": 4, "to_length": 4}], "position": {"node_id": "3"}, "rank": "3"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"node_id": "4"}, "rank": "4"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "5"}, "rank": "5"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "6"}, "rank": "6"}, {"edit": [{"from_length": 2, "to_length": 2}], "position": {"node_id": "7"}, "rank": "7"}, {"edit": [{"from_length": 4, "to_length": 4}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 3, "to_length": 3}], "position": {"node_id": "8"}, "rank": "8"}, {"edit": [{"from_length": 1, "sequence": "C", "to_length": 1}], "position": {"node_id": "9"}, "rank": "9"}, {"edit": [{"from_length": 5, "to_length": 5}, {"from_length": 1, "sequence": "T", "to_length": 1}], "position": {"node_id": "10"}, "rank": "10"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "11"}, "rank": "11"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"node_id": "12"}, "rank": "12"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "13"}, "rank": "13"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "14"}, "rank": "14"}, {"edit": [{"from_length": 5, "to_length": 5}, {"from_length": 1}], "position": {"node_id": "15"}, "rank": "15"}, {"edit": [{"from_length": 8}], "position": {"node_id": "16"}, "rank": "16"}, {"edit": [{"from_length": 1}], "position": {"node_id": "17"}, "rank": "17"}, {"edit": [{"from_length": 4, "to_length": 4}], "position": {"node_id": "18"}, "rank": "1"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "19"}, "rank": "2"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"node_id": "20"}, "rank": "3"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "21"}, "rank": "4"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"is_reverse": true, "node_id": "22"}, "rank": "5"}, {"edit": [{"from_length": 3, "to_length": 3}], "position": {"is_reverse": true, "node_id": "23"}, "rank": "6"}, {"edit": [{"from_length": 10, "to_length": 10}], "position": {"node_id": "24"}, "rank": "7"}, {"edit": [{"from_length": 1, "to_length": 1}], "position": {"node_id": "25"}, "rank": "8"}, {"edit": [{"from_length": 3, "to_length": 3}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 3, "to_length": 3}], "position": {"node_id": "26"}, "rank": "9"}, {"edit": [{"from_length": 3, "to_length": 3}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 1, "to_length": 1}], "position": {"node_id": "27"}, "rank": "10"}, {"edit": [{"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 5, "to_length": 5}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 5, "to_length": 5}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 13, "to_length": 13}], "position": {"node_id": "28"}, "rank": "11"}, {"edit": [{"from_length": 4, "to_length": 4}], "position": {"node_id": "29"}, "rank": "12"}, {"edit": [{"from_length": 19, "to_length": 19}, {"sequence": "GTTCATTCAATTCCATTCTATTCCATTCCAATGGATTCCATTCCACTTCAT", "to_length": 51}], "position": {"node_id": "30"}, "rank": "13"}]},  "sequence": "ATTCCATTCCACTTGGCGTGATTCAATTCCATTCAATTCCATATCATTCCATTCCATTCCAGTTGATTCTATTCCATTCTATTCCATTCCATTCCATTCCATTCCATTCCATTCCATTGCATTCCTTTCAATTCCATTTCACTCAGGTTGATTCCATTCCATTCCATTCCTTTCCATTCCAGTTCATTCAATTCCATTCTATTCCATTCCAATGGATTCCATTCCACTTCAT"})";
+
+        Alignment aln;
+        json2pb(aln, alignment_string.c_str(), alignment_string.size());
+
+        for (bool left : {false, true}) {
+            normalize_indel_adjustment(aln, left, graph);
+            auto validity = alignment_is_valid(aln, &graph, true);
+            REQUIRE((bool) validity);
+        }
+    }
+
+    SECTION("Empirical case 3") {
+
+        bdsg::HashGraph graph;
+
+        auto h1 = graph.create_handle("GCATTCTCAGTAAGAGGTTGTTATGTTTGCAATCATCTCACAGACTTGAACCTTTCTTTTGATAGAGCAGTGTTGAAATGCACTTTTTGTAGAATCTGCATGTGTTCATTTGGAGCGCTTTGTTGCCAGTGGTGGAAAAAGAAATATCTTCATATAAAAACTAGATAGAAGCATTTGCAGAAACCCCTTTGTGATGTGTGTGTTCAATTCACAGAGTTTAACCTTTCTTTAGATAGAGCAGTTTTGAAACACTGCCTTTGTAGGATCTGCTTGTGGATATTTGGAGCTCTTTAAGGAATTCGTTGTAAACGGGATAACTTCACATACAAACTAGACAGAAGCATTCTCAGAAACTGCTTTGTGACGTGTGCATTCAACTCACAGAGTTGAACCTTCTTTTTGAGAGATCAATTTTGAAACAGTCTGATTGTATTATCTGCAAGTGGATAATTGGAGCGACTTGAGGCCTAAGATGGACAAGGAGATAGCTTCACATACAAACTAGACAGAAGAATTCTCAGAAACTTCTTTGTGATGTGTGCATTCAACTCATTGTCTAGAACAATTCTTTTGATAGAGCAGTGTTGAAACAGCCTTCTTGTGGAATCTGCAAGTGTTCATTTGGAGAGCTTTGTTGCCTATTCTGGAAAAAGAAACATCTTCACATAAAAACTAGACAGAAGCATTCTCAGAGACTCCTTTTTGATATGTGTGTTCCATTCACAGAGTTGAACCATTCTTTTGATAGAGCAGTTTTGAAACACTGTTTTTGTAGCATCTGCTTGTGGATATT");
+        auto h2 = graph.create_handle("GA");
+        auto h3 = graph.create_handle("AGCTCTTTCTGGAATTCGTTGTAAACGGGATATCTTCACATACAAACTAGACAGAAGCATTCTCAGAAACTACTTTGTGATGTGTGCATTCAACTCACAGAGTTGAGCCTTCCTTTTGAGAGAGCAGTTTTGAAACAGTCTTTTTGTAGTATCTGCAAGTGGATATTAGGAGCGATTTGAGGCCTATGATGAAAAAGGAAATATCTTCACATACAACGAGACAGAAGCATTCTCAGACACTGCTTTGTGATGTGTGCATTCAACTCACAGTGTTGAAGCTTCCTTTTGAGAGAGCAGTTTTGAAACAGTCTTTTTGTAGTGGCTGCAAGTGGATATTTGGAGCGATTTCAGGCCTGTGATGGAAAAGGAAATATCTTCACATAAAAACTAGACAGAATCATTCTCAGAAACTGCTTTGTGATGTGTGCATTCACCTCACAGAGTGGAACCGTTCTTTTGATAGATCAGTTTTGAAACAGTCTTTTTGTAGGATCTGCAAGTGTTCATGTGGAGTGCTTTGTAGCCAAAGATGAGAACGGAAATATCTTCACGTAAAAACTAGACAGAAGCGTTCTCAGGAACTTCATTGAGATGTGTGCATTCAACTGACAGAGTTGAAACTGTCTTTTGATAGAGCAGTATTGAAACACTCCGTTTGTAGTATCTGGTTGTGGATATTTGGAACTCTTTGAGGAATTCATTGGAAACCGGTATCTTCACATAAAATATAGACCCAAGCATTCTCTGAAATTTATTTCTGATGTGTGCATTCAACTAACAGACGTGAACCTTTTCTTTGACAGAGCAGTGATGAAACACACTTTTTGTGGAATCTGCAAATTTTCATTTCGTGTGCTTTGTTGCCTACGGTTGAAAATAATATCTTCACATAAAAACTAGACAGAAGCATTCTCAGAAACTCTTTGGATGTGTCTGTTCAATTCACAGAGTTAAACCTTTCTTTTTATAGAGCAGTTTTGAAACACTACTTTTGTGGAATGTGCTTGTGGAGATTTGGAACTGT");
+
+        graph.create_edge(h1, h2);
+        graph.create_edge(h2, h3);
+
+        string alignment_string = R"({"path": {"mapping": [{"edit": [{"sequence": "AAGCAGATTCTACAAAAGCAG", "to_length": 21}, {"from_length": 17, "to_length": 17}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 7, "to_length": 7}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 9, "to_length": 9}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 25, "to_length": 25}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 3, "to_length": 3}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 6, "to_length": 6}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 4, "to_length": 4}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 15, "to_length": 15}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 15, "to_length": 15}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 14, "to_length": 14}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 1}, {"from_length": 4, "to_length": 4}], "position": {"is_reverse": true, "node_id": "3", "offset": "887"}, "rank": "1"}, {"edit": [{"from_length": 2, "to_length": 2}, {"sequence": "A", "to_length": 1}], "position": {"is_reverse": true, "node_id": "2"}, "rank": "2"}, {"edit": [{"from_length": 11, "to_length": 11}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 5, "to_length": 5}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 8, "to_length": 8}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 20, "to_length": 20}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 9, "to_length": 9}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 9, "to_length": 9}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 11, "to_length": 11}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 5, "to_length": 5}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 4, "to_length": 4}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 18, "to_length": 18}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 18, "to_length": 18}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 66, "to_length": 66}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 3, "to_length": 3}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 1, "to_length": 1}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 4, "to_length": 4}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 1, "to_length": 1}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 19, "to_length": 19}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 7, "to_length": 7}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 15, "to_length": 15}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 8, "to_length": 8}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 5, "to_length": 5}, {"from_length": 1}, {"from_length": 7, "to_length": 7}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 14, "to_length": 14}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 6, "to_length": 6}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 3, "to_length": 3}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 1, "to_length": 1}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 3, "to_length": 3}, {"from_length": 1}, {"from_length": 1, "to_length": 1}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 1, "to_length": 1}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 4, "to_length": 4}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 3, "to_length": 3}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 1, "to_length": 1}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 11, "to_length": 11}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 4, "to_length": 4}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 5, "to_length": 5}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 1, "sequence": "T", "to_length": 1}, {"from_length": 13, "to_length": 13}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 2, "to_length": 2}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 10, "to_length": 10}, {"from_length": 1, "sequence": "G", "to_length": 1}, {"from_length": 3, "to_length": 3}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 15, "to_length": 15}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 6, "to_length": 6}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 4, "to_length": 4}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 16, "to_length": 16}, {"from_length": 1, "sequence": "A", "to_length": 1}, {"from_length": 3, "to_length": 3}, {"from_length": 1, "sequence": "C", "to_length": 1}, {"from_length": 11, "to_length": 11}], "position": {"is_reverse": true, "node_id": "1"}, "rank": "1"}]}, "sequence": "AAGCAGATTCTACAAAAGCAGTGTTTCAAAACTGCTCTATCAAAAGAAAGGCTCAAGTCTGTGAGTTGAATGCACACATCACCAAGCAGTTTCCAAGAAAGCTTCTGTCTAGTTTTTATGTGAAGATATCCAGTTTACAACGAATTTCACAACAGCTTCAAATATCCACAAACAGATTCTACAAAAGCAGTGTTTCAAAACTGCTCTTTCAAAAGAAAGGTTCAACTTTGTGAATGGAAAACACACATCACAAAGGAGTCTCTGAGAATACTTCTGTCTAGTTTTTATTTGAAGATGTTTCTTTTTCCAGAATAGGCAACAAAGCTCTCCAAATGAACACTTGCAGATTCCACAAAAAGACCGTTTAAGCACTGCTCTATCAAAAGAAATGTTCTACACTGAGAGTTGAATGCACACCTCACAAAGCAGTTTTGAGAATGCTTCTGTCTAGTTTTTACGTGAAGATATTTTCTTTTCACCATATGCCTGAAATCGTTTGAAATATCCACTTGCCGATACTACAAAATGACTGTTTCAAAACTGCTCTCTCAAAAGGAAAGTTCAACTCTGTGAGATGAATGAACACATCACAAAGCAGTTTCTAAGACTGCTTCTGTCT"})";
+
+        Alignment aln;
+        json2pb(aln, alignment_string.c_str(), alignment_string.size());
+
+        normalize_indel_adjustment(aln, false, graph);
+
+        auto validity = alignment_is_valid(aln, &graph, true);
+        REQUIRE((bool) validity);
+
+    }
+}
+
 }
 }

--- a/src/unittest/longest_overlap.cpp
+++ b/src/unittest/longest_overlap.cpp
@@ -1,0 +1,54 @@
+/// \file longest_overlap.cpp
+///  
+/// Unit tests for the longest overlap function
+///
+
+#include <iostream>
+#include <string>
+#include "../longest_overlap.hpp"
+#include "../utility.hpp"
+#include "catch.hpp"
+
+
+namespace vg {
+namespace unittest {
+using namespace std;
+
+TEST_CASE("Longest overlap algorithm works on curated inputs", "[string][z]") {
+    
+    SECTION("Simple case") {
+        string str1 = "ACG";
+        string str2 = "CGT";
+        REQUIRE(longest_overlap(str1, str2) == 2);
+        REQUIRE(longest_overlap(str2, str1) == 0);
+    }
+
+    SECTION("Empty cases") {
+        string str1 = "ACG";
+        string str2 = "";
+        REQUIRE(longest_overlap(str1, str2) == 0);
+        REQUIRE(longest_overlap(str2, str1) == 0);
+        REQUIRE(longest_overlap(str2, str2) == 0);
+    }
+
+    SECTION("Random cases") {
+        for (size_t i = 0; i < 500; ++i) {
+            string str1 = pseudo_random_sequence(10, 2 * i);
+            string str2 = pseudo_random_sequence(10, 2 * i + 1);
+            size_t l = 0;
+            for (size_t i = min(str1.size(), str2.size()); i != 0; --i) {
+                if (str1.substr(str1.size() - i, i) == str2.substr(0, i)) {
+                    l = i;
+                    break;
+                }
+            }
+            REQUIRE(longest_overlap(str1, str2) == l);
+        }
+
+    }
+    
+}
+   
+}
+}
+        


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` and `vg surject` have a `--left-align` option to generate HTSLib formats with left-aligned indels

## Description

The left-alignment is accomplished via a post-processing step on the surjected alignment similar to `freebayes bamleftalign`. However, the algorithm I implemented is a fair bit more general, which helps with normalizing the sometimes chaotic indel representation in low complexity sequences. 