### PR TITLE
error on gzipped GFAs

### DIFF
--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -103,7 +103,7 @@ void help_autoindex(char** argv) {
          << "  -r, --ref-fasta FILE   FASTA file with the reference sequence (may repeat)" << endl
          << "  -v, --vcf FILE         VCF file with sequence names matching -r (may repeat)" << endl
          << "  -i, --ins-fasta FILE   FASTA file with sequences of INS variants from -v" << endl
-         << "  -g, --gfa FILE         GFA file to make a graph from" << endl
+         << "  -g, --gfa FILE         GFA file to make a graph from (uncompressed)" << endl
          << "  -G, --gbz FILE         GBZ file to make indexes from" << endl
          << "  -x, --tx-gff FILE      GTF/GFF file with transcript annotations (may repeat)" << endl
          << "  -H, --hap-tx-gff FILE  GTF/GFF file with transcript annotations " << endl
@@ -247,6 +247,7 @@ int main_autoindex(int argc, char** argv) {
                 break;
             case 'g':
                 gfa_name = require_exists(logger, optarg);
+                require_non_gzipped(logger, gfa_name);
                 break;
             case 'G':
                 gbz_name = require_exists(logger, optarg);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex --gfa` will error if the filename seemed gzipped

## Description

Saw #4856 and, didja know, there's a utility function for that :)

This doesn't actually detect the gzip-ness from the file content, just from filenames. It's a band-aid. Likely effective though.