### PR TITLE
Point at new, more permanent CI data home

### DIFF
--- a/scripts/mcmc_Makefile
+++ b/scripts/mcmc_Makefile
@@ -85,10 +85,10 @@ clean:
 	rm -r $(TOIL_OS) 
 
 CHR21.fa:
-	wget https://public.gi.ucsc.edu/~anovak/vg-data/bakeoff/CHR21.fa
+	wget https://public.gi.ucsc.edu/cgl/ci/vg/vg-data/bakeoff/CHR21.fa
 
 1kg_hg19-CHR21.vcf.gz:
-	wget https://public.gi.ucsc.edu/~anovak/vg-data/bakeoff/1kg_hg19-CHR21.vcf.gz
+	wget https://public.gi.ucsc.edu/cgl/ci/vg/vg-data/bakeoff/1kg_hg19-CHR21.vcf.gz
 
 1kg_hg19-CHR21.vcf.gz.tbi:
-	wget https://public.gi.ucsc.edu/~anovak/vg-data/bakeoff/1kg_hg19-CHR21.vcf.gz.tbi
+	wget https://public.gi.ucsc.edu/cgl/ci/vg/vg-data/bakeoff/1kg_hg19-CHR21.vcf.gz.tbi

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -58,8 +58,8 @@ class VGCITest(TestCase):
         # when moving to a more inclusive reference?
         self.worse_threshold = 0.005
         # /public/groups/vg/vg-data on Courtyard is served as
-        # https://public.gi.ucsc.edu/~anovak/vg-data/
-        self.vg_data = 'https://public.gi.ucsc.edu/~anovak/vg-data'
+        # https://public.gi.ucsc.edu/cgl/ci/vg/vg-data/
+        self.vg_data = 'https://public.gi.ucsc.edu/cgl/ci/vg/vg-data'
         self.input_store = self.vg_data + '/bakeoff'
         self.vg_docker = None
         self.container = None # Use value from config file, if any.

--- a/vgci/vgci.sh
+++ b/vgci/vgci.sh
@@ -32,7 +32,7 @@ KEEP_INTERMEDIATE_FILES=0
 # Should we show stdout and stderr from tests? If so, set to "-s".
 SHOW_OPT=""
 # What toil-vg should we install?
-TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@db3dbc9616f60187cdad248f7d7c4d42e83f3549"
+TOIL_VG_PACKAGE="git+https://github.com/vgteam/toil-vg.git@f5f703b129fb7577f8ae91b80e1bb3ac92ab8628"
 # What toil should we install?
 # Could be something like "toil[aws,mesos]==3.20.0"
 # or "toil[wdl,aws,mesos]@git+https://github.com/DataBiosphere/toil.git@52aa2979f23c24001837b2808552973e7bb263e6"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg CI data is no longer hosted under a user public_html directory

## Description

This moves where we get the out-of-source-tree CI data from to be under https://public.gi.ucsc.edu/cgl/ci/vg/vg-data/, which is more permanent.

It also points at toil-vg with https://github.com/vgteam/toil-vg/pull/866 which does the same there.