### PR TITLE
add new "sampling" workflow to vg autoindex

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -4670,10 +4670,8 @@ vector<IndexName> VGIndexes::get_default_long_path_giraffe_indexes() {
 
 vector<IndexName> VGIndexes::get_default_haplotype_sampling_indexes() {
     vector<IndexName> indexes{
-        "Top Level Chain Distance Index",
         "GBZ",
         "Haplotype Index",
-        "r Index"
     };
     return indexes;
 }

--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -4668,6 +4668,16 @@ vector<IndexName> VGIndexes::get_default_long_path_giraffe_indexes() {
     return indexes;
 }
 
+vector<IndexName> VGIndexes::get_default_haplotype_sampling_indexes() {
+    vector<IndexName> indexes{
+        "Top Level Chain Distance Index",
+        "GBZ",
+        "Haplotype Index",
+        "r Index"
+    };
+    return indexes;
+}
+
 bool IndexingPlan::is_intermediate(const IndexName& identifier) const {
     if (registry->get_index(identifier)->was_provided_directly()) {
         // It's not an intermediate if it is input

--- a/src/index_registry.hpp
+++ b/src/index_registry.hpp
@@ -163,6 +163,8 @@ struct VGIndexes {
     static vector<IndexName> get_default_long_giraffe_indexes();
     /// A list of the identifiers of the default indexes to run vg giraffe on long reads with path minimizers
     static vector<IndexName> get_default_long_path_giraffe_indexes();
+    /// A list of the identifiers of the default indexes to run vg haplotypes
+    static vector<IndexName> get_default_haplotype_sampling_indexes();
 };
 
 /**

--- a/src/subcommand/autoindex_main.cpp
+++ b/src/subcommand/autoindex_main.cpp
@@ -98,7 +98,7 @@ void help_autoindex(char** argv) {
          << "output:" << endl
          << "  -p, --prefix PREFIX    prefix to use for all output [index]" << endl
          << "  -w, --workflow NAME    workflow to produce indexes for (may repeat) [map]" << endl
-         << "                         {map, mpmap, rpvg, giraffe, sr-giraffe, lr-giraffe}" << endl
+         << "                         {map, mpmap, rpvg, sr-giraffe, lr-giraffe, sampling}" << endl
          << "input data:" << endl
          << "  -r, --ref-fasta FILE   FASTA file with the reference sequence (may repeat)" << endl
          << "  -v, --vcf FILE         VCF file with sequence names matching -r (may repeat)" << endl
@@ -227,6 +227,11 @@ int main_autoindex(int argc, char** argv) {
                 }
                 else if (optarg == string("rpvg")) {
                     for (auto& target : VGIndexes::get_default_rpvg_indexes()) {
+                        targets.emplace_back(std::move(target));
+                    }
+                }
+                else if (optarg == string("sampling")) {
+                    for (auto& target : VGIndexes::get_default_haplotype_sampling_indexes()) {
                         targets.emplace_back(std::move(target));
                     }
                 }

--- a/test/t/52_vg_autoindex.t
+++ b/test/t/52_vg_autoindex.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 64
+plan tests 66
 
 rm auto.*
 
@@ -212,4 +212,11 @@ vg autoindex -p auto -w lr-giraffe --gfa graphs/chain-clip.gfa
 is "$(echo $?)" 0 "autoindexing successfully completes indexing of graph with oversized snarls"
 
 rm auto.* log.txt
+
+vg autoindex -p auto -w sampling --gfa graphs/gfa_with_reference.gfa
+is "$(echo $?)" 0 "autoindexing successfully completes indexing for haplotype sampling"
+vg haplotypes -i auto.hapl -k haplotype-sampling/HG003.kff -g sampled.gbz auto.gbz
+is "$(echo $?)" 0 "haplotype sampling indexes can be used"
+
+rm auto.* sampled.gbz
 rm read.fq read.gam


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg autoindex` has a `-w sampling` workflow to make indexes for haplotype sampling 

## Description

Resolves #4872

That was easier than expected. I figured out the various places that would need to be poked in order to register a new workflow (thankfully all of the individual pieces were already known as recipes) and slapped this together. Should make it easier to point folks who need to make these indexes because they can't index the full graph.