### PR TITLE
Fix potentially very large loop when looking for rescue graph

### DIFF
--- a/src/snarl_distance_index.cpp
+++ b/src/snarl_distance_index.cpp
@@ -1654,7 +1654,8 @@ cerr << "Start search along parent chain " << distance_index.net_handle_as_strin
                 super_graph->follow_edges(current_loop_handle, false, [&](const handle_t& next_handle) {
                     //If the next node is close enough and isn't exiting the snarl, then add it to stack
                     size_t new_distance = SnarlDistanceIndex::sum(current_loop_distance, super_graph->get_length(next_handle));
-                    if (new_distance < min_distance && next_handle != start_out && next_handle != end_out) {
+                    if (new_distance < min_distance && next_handle != start_out && next_handle != end_out &&
+                        seen_nodes.count(std::make_pair(super_graph->get_id(next_handle), super_graph->get_is_reverse(next_handle))) == 0) {
                         loop_handles_to_check.emplace_back(next_handle, new_distance);
                     }
                 });
@@ -1882,7 +1883,8 @@ void subgraph_in_distance_range_walk_across_chain (const SnarlDistanceIndex& dis
                             super_graph->follow_edges(current_loop_handle, false, [&](const handle_t& next_handle) {
                                 //If the next node is close enough and isn't exiting the snarl, then add it to stack
                                 size_t new_distance = SnarlDistanceIndex::sum(current_loop_distance, super_graph->get_length(next_handle));
-                                if (new_distance < min_distance && next_handle != start_out && next_handle != end_out) {
+                                if (new_distance < min_distance && next_handle != start_out && next_handle != end_out &&
+                                    seen_nodes.count(std::make_pair(super_graph->get_id(next_handle), super_graph->get_is_reverse(next_handle))) == 0) {
                                     loop_handles_to_check.emplace_back(next_handle, new_distance);
                                 }
                             });


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fix bug making giraffe rescue slow

## Description
This fixes a bug where the rescue graph finding algorithm could go through a loop multiple times until it hit the minimum distance. This was very slow when the loop was one bp.