### PR TITLE
Rebrand augmented reference (augref) as graph reference (gref)

### DIFF
--- a/src/graph_caller.cpp
+++ b/src/graph_caller.cpp
@@ -1,7 +1,7 @@
 #include "graph_caller.hpp"
 #include "algorithms/expand_context.hpp"
 #include "annotation.hpp"
-#include "augref.hpp"
+#include "gref.hpp"
 
 //#define debug
 
@@ -1976,16 +1976,16 @@ bool FlowCaller::call_snarl_internal(const Snarl& managed_snarl,
 #endif
     }
 
-    // Use parent's ref path if no direct path, otherwise prefer base reference over augref paths
+    // Use parent's ref path if no direct path, otherwise prefer base reference over gref paths
     string ref_path_name;
     if (common_names.empty()) {
         ref_path_name = parent_ref_path_name;
     } else {
-        // Prefer base reference paths over derived augref paths
-        // common_names is sorted, so we iterate to find first non-augref path
+        // Prefer base reference paths over derived gref paths
+        // common_names is sorted, so we iterate to find first non-gref path
         ref_path_name = common_names.front();  // default to first (lexicographically smallest)
         for (const string& name : common_names) {
-            if (!AugRefCover::is_augref_name(name)) {
+            if (!GrefCover::is_gref_name(name)) {
                 ref_path_name = name;
                 break;
             }
@@ -2439,10 +2439,10 @@ bool NestedFlowCaller::call_snarl_recursive(const Snarl& managed_snarl, int max_
     pair<size_t, size_t> gt_ref_interval;
     
     if (!common_names.empty()) {
-        // Prefer base reference paths over derived augref paths
+        // Prefer base reference paths over derived gref paths
         ref_path_name = common_names.front();  // default to first (lexicographically smallest)
         for (const string& name : common_names) {
-            if (!AugRefCover::is_augref_name(name)) {
+            if (!GrefCover::is_gref_name(name)) {
                 ref_path_name = name;
                 break;
             }

--- a/src/graph_caller.hpp
+++ b/src/graph_caller.hpp
@@ -15,7 +15,7 @@
 #include "region.hpp"
 #include "zstdutil.hpp"
 #include "vg/io/alignment_emitter.hpp"
-#include "augref.hpp"
+#include "gref.hpp"
 
 namespace vg {
 

--- a/src/gref.cpp
+++ b/src/gref.cpp
@@ -1,4 +1,4 @@
-#include "augref.hpp"
+#include "gref.hpp"
 #include <sstream>
 #include <algorithm>
 #include <functional>
@@ -11,20 +11,20 @@ namespace vg {
 
 using namespace std;
 
-const string AugRefCover::augref_suffix = "_alt";
+const string GrefCover::gref_suffix = "_alt";
 
-string AugRefCover::make_augref_name(const string& base_path_name, int64_t augref_index) {
+string GrefCover::make_gref_name(const string& base_path_name, int64_t gref_index) {
     // New naming convention: {base}_{N}_alt
-    return base_path_name + "_" + to_string(augref_index) + augref_suffix;
+    return base_path_name + "_" + to_string(gref_index) + gref_suffix;
 }
 
-bool AugRefCover::is_augref_name(const string& path_name) {
+bool GrefCover::is_gref_name(const string& path_name) {
     // Check for pattern: _{digits}_alt at the end
     // Must end with "_alt"
     if (path_name.length() < 7) {  // minimum: "x_1_alt" (7 chars)
         return false;
     }
-    if (path_name.substr(path_name.length() - 4) != augref_suffix) {
+    if (path_name.substr(path_name.length() - 4) != gref_suffix) {
         return false;
     }
     // Find the underscore before the digits
@@ -42,61 +42,61 @@ bool AugRefCover::is_augref_name(const string& path_name) {
     return true;
 }
 
-string AugRefCover::parse_base_path(const string& augref_name) {
-    if (!is_augref_name(augref_name)) {
-        return augref_name;
+string GrefCover::parse_base_path(const string& gref_name) {
+    if (!is_gref_name(gref_name)) {
+        return gref_name;
     }
     // Find _{N}_alt and strip it
-    size_t alt_pos = augref_name.length() - 4;  // position of "_alt"
-    size_t underscore_pos = augref_name.rfind('_', alt_pos - 1);
-    return augref_name.substr(0, underscore_pos);
+    size_t alt_pos = gref_name.length() - 4;  // position of "_alt"
+    size_t underscore_pos = gref_name.rfind('_', alt_pos - 1);
+    return gref_name.substr(0, underscore_pos);
 }
 
-int64_t AugRefCover::parse_augref_index(const string& augref_name) {
-    if (!is_augref_name(augref_name)) {
+int64_t GrefCover::parse_gref_index(const string& gref_name) {
+    if (!is_gref_name(gref_name)) {
         return -1;
     }
     // Extract N from _{N}_alt
-    size_t alt_pos = augref_name.length() - 4;  // position of "_alt"
-    size_t underscore_pos = augref_name.rfind('_', alt_pos - 1);
-    return stoll(augref_name.substr(underscore_pos + 1, alt_pos - underscore_pos - 1));
+    size_t alt_pos = gref_name.length() - 4;  // position of "_alt"
+    size_t underscore_pos = gref_name.rfind('_', alt_pos - 1);
+    return stoll(gref_name.substr(underscore_pos + 1, alt_pos - underscore_pos - 1));
 }
 
-void AugRefCover::set_augref_sample(const string& sample_name) {
-    this->augref_sample_name = sample_name;
+void GrefCover::set_gref_sample(const string& sample_name) {
+    this->gref_sample_name = sample_name;
 }
 
-const string& AugRefCover::get_augref_sample() const {
-    return this->augref_sample_name;
+const string& GrefCover::get_gref_sample() const {
+    return this->gref_sample_name;
 }
 
-void AugRefCover::set_verbose(bool verbose) {
+void GrefCover::set_verbose(bool verbose) {
     this->verbose = verbose;
 }
 
-bool AugRefCover::get_verbose() const {
+bool GrefCover::get_verbose() const {
     return this->verbose;
 }
 
-void AugRefCover::clear(MutablePathMutableHandleGraph* graph) {
-    vector<path_handle_t> augref_paths_to_remove;
+void GrefCover::clear(MutablePathMutableHandleGraph* graph) {
+    vector<path_handle_t> gref_paths_to_remove;
     graph->for_each_path_handle([&](path_handle_t path_handle) {
-        if (is_augref_name(graph->get_path_name(path_handle))) {
-            augref_paths_to_remove.push_back(path_handle);
+        if (is_gref_name(graph->get_path_name(path_handle))) {
+            gref_paths_to_remove.push_back(path_handle);
         }
     });
-    for (path_handle_t path_handle : augref_paths_to_remove) {
+    for (path_handle_t path_handle : gref_paths_to_remove) {
         graph->destroy_path(path_handle);
     }
 }
 
-void AugRefCover::compute(const PathHandleGraph* graph,
+void GrefCover::compute(const PathHandleGraph* graph,
                             SnarlManager* snarl_manager,
                             const unordered_set<path_handle_t>& reference_paths,
                             int64_t minimum_length) {
 
     // start from scratch
-    this->augref_intervals.clear();
+    this->gref_intervals.clear();
     this->interval_snarl_bounds.clear();
     this->node_to_interval.clear();
     this->graph = graph;
@@ -113,40 +113,40 @@ void AugRefCover::compute(const PathHandleGraph* graph,
 
     // start with the reference paths
     for (const path_handle_t& ref_path_handle : reference_paths) {
-        this->augref_intervals.push_back(make_pair(graph->path_begin(ref_path_handle),
+        this->gref_intervals.push_back(make_pair(graph->path_begin(ref_path_handle),
                                                     graph->path_end(ref_path_handle)));
         this->interval_snarl_bounds.push_back({0, 0});
         graph->for_each_step_in_path(ref_path_handle, [&](step_handle_t step_handle) {
             nid_t node_id = graph->get_id(graph->get_handle_of_step(step_handle));
             if (node_to_interval.count(node_id)) {
-                cerr << "[augref error]: node " << node_id << " covered by two reference paths,"
+                cerr << "[gref error]: node " << node_id << " covered by two reference paths,"
                      << " including " << graph->get_path_name(ref_path_handle) << " and "
-                     << graph->get_path_name(graph->get_path_handle_of_step(augref_intervals.at(node_to_interval.at(node_id)).first))
-                     << ". Augmented reference path support currently requires disjoint acyclic reference paths" << endl;
+                     << graph->get_path_name(graph->get_path_handle_of_step(gref_intervals.at(node_to_interval.at(node_id)).first))
+                     << ". Graph reference path support currently requires disjoint acyclic reference paths" << endl;
                 exit(1);
             }
-            node_to_interval[node_id] = augref_intervals.size() - 1;
+            node_to_interval[node_id] = gref_intervals.size() - 1;
         });
     }
-    this->num_ref_intervals = this->augref_intervals.size();
+    this->num_ref_intervals = this->gref_intervals.size();
 
 #ifdef debug
 #pragma omp critical(cerr)
-    cerr << "[augref] Selected " << augref_intervals.size() << " rank=0 reference paths" << endl;
+    cerr << "[gref] Selected " << gref_intervals.size() << " rank=0 reference paths" << endl;
 #endif
 
     // we use the path traversal finder for everything
     PathTraversalFinder path_trav_finder(*graph);
 
-    // we collect the augref cover in parallel as a list of path fragments
+    // we collect the gref cover in parallel as a list of path fragments
     size_t thread_count = get_thread_count();
-    vector<vector<pair<step_handle_t, step_handle_t>>> augref_intervals_vector(thread_count);
+    vector<vector<pair<step_handle_t, step_handle_t>>> gref_intervals_vector(thread_count);
     vector<vector<pair<nid_t, nid_t>>> snarl_bounds_vector(thread_count);
 
     // we process top-level snarls in parallel
     snarl_manager->for_each_top_level_snarl_parallel([&](const Snarl* snarl) {
         // per-thread output (intervals and snarl bounds accumulate across snarls)
-        vector<pair<step_handle_t, step_handle_t>>& thread_augref_intervals = augref_intervals_vector[omp_get_thread_num()];
+        vector<pair<step_handle_t, step_handle_t>>& thread_gref_intervals = gref_intervals_vector[omp_get_thread_num()];
         vector<pair<nid_t, nid_t>>& thread_snarl_bounds = snarl_bounds_vector[omp_get_thread_num()];
         // scratch: maps node IDs to interval indices within this snarl only
         unordered_map<nid_t, int64_t> thread_node_to_interval;
@@ -163,7 +163,7 @@ void AugRefCover::compute(const PathHandleGraph* graph,
 
             // get the snarl cover
             compute_snarl(*cur_snarl, path_trav_finder, 1 /*defer length filter to post-merge*/,
-                          thread_augref_intervals,
+                          thread_gref_intervals,
                           thread_node_to_interval,
                           top_snarl_start, top_snarl_end,
                           thread_snarl_bounds);
@@ -187,8 +187,8 @@ void AugRefCover::compute(const PathHandleGraph* graph,
     };
     vector<FoldEntry> all_intervals;
     for (int64_t t = 0; t < thread_count; ++t) {
-        for (int64_t j = 0; j < augref_intervals_vector[t].size(); ++j) {
-            const auto& interval = augref_intervals_vector[t][j];
+        for (int64_t j = 0; j < gref_intervals_vector[t].size(); ++j) {
+            const auto& interval = gref_intervals_vector[t][j];
             if (interval.first != graph->path_end(graph->get_path_handle_of_step(interval.first))) {
                 nid_t first_id = graph->get_id(graph->get_handle_of_step(interval.first));
                 nid_t last_id = graph->get_id(graph->get_handle_of_step(
@@ -198,7 +198,7 @@ void AugRefCover::compute(const PathHandleGraph* graph,
                                          graph->get_path_name(graph->get_path_handle_of_step(interval.first))});
             }
         }
-        augref_intervals_vector[t].clear();
+        gref_intervals_vector[t].clear();
         snarl_bounds_vector[t].clear();
     }
     std::sort(all_intervals.begin(), all_intervals.end(), [&](const FoldEntry& a, const FoldEntry& b) {
@@ -239,7 +239,7 @@ void AugRefCover::compute(const PathHandleGraph* graph,
                 continue;
             }
         }
-        add_interval(this->augref_intervals, this->node_to_interval, entry.interval, true,
+        add_interval(this->gref_intervals, this->node_to_interval, entry.interval, true,
                      &this->interval_snarl_bounds, entry.snarl_bounds);
         try_cross_path_merge(entry.interval.first);
     }
@@ -262,13 +262,13 @@ void AugRefCover::compute(const PathHandleGraph* graph,
     filter_short_intervals(minimum_length);
 
     if (verbose) {
-        int64_t final_alt = augref_intervals.size() - num_ref_intervals;
-        cerr << "[augref] After length filter (min " << minimum_length << " bp): "
+        int64_t final_alt = gref_intervals.size() - num_ref_intervals;
+        cerr << "[gref] After length filter (min " << minimum_length << " bp): "
              << final_alt << " alt intervals" << endl;
     }
 }
 
-void AugRefCover::fill_uncovered_nodes(int64_t minimum_length) {
+void GrefCover::fill_uncovered_nodes(int64_t minimum_length) {
     // Collect all uncovered nodes and the paths that pass through them
     unordered_set<nid_t> uncovered_nodes;
     map<string, path_handle_t> candidate_paths;  // sorted by name for deterministic ordering
@@ -281,8 +281,8 @@ void AugRefCover::fill_uncovered_nodes(int64_t minimum_length) {
             graph->for_each_step_on_handle(handle, [&](step_handle_t step) {
                 path_handle_t path_handle = graph->get_path_handle_of_step(step);
                 string path_name = graph->get_path_name(path_handle);
-                // Skip existing augref paths
-                if (!is_augref_name(path_name)) {
+                // Skip existing gref paths
+                if (!is_gref_name(path_name)) {
                     candidate_paths[path_name] = path_handle;
                 }
                 return true;
@@ -296,7 +296,7 @@ void AugRefCover::fill_uncovered_nodes(int64_t minimum_length) {
 
 #ifdef debug
 #pragma omp critical(cerr)
-    cerr << "[augref] fill_uncovered_nodes: " << uncovered_nodes.size() << " uncovered nodes, "
+    cerr << "[gref] fill_uncovered_nodes: " << uncovered_nodes.size() << " uncovered nodes, "
          << candidate_paths.size() << " candidate paths" << endl;
 #endif
 
@@ -317,7 +317,7 @@ void AugRefCover::fill_uncovered_nodes(int64_t minimum_length) {
         auto close_interval = [&]() {
             if (in_interval) {
                 if (interval_length >= minimum_length) {
-                    add_interval(this->augref_intervals, this->node_to_interval,
+                    add_interval(this->gref_intervals, this->node_to_interval,
                                  make_pair(interval_start, interval_end), true,
                                  &this->interval_snarl_bounds, {0, 0});
                     try_cross_path_merge(interval_start);
@@ -381,14 +381,14 @@ void AugRefCover::fill_uncovered_nodes(int64_t minimum_length) {
 
 #ifdef debug
 #pragma omp critical(cerr)
-    cerr << "[augref] fill_uncovered_nodes: " << uncovered_nodes.size() << " nodes still uncovered after second pass" << endl;
+    cerr << "[gref] fill_uncovered_nodes: " << uncovered_nodes.size() << " nodes still uncovered after second pass" << endl;
 #endif
 }
 
-void AugRefCover::load(const PathHandleGraph* graph,
+void GrefCover::load(const PathHandleGraph* graph,
                          const unordered_set<path_handle_t>& reference_paths) {
     // start from scratch
-    this->augref_intervals.clear();
+    this->gref_intervals.clear();
     this->interval_snarl_bounds.clear();
     this->node_to_interval.clear();
     this->graph = graph;
@@ -398,89 +398,89 @@ void AugRefCover::load(const PathHandleGraph* graph,
         graph->for_each_step_in_path(ref_path_handle, [&](step_handle_t step_handle) {
             nid_t node_id = graph->get_id(graph->get_handle_of_step(step_handle));
             if (graph->get_is_reverse(graph->get_handle_of_step(step_handle))) {
-                cerr << "[augref] error: Reversed step " << node_id << " found in rank-0 reference "
-                     << graph->get_path_name(ref_path_handle) << ". All augref fragments must be forward-only." << endl;
+                cerr << "[gref] error: Reversed step " << node_id << " found in rank-0 reference "
+                     << graph->get_path_name(ref_path_handle) << ". All gref fragments must be forward-only." << endl;
                 exit(1);
             }
             if (node_to_interval.count(node_id)) {
-                cerr << "[augref] error: Cycle found on node " << node_id << " in rank-0 reference "
-                     << graph->get_path_name(ref_path_handle) << ". All augref fragments must be acyclic." << endl;
+                cerr << "[gref] error: Cycle found on node " << node_id << " in rank-0 reference "
+                     << graph->get_path_name(ref_path_handle) << ". All gref fragments must be acyclic." << endl;
                 exit(1);
             }
-            node_to_interval[node_id] = augref_intervals.size();
+            node_to_interval[node_id] = gref_intervals.size();
         });
-        this->augref_intervals.push_back(make_pair(graph->path_begin(ref_path_handle),
+        this->gref_intervals.push_back(make_pair(graph->path_begin(ref_path_handle),
                                                     graph->path_end(ref_path_handle)));
         this->interval_snarl_bounds.push_back({0, 0});
     }
-    this->num_ref_intervals = this->augref_intervals.size();
+    this->num_ref_intervals = this->gref_intervals.size();
 
-    // load existing augref paths from the graph
+    // load existing gref paths from the graph
     graph->for_each_path_handle([&](path_handle_t path_handle) {
         string path_name = graph->get_path_name(path_handle);
-        if (is_augref_name(path_name)) {
+        if (is_gref_name(path_name)) {
             graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
-                node_to_interval[graph->get_id(graph->get_handle_of_step(step_handle))] = augref_intervals.size();
+                node_to_interval[graph->get_id(graph->get_handle_of_step(step_handle))] = gref_intervals.size();
             });
-            this->augref_intervals.push_back(make_pair(graph->path_begin(path_handle),
+            this->gref_intervals.push_back(make_pair(graph->path_begin(path_handle),
                                                         graph->path_end(path_handle)));
             this->interval_snarl_bounds.push_back({0, 0});
         }
     });
 }
 
-void AugRefCover::apply(MutablePathMutableHandleGraph* mutable_graph) {
+void GrefCover::apply(MutablePathMutableHandleGraph* mutable_graph) {
     if (this->graph != static_cast<const PathHandleGraph*>(mutable_graph)) {
-        cerr << "[augref] error: apply() called with a different graph than compute()/load()" << endl;
+        cerr << "[gref] error: apply() called with a different graph than compute()/load()" << endl;
         exit(1);
     }
 #ifdef debug
-    cerr << "applying augref cover with " << this->num_ref_intervals << " ref intervals "
-         << " and " << this->augref_intervals.size() << " total intervals" << endl;
+    cerr << "applying gref cover with " << this->num_ref_intervals << " ref intervals "
+         << " and " << this->gref_intervals.size() << " total intervals" << endl;
 #endif
 
-    // If augref_sample_name is set, first copy base reference paths to the new sample
-    if (!augref_sample_name.empty()) {
+    // If gref_sample_name is set, first copy base reference paths to the new sample
+    if (!gref_sample_name.empty()) {
         // Collect reference path handles from the reference intervals
         unordered_set<path_handle_t> reference_paths;
         for (int64_t i = 0; i < this->num_ref_intervals; ++i) {
-            reference_paths.insert(graph->get_path_handle_of_step(augref_intervals[i].first));
+            reference_paths.insert(graph->get_path_handle_of_step(gref_intervals[i].first));
         }
         copy_base_paths_to_sample(mutable_graph, reference_paths);
     }
 
-    // Reset augref counters for each base path
-    base_path_augref_counter.clear();
+    // Reset gref counters for each base path
+    base_path_gref_counter.clear();
 
-    // First pass: determine the maximum existing augref index for each base path
-    // This ensures we don't overwrite existing augref paths
+    // First pass: determine the maximum existing gref index for each base path
+    // This ensures we don't overwrite existing gref paths
     mutable_graph->for_each_path_handle([&](path_handle_t path_handle) {
         string path_name = mutable_graph->get_path_name(path_handle);
-        if (is_augref_name(path_name)) {
+        if (is_gref_name(path_name)) {
             string base = parse_base_path(path_name);
-            int64_t idx = parse_augref_index(path_name);
-            if (base_path_augref_counter.count(base)) {
-                base_path_augref_counter[base] = max(base_path_augref_counter[base], idx);
+            int64_t idx = parse_gref_index(path_name);
+            if (base_path_gref_counter.count(base)) {
+                base_path_gref_counter[base] = max(base_path_gref_counter[base], idx);
             } else {
-                base_path_augref_counter[base] = idx;
+                base_path_gref_counter[base] = idx;
             }
         }
     });
 
-    // write the augref paths
+    // write the gref paths
     int64_t written_intervals = 0;
     int64_t written_length = 0;
     int64_t skipped_intervals = 0;
-    for (int64_t i = this->num_ref_intervals; i < this->augref_intervals.size(); ++i) {
+    for (int64_t i = this->num_ref_intervals; i < this->gref_intervals.size(); ++i) {
         // Skip empty intervals (these can be created by defragment_intervals or merging)
-        path_handle_t interval_path = graph->get_path_handle_of_step(augref_intervals[i].first);
-        if (augref_intervals[i].first == graph->path_end(interval_path)) {
+        path_handle_t interval_path = graph->get_path_handle_of_step(gref_intervals[i].first);
+        if (gref_intervals[i].first == graph->path_end(interval_path)) {
             skipped_intervals++;
             continue;
         }
 
-        // Find the reference path this augref path extends from by tracing back to reference
-        nid_t first_node = graph->get_id(graph->get_handle_of_step(augref_intervals[i].first));
+        // Find the reference path this gref path extends from by tracing back to reference
+        nid_t first_node = graph->get_id(graph->get_handle_of_step(gref_intervals[i].first));
         vector<pair<int64_t, nid_t>> ref_nodes = this->get_reference_nodes(first_node, true);
 
         // Get the reference path name from the reference node
@@ -488,21 +488,21 @@ void AugRefCover::apply(MutablePathMutableHandleGraph* mutable_graph) {
         if (!ref_nodes.empty()) {
             nid_t ref_node_id = ref_nodes.at(0).second;
             int64_t ref_interval_idx = this->node_to_interval.at(ref_node_id);
-            path_handle_t ref_path_handle = graph->get_path_handle_of_step(augref_intervals[ref_interval_idx].first);
+            path_handle_t ref_path_handle = graph->get_path_handle_of_step(gref_intervals[ref_interval_idx].first);
             base_path_name = graph->get_path_name(ref_path_handle);
             // Strip any subrange from the reference path name
             subrange_t subrange;
             base_path_name = Paths::strip_subrange(base_path_name, &subrange);
         } else {
             // Fallback to source path if no reference found (shouldn't happen)
-            path_handle_t source_path_handle = mutable_graph->get_path_handle_of_step(augref_intervals[i].first);
+            path_handle_t source_path_handle = mutable_graph->get_path_handle_of_step(gref_intervals[i].first);
             base_path_name = graph->get_path_name(source_path_handle);
             subrange_t subrange;
             base_path_name = Paths::strip_subrange(base_path_name, &subrange);
         }
 
-        // If augref_sample_name is set, replace the sample in base_path_name
-        if (!augref_sample_name.empty()) {
+        // If gref_sample_name is set, replace the sample in base_path_name
+        if (!gref_sample_name.empty()) {
             PathSense sense;
             string sample, locus;
             size_t haplotype, phase_block;
@@ -510,20 +510,20 @@ void AugRefCover::apply(MutablePathMutableHandleGraph* mutable_graph) {
             PathMetadata::parse_path_name(base_path_name, sense, sample, locus, haplotype, phase_block, subrange);
 
             if (sample.empty()) {
-                // Simple path name - prepend augref sample
-                base_path_name = augref_sample_name + "#0#" + base_path_name;
+                // Simple path name - prepend gref sample
+                base_path_name = gref_sample_name + "#0#" + base_path_name;
             } else {
-                // Replace sample with augref sample
-                base_path_name = PathMetadata::create_path_name(sense, augref_sample_name, locus, haplotype, phase_block, subrange);
+                // Replace sample with gref sample
+                base_path_name = PathMetadata::create_path_name(sense, gref_sample_name, locus, haplotype, phase_block, subrange);
             }
         }
 
         // Check if this interval is all-reverse (needs to be flipped when writing)
-        bool all_reverse = graph->get_is_reverse(graph->get_handle_of_step(augref_intervals[i].first));
+        bool all_reverse = graph->get_is_reverse(graph->get_handle_of_step(gref_intervals[i].first));
 
         // Safety check: verify consistent orientation (should be guaranteed by upstream filtering)
         bool mixed = false;
-        for (step_handle_t step_handle = augref_intervals[i].first; step_handle != augref_intervals[i].second;
+        for (step_handle_t step_handle = gref_intervals[i].first; step_handle != gref_intervals[i].second;
              step_handle = graph->get_next_step(step_handle)) {
             if (graph->get_is_reverse(graph->get_handle_of_step(step_handle)) != all_reverse) {
                 mixed = true;
@@ -536,33 +536,33 @@ void AugRefCover::apply(MutablePathMutableHandleGraph* mutable_graph) {
             continue;
         }
 
-        // Get next available augref index for this base path
-        int64_t augref_index = ++base_path_augref_counter[base_path_name];
+        // Get next available gref index for this base path
+        int64_t gref_index = ++base_path_gref_counter[base_path_name];
 
-        // Create the augref path name
-        string augref_name = make_augref_name(base_path_name, augref_index);
+        // Create the gref path name
+        string gref_name = make_gref_name(base_path_name, gref_index);
 
         // Create the path as REFERENCE sense
-        path_handle_t augref_handle = mutable_graph->create_path_handle(augref_name, false);
+        path_handle_t gref_handle = mutable_graph->create_path_handle(gref_name, false);
 
         int64_t interval_length = 0;
         if (!all_reverse) {
             // Forward interval: walk forward and append steps as-is
-            for (step_handle_t step_handle = augref_intervals[i].first; step_handle != augref_intervals[i].second;
+            for (step_handle_t step_handle = gref_intervals[i].first; step_handle != gref_intervals[i].second;
                  step_handle = mutable_graph->get_next_step(step_handle)) {
-                mutable_graph->append_step(augref_handle, mutable_graph->get_handle_of_step(step_handle));
+                mutable_graph->append_step(gref_handle, mutable_graph->get_handle_of_step(step_handle));
                 interval_length += mutable_graph->get_length(mutable_graph->get_handle_of_step(step_handle));
             }
         } else {
             // All-reverse interval: collect handles, reverse order, flip each to forward
             vector<handle_t> handles;
-            for (step_handle_t step_handle = augref_intervals[i].first; step_handle != augref_intervals[i].second;
+            for (step_handle_t step_handle = gref_intervals[i].first; step_handle != gref_intervals[i].second;
                  step_handle = graph->get_next_step(step_handle)) {
                 handles.push_back(mutable_graph->flip(mutable_graph->get_handle_of_step(step_handle)));
             }
             std::reverse(handles.begin(), handles.end());
             for (handle_t h : handles) {
-                mutable_graph->append_step(augref_handle, h);
+                mutable_graph->append_step(gref_handle, h);
                 interval_length += mutable_graph->get_length(h);
             }
         }
@@ -571,34 +571,34 @@ void AugRefCover::apply(MutablePathMutableHandleGraph* mutable_graph) {
     }
 
 #ifdef debug
-    cerr << "[augref] apply: wrote " << written_intervals << " augref paths (" << written_length << " bp), skipped " << skipped_intervals << " empty intervals" << endl;
+    cerr << "[gref] apply: wrote " << written_intervals << " gref paths (" << written_length << " bp), skipped " << skipped_intervals << " empty intervals" << endl;
 #endif
 }
 
-int64_t AugRefCover::get_rank(nid_t node_id) const {
+int64_t GrefCover::get_rank(nid_t node_id) const {
     // search back to reference in order to find the rank.
     vector<pair<int64_t, nid_t>> ref_steps = this->get_reference_nodes(node_id, true);
     // Return -1 if node is in a disconnected component that can't reach reference
     return ref_steps.empty() ? -1 : ref_steps.at(0).first;
 }
 
-const vector<pair<step_handle_t, step_handle_t>>& AugRefCover::get_intervals() const {
-    return this->augref_intervals;
+const vector<pair<step_handle_t, step_handle_t>>& GrefCover::get_intervals() const {
+    return this->gref_intervals;
 }
 
-const pair<step_handle_t, step_handle_t>* AugRefCover::get_interval(nid_t node_id) const {
+const pair<step_handle_t, step_handle_t>* GrefCover::get_interval(nid_t node_id) const {
     if (this->node_to_interval.count(node_id)) {
-        return &this->augref_intervals.at(node_to_interval.at(node_id));
+        return &this->gref_intervals.at(node_to_interval.at(node_id));
     }
     return nullptr;
 }
 
-int64_t AugRefCover::get_num_ref_intervals() const {
+int64_t GrefCover::get_num_ref_intervals() const {
     return this->num_ref_intervals;
 }
 
-void AugRefCover::compute_snarl(const Snarl& snarl, PathTraversalFinder& path_trav_finder, int64_t minimum_length,
-                                  vector<pair<step_handle_t, step_handle_t>>& thread_augref_intervals,
+void GrefCover::compute_snarl(const Snarl& snarl, PathTraversalFinder& path_trav_finder, int64_t minimum_length,
+                                  vector<pair<step_handle_t, step_handle_t>>& thread_gref_intervals,
                                   unordered_map<nid_t, int64_t>& thread_node_to_interval,
                                   nid_t top_snarl_start, nid_t top_snarl_end,
                                   vector<pair<nid_t, nid_t>>& thread_snarl_bounds) {
@@ -613,10 +613,10 @@ void AugRefCover::compute_snarl(const Snarl& snarl, PathTraversalFinder& path_tr
         // reduce protobuf usage by going back to vector of steps instead of keeping SnarlTraversals around
         for (int64_t i = 0; i < path_travs.first.size(); ++i) {
             string trav_path_name = graph->get_path_name(graph->get_path_handle_of_step(path_travs.second[i].first));
-            if (is_augref_name(trav_path_name)) {
-                // we ignore existing (off-reference) augref paths
+            if (is_gref_name(trav_path_name)) {
+                // we ignore existing (off-reference) gref paths
 #ifdef debug
-                cerr << "Warning : skipping existing augref traversal " << trav_path_name << endl;
+                cerr << "Warning : skipping existing gref traversal " << trav_path_name << endl;
 #endif
                 continue;
             }
@@ -762,12 +762,12 @@ void AugRefCover::compute_snarl(const Snarl& snarl, PathTraversalFinder& path_tr
 #pragma omp critical(cerr)
         cerr << "adding interval with length " << interval_length << endl;
 #endif
-        add_interval(thread_augref_intervals, thread_node_to_interval, new_interval, false,
+        add_interval(thread_gref_intervals, thread_node_to_interval, new_interval, false,
                      &thread_snarl_bounds, {top_snarl_start, top_snarl_end});
     }
 }
 
-vector<pair<int64_t, int64_t>> AugRefCover::get_uncovered_intervals(const vector<step_handle_t>& trav,
+vector<pair<int64_t, int64_t>> GrefCover::get_uncovered_intervals(const vector<step_handle_t>& trav,
                                                                       const unordered_map<nid_t, int64_t>& thread_node_to_interval) {
 
     vector<pair<int64_t, int64_t>> intervals;
@@ -796,7 +796,7 @@ vector<pair<int64_t, int64_t>> AugRefCover::get_uncovered_intervals(const vector
     return intervals;
 }
 
-optional<step_handle_t> AugRefCover::try_extend_forward(step_handle_t start_step, path_handle_t path,
+optional<step_handle_t> GrefCover::try_extend_forward(step_handle_t start_step, path_handle_t path,
                                                          const pair<step_handle_t, step_handle_t>& other_interval) {
     step_handle_t path_end = graph->path_end(path);
     step_handle_t cur = start_step;
@@ -816,7 +816,7 @@ optional<step_handle_t> AugRefCover::try_extend_forward(step_handle_t start_step
     return cur; // new end step (one past last matching)
 }
 
-optional<step_handle_t> AugRefCover::try_extend_backward(step_handle_t start_step, path_handle_t path,
+optional<step_handle_t> GrefCover::try_extend_backward(step_handle_t start_step, path_handle_t path,
                                                           const pair<step_handle_t, step_handle_t>& other_interval) {
     // Collect other_interval's node IDs + orientations into a vector
     vector<pair<nid_t, bool>> other_steps;
@@ -850,7 +850,7 @@ optional<step_handle_t> AugRefCover::try_extend_backward(step_handle_t start_ste
     return graph->get_next_step(cur);
 }
 
-bool AugRefCover::merge_would_duplicate_node(const pair<step_handle_t, step_handle_t>& interval_a,
+bool GrefCover::merge_would_duplicate_node(const pair<step_handle_t, step_handle_t>& interval_a,
                                               const pair<step_handle_t, step_handle_t>& interval_b) const {
     // Walk the combined range [interval_a.first, interval_b.second) and check for
     // any node ID appearing twice.  This correctly handles both exact adjacency
@@ -865,7 +865,7 @@ bool AugRefCover::merge_would_duplicate_node(const pair<step_handle_t, step_hand
     return false;
 }
 
-bool AugRefCover::extension_would_duplicate_node(const unordered_map<nid_t, int64_t>& nti,
+bool GrefCover::extension_would_duplicate_node(const unordered_map<nid_t, int64_t>& nti,
                                                   int64_t target_interval_idx,
                                                   step_handle_t ext_start, step_handle_t ext_end) const {
     // Walk only the new/extension steps and check if any node already belongs
@@ -881,7 +881,7 @@ bool AugRefCover::extension_would_duplicate_node(const unordered_map<nid_t, int6
     return false;
 }
 
-bool AugRefCover::would_duplicate_node(bool global,
+bool GrefCover::would_duplicate_node(bool global,
                                         const unordered_map<nid_t, int64_t>& nti,
                                         int64_t target_idx,
                                         step_handle_t ext_start, step_handle_t ext_end,
@@ -894,7 +894,7 @@ bool AugRefCover::would_duplicate_node(bool global,
     }
 }
 
-bool AugRefCover::add_interval(vector<pair<step_handle_t, step_handle_t>>& thread_augref_intervals,
+bool GrefCover::add_interval(vector<pair<step_handle_t, step_handle_t>>& thread_gref_intervals,
                                  unordered_map<nid_t, int64_t>& thread_node_to_interval,
                                  const pair<step_handle_t, step_handle_t>& new_interval,
                                  bool global,
@@ -928,7 +928,7 @@ bool AugRefCover::add_interval(vector<pair<step_handle_t, step_handle_t>>& threa
         nid_t prev_node_id = graph->get_id(graph->get_handle_of_step(before_first_step));
         if (thread_node_to_interval.count(prev_node_id)) {
             int64_t prev_idx = thread_node_to_interval[prev_node_id];
-            pair<step_handle_t, step_handle_t>& prev_interval = thread_augref_intervals[prev_idx];
+            pair<step_handle_t, step_handle_t>& prev_interval = thread_gref_intervals[prev_idx];
             if (graph->get_path_handle_of_step(prev_interval.first) == path_handle) {
                 // Same-path left merge: only merge if orientations are consistent
                 bool orientations_match = graph->get_is_reverse(graph->get_handle_of_step(prev_interval.first)) ==
@@ -972,7 +972,7 @@ bool AugRefCover::add_interval(vector<pair<step_handle_t, step_handle_t>>& threa
         nid_t next_node_id = graph->get_id(graph->get_handle_of_step(new_interval.second));
         if (thread_node_to_interval.count(next_node_id)) {
             int64_t next_idx = thread_node_to_interval[next_node_id];
-            pair<step_handle_t, step_handle_t>& next_interval = thread_augref_intervals[next_idx];
+            pair<step_handle_t, step_handle_t>& next_interval = thread_gref_intervals[next_idx];
             path_handle_t next_path = graph->get_path_handle_of_step(next_interval.first);
             if (graph->get_path_handle_of_step(next_interval.first) == path_handle) {
                 // Same-path right merge: only merge if orientations are consistent
@@ -994,7 +994,7 @@ bool AugRefCover::add_interval(vector<pair<step_handle_t, step_handle_t>>& threa
                                                                  : next_interval.first;
                         no_dup = !would_duplicate_node(global, thread_node_to_interval, merged_interval_idx,
                                                        walk_start, next_interval.second,
-                                                       thread_augref_intervals[merged_interval_idx], next_interval);
+                                                       thread_gref_intervals[merged_interval_idx], next_interval);
                     } else {
                         // Walk new_interval against next_interval.
                         // Shared boundary is the LAST step of new_interval.
@@ -1026,7 +1026,7 @@ bool AugRefCover::add_interval(vector<pair<step_handle_t, step_handle_t>>& threa
                                 (*snarl_bounds_vec)[next_idx] = {0, 0};
                             }
                             // extend the merged interval right to cover new_interval + decommissioned next_interval
-                            thread_augref_intervals[merged_interval_idx].second = decom_saved_second;
+                            thread_gref_intervals[merged_interval_idx].second = decom_saved_second;
                         } else {
                             // extend next_interval left
                             next_interval.first = new_interval.first;
@@ -1041,8 +1041,8 @@ bool AugRefCover::add_interval(vector<pair<step_handle_t, step_handle_t>>& threa
 
     // --- Commit: apply the merge result ---
     if (!merged) {
-        merged_interval_idx = thread_augref_intervals.size();
-        thread_augref_intervals.push_back(new_interval);
+        merged_interval_idx = thread_gref_intervals.size();
+        thread_gref_intervals.push_back(new_interval);
         if (snarl_bounds_vec) {
             snarl_bounds_vec->push_back(snarl_bounds);
         }
@@ -1059,7 +1059,7 @@ bool AugRefCover::add_interval(vector<pair<step_handle_t, step_handle_t>>& threa
     return !merged;
 }
 
-void AugRefCover::try_cross_path_merge(step_handle_t ref_step) {
+void GrefCover::try_cross_path_merge(step_handle_t ref_step) {
     // Find which interval owns the node at ref_step.
     nid_t ref_nid = graph->get_id(graph->get_handle_of_step(ref_step));
     auto it = this->node_to_interval.find(ref_nid);
@@ -1067,7 +1067,7 @@ void AugRefCover::try_cross_path_merge(step_handle_t ref_step) {
         return;
     }
     int64_t my_idx = it->second;
-    pair<step_handle_t, step_handle_t>& my_interval = this->augref_intervals[my_idx];
+    pair<step_handle_t, step_handle_t>& my_interval = this->gref_intervals[my_idx];
     path_handle_t my_path = graph->get_path_handle_of_step(my_interval.first);
 
     // Check if interval is already decommissioned.
@@ -1077,7 +1077,7 @@ void AugRefCover::try_cross_path_merge(step_handle_t ref_step) {
 
     // Helper: decommission an interval (set to sentinels, clear snarl bounds).
     auto decommission = [&](int64_t idx) {
-        pair<step_handle_t, step_handle_t>& interval = this->augref_intervals[idx];
+        pair<step_handle_t, step_handle_t>& interval = this->gref_intervals[idx];
         path_handle_t path = graph->get_path_handle_of_step(interval.first);
         interval.first = graph->path_end(path);
         interval.second = graph->path_front_end(path);
@@ -1099,7 +1099,7 @@ void AugRefCover::try_cross_path_merge(step_handle_t ref_step) {
         auto prev_it = this->node_to_interval.find(prev_nid);
         if (prev_it != this->node_to_interval.end()) {
             int64_t other_idx = prev_it->second;
-            pair<step_handle_t, step_handle_t>& other_interval = this->augref_intervals[other_idx];
+            pair<step_handle_t, step_handle_t>& other_interval = this->gref_intervals[other_idx];
             path_handle_t other_path = graph->get_path_handle_of_step(other_interval.first);
             // Only cross-path: skip if same path.
             if (other_path != my_path) {
@@ -1152,7 +1152,7 @@ void AugRefCover::try_cross_path_merge(step_handle_t ref_step) {
         auto next_it = this->node_to_interval.find(next_nid);
         if (next_it != this->node_to_interval.end()) {
             int64_t other_idx = next_it->second;
-            pair<step_handle_t, step_handle_t>& other_interval = this->augref_intervals[other_idx];
+            pair<step_handle_t, step_handle_t>& other_interval = this->gref_intervals[other_idx];
             path_handle_t other_path = graph->get_path_handle_of_step(other_interval.first);
             // Only cross-path: skip if same path.
             if (other_path != my_path) {
@@ -1190,34 +1190,34 @@ void AugRefCover::try_cross_path_merge(step_handle_t ref_step) {
     }
 }
 
-void AugRefCover::defragment_intervals() {
+void GrefCover::defragment_intervals() {
     vector<pair<step_handle_t, step_handle_t>> new_intervals;
     vector<pair<nid_t, nid_t>> new_snarl_bounds;
     this->node_to_interval.clear();
-    for (int64_t i = 0; i < this->augref_intervals.size(); ++i) {
-        const pair<step_handle_t, step_handle_t>& interval = this->augref_intervals[i];
+    for (int64_t i = 0; i < this->gref_intervals.size(); ++i) {
+        const pair<step_handle_t, step_handle_t>& interval = this->gref_intervals[i];
         path_handle_t path_handle = graph->get_path_handle_of_step(interval.first);
         if (interval.first != graph->path_end(path_handle)) {
             new_intervals.push_back(interval);
             new_snarl_bounds.push_back(this->interval_snarl_bounds[i]);
         }
     }
-    this->augref_intervals = std::move(new_intervals);
+    this->gref_intervals = std::move(new_intervals);
     this->interval_snarl_bounds = std::move(new_snarl_bounds);
-    for (int64_t i = 0; i < this->augref_intervals.size(); ++i) {
-        const pair<step_handle_t, step_handle_t>& interval = this->augref_intervals[i];
+    for (int64_t i = 0; i < this->gref_intervals.size(); ++i) {
+        const pair<step_handle_t, step_handle_t>& interval = this->gref_intervals[i];
         for (step_handle_t step = interval.first; step != interval.second; step = graph->get_next_step(step)) {
             this->node_to_interval[graph->get_id(graph->get_handle_of_step(step))] = i;
         }
     }
 }
 
-void AugRefCover::filter_short_intervals(int64_t minimum_length) {
+void GrefCover::filter_short_intervals(int64_t minimum_length) {
     if (minimum_length <= 1) {
         return;
     }
-    for (int64_t i = num_ref_intervals; i < augref_intervals.size(); ++i) {
-        auto& interval = augref_intervals[i];
+    for (int64_t i = num_ref_intervals; i < gref_intervals.size(); ++i) {
+        auto& interval = gref_intervals[i];
         path_handle_t ph = graph->get_path_handle_of_step(interval.first);
         if (interval.first == graph->path_end(ph)) {
             continue;  // already decommissioned
@@ -1236,7 +1236,7 @@ void AugRefCover::filter_short_intervals(int64_t minimum_length) {
     defragment_intervals();
 }
 
-int64_t AugRefCover::get_coverage(const vector<step_handle_t>& trav, const pair<int64_t, int64_t>& uncovered_interval) {
+int64_t GrefCover::get_coverage(const vector<step_handle_t>& trav, const pair<int64_t, int64_t>& uncovered_interval) {
     int64_t coverage = 0;
 
     for (int64_t i = uncovered_interval.first; i < uncovered_interval.second; ++i) {
@@ -1255,7 +1255,7 @@ int64_t AugRefCover::get_coverage(const vector<step_handle_t>& trav, const pair<
 }
 
 
-vector<pair<int64_t, nid_t>> AugRefCover::get_reference_nodes(nid_t node_id, bool first) const {
+vector<pair<int64_t, nid_t>> GrefCover::get_reference_nodes(nid_t node_id, bool first) const {
 
     // search back to reference in order to find the rank.
     unordered_set<nid_t> visited;
@@ -1281,7 +1281,7 @@ vector<pair<int64_t, nid_t>> AugRefCover::get_reference_nodes(nid_t node_id, boo
             if (this->node_to_interval.count(current_id)) {
                 int64_t interval_idx = this->node_to_interval.at(current_id);
 
-                const pair<step_handle_t, step_handle_t>& augref_interval = this->augref_intervals.at(interval_idx);
+                const pair<step_handle_t, step_handle_t>& gref_interval = this->gref_intervals.at(interval_idx);
 
                 // we've hit the reference, fish out its step and stop searching.
                 if (interval_idx < this->num_ref_intervals) {
@@ -1293,16 +1293,16 @@ vector<pair<int64_t, nid_t>> AugRefCover::get_reference_nodes(nid_t node_id, boo
                 }
 
                 // search out of the snarl -- any parent traversals will overlap here
-                graph->follow_edges(graph->get_handle_of_step(augref_interval.first), true, [&](handle_t prev) {
+                graph->follow_edges(graph->get_handle_of_step(gref_interval.first), true, [&](handle_t prev) {
                     queue.push(make_pair(distance + 1, graph->get_id(prev)));
                 });
                 // hack around gbwtgraph bug (feature?) that does not let you decrement path_end
-                path_handle_t path_handle = graph->get_path_handle_of_step(augref_interval.first);
+                path_handle_t path_handle = graph->get_path_handle_of_step(gref_interval.first);
                 step_handle_t last_step;
-                if (augref_interval.second == graph->path_end(path_handle)) {
+                if (gref_interval.second == graph->path_end(path_handle)) {
                     last_step = graph->path_back(path_handle);
                 } else {
-                    last_step = graph->get_previous_step(augref_interval.second);
+                    last_step = graph->get_previous_step(gref_interval.second);
                 }
                 graph->follow_edges(graph->get_handle_of_step(last_step), false, [&](handle_t next) {
                     queue.push(make_pair(distance + 1, graph->get_id(next)));
@@ -1326,8 +1326,8 @@ vector<pair<int64_t, nid_t>> AugRefCover::get_reference_nodes(nid_t node_id, boo
     return output_reference_nodes;
 }
 
-void AugRefCover::verify_cover(int64_t minimum_length) const {
-    // Check that every node in the graph is covered by the augref cover.
+void GrefCover::verify_cover(int64_t minimum_length) const {
+    // Check that every node in the graph is covered by the gref cover.
     // Uncovered nodes are expected when minimum_length > 1 (short intervals
     // will be filtered later), so only warn when full coverage was intended.
     int64_t total_nodes = 0;
@@ -1361,23 +1361,23 @@ void AugRefCover::verify_cover(int64_t minimum_length) const {
     });
 
     if (uncovered_nodes > 0 && minimum_length <= 1) {
-        cerr << "[augref] warning: " << uncovered_nodes << " nodes ("
-             << uncovered_length << " bp) not covered by augref paths" << endl;
+        cerr << "[gref] warning: " << uncovered_nodes << " nodes ("
+             << uncovered_length << " bp) not covered by gref paths" << endl;
     }
 
     if (verbose) {
-        cerr << "[augref] verify_cover summary:" << endl
+        cerr << "[gref] verify_cover summary:" << endl
              << "  Total nodes: " << total_nodes << " (" << total_length << " bp)" << endl
              << "  Reference nodes: " << ref_nodes << " (" << ref_length << " bp)" << endl
              << "  Alt nodes: " << alt_nodes << " (" << alt_length << " bp)" << endl
              << "  Uncovered nodes: " << uncovered_nodes << " (" << uncovered_length << " bp)" << endl
-             << "  Intervals: " << num_ref_intervals << " ref + " << (augref_intervals.size() - num_ref_intervals) << " alt" << endl;
+             << "  Intervals: " << num_ref_intervals << " ref + " << (gref_intervals.size() - num_ref_intervals) << " alt" << endl;
     }
 }
 
-void AugRefCover::copy_base_paths_to_sample(MutablePathMutableHandleGraph* mutable_graph,
+void GrefCover::copy_base_paths_to_sample(MutablePathMutableHandleGraph* mutable_graph,
                                               const unordered_set<path_handle_t>& reference_paths) {
-    if (augref_sample_name.empty()) {
+    if (gref_sample_name.empty()) {
         return;
     }
 
@@ -1392,20 +1392,20 @@ void AugRefCover::copy_base_paths_to_sample(MutablePathMutableHandleGraph* mutab
         subrange_t subrange;
         PathMetadata::parse_path_name(ref_name, sense, sample, locus, haplotype, phase_block, subrange);
 
-        // Create new path name with augref sample
+        // Create new path name with gref sample
         string new_name;
         if (sample.empty()) {
-            // Simple path name (no sample info) - prepend augref sample
-            new_name = augref_sample_name + "#0#" + ref_name;
+            // Simple path name (no sample info) - prepend gref sample
+            new_name = gref_sample_name + "#0#" + ref_name;
         } else {
-            // Replace sample with augref sample
-            new_name = PathMetadata::create_path_name(sense, augref_sample_name, locus, haplotype, phase_block, subrange);
+            // Replace sample with gref sample
+            new_name = PathMetadata::create_path_name(sense, gref_sample_name, locus, haplotype, phase_block, subrange);
         }
 
         // Check if path already exists
         if (mutable_graph->has_path(new_name)) {
 #ifdef debug
-            cerr << "[augref] copy_base_paths_to_sample: path " << new_name << " already exists, skipping" << endl;
+            cerr << "[gref] copy_base_paths_to_sample: path " << new_name << " already exists, skipping" << endl;
 #endif
             continue;
         }
@@ -1420,25 +1420,25 @@ void AugRefCover::copy_base_paths_to_sample(MutablePathMutableHandleGraph* mutab
         });
 
 #ifdef debug
-        cerr << "[augref] copy_base_paths_to_sample: copied " << ref_name << " -> " << new_name << endl;
+        cerr << "[gref] copy_base_paths_to_sample: copied " << ref_name << " -> " << new_name << endl;
 #endif
     }
 }
 
-void AugRefCover::write_augref_segments(ostream& os) {
-    // Track augref counters to predict path names (same logic as apply())
-    unordered_map<string, int64_t> local_augref_counter;
+void GrefCover::write_gref_segments(ostream& os) {
+    // Track gref counters to predict path names (same logic as apply())
+    unordered_map<string, int64_t> local_gref_counter;
 
-    // First pass: find maximum existing augref index for each base path
+    // First pass: find maximum existing gref index for each base path
     graph->for_each_path_handle([&](path_handle_t path_handle) {
         string path_name = graph->get_path_name(path_handle);
-        if (is_augref_name(path_name)) {
+        if (is_gref_name(path_name)) {
             string base = parse_base_path(path_name);
-            int64_t idx = parse_augref_index(path_name);
-            if (local_augref_counter.count(base)) {
-                local_augref_counter[base] = max(local_augref_counter[base], idx);
+            int64_t idx = parse_gref_index(path_name);
+            if (local_gref_counter.count(base)) {
+                local_gref_counter[base] = max(local_gref_counter[base], idx);
             } else {
-                local_augref_counter[base] = idx;
+                local_gref_counter[base] = idx;
             }
         }
     });
@@ -1447,7 +1447,7 @@ void AugRefCover::write_augref_segments(ostream& os) {
     // Maps node ID -> (ref_path_handle, offset of node start on ref path)
     unordered_map<nid_t, pair<path_handle_t, int64_t>> ref_node_positions;
     for (int64_t i = 0; i < this->num_ref_intervals; ++i) {
-        const pair<step_handle_t, step_handle_t>& ref_interval = this->augref_intervals[i];
+        const pair<step_handle_t, step_handle_t>& ref_interval = this->gref_intervals[i];
         path_handle_t ref_path_handle = graph->get_path_handle_of_step(ref_interval.first);
         int64_t offset = 0;
         for (step_handle_t step = ref_interval.first; step != ref_interval.second;
@@ -1462,8 +1462,8 @@ void AugRefCover::write_augref_segments(ostream& os) {
     // This avoids caching every step of every source path.
     unordered_set<step_handle_t> needed_steps;
     unordered_set<path_handle_t> source_paths_needed;
-    for (int64_t i = this->num_ref_intervals; i < this->augref_intervals.size(); ++i) {
-        const pair<step_handle_t, step_handle_t>& interval = this->augref_intervals[i];
+    for (int64_t i = this->num_ref_intervals; i < this->gref_intervals.size(); ++i) {
+        const pair<step_handle_t, step_handle_t>& interval = this->gref_intervals[i];
         path_handle_t ph = graph->get_path_handle_of_step(interval.first);
         source_paths_needed.insert(ph);
         needed_steps.insert(interval.first);
@@ -1494,9 +1494,9 @@ void AugRefCover::write_augref_segments(ostream& os) {
     // Stores (display_name, subrange_offset) per source path.
     unordered_map<path_handle_t, pair<string, int64_t>> source_display_cache;
 
-    // Write each augref interval
-    for (int64_t i = this->num_ref_intervals; i < this->augref_intervals.size(); ++i) {
-        const pair<step_handle_t, step_handle_t>& interval = this->augref_intervals[i];
+    // Write each gref interval
+    for (int64_t i = this->num_ref_intervals; i < this->gref_intervals.size(); ++i) {
+        const pair<step_handle_t, step_handle_t>& interval = this->gref_intervals[i];
         path_handle_t source_path_handle = graph->get_path_handle_of_step(interval.first);
 
         // Skip empty intervals
@@ -1563,7 +1563,7 @@ void AugRefCover::write_augref_segments(ostream& os) {
             if (!ref_nodes.empty()) {
                 nid_t ref_node_id = ref_nodes.at(0).second;
                 int64_t ref_interval_idx = this->node_to_interval.at(ref_node_id);
-                path_handle_t ref_path_handle = graph->get_path_handle_of_step(augref_intervals[ref_interval_idx].first);
+                path_handle_t ref_path_handle = graph->get_path_handle_of_step(gref_intervals[ref_interval_idx].first);
                 base_path_name = graph->get_path_name(ref_path_handle);
                 subrange_t subrange;
                 base_path_name = Paths::strip_subrange(base_path_name, &subrange);
@@ -1583,8 +1583,8 @@ void AugRefCover::write_augref_segments(ostream& os) {
             }
         }
 
-        // If augref_sample_name is set, replace sample in base_path_name
-        if (!augref_sample_name.empty()) {
+        // If gref_sample_name is set, replace sample in base_path_name
+        if (!gref_sample_name.empty()) {
             PathSense sense;
             string sample, locus;
             size_t haplotype, phase_block;
@@ -1592,15 +1592,15 @@ void AugRefCover::write_augref_segments(ostream& os) {
             PathMetadata::parse_path_name(base_path_name, sense, sample, locus, haplotype, phase_block, subrange);
 
             if (sample.empty()) {
-                base_path_name = augref_sample_name + "#0#" + base_path_name;
+                base_path_name = gref_sample_name + "#0#" + base_path_name;
             } else {
-                base_path_name = PathMetadata::create_path_name(sense, augref_sample_name, locus, haplotype, phase_block, subrange);
+                base_path_name = PathMetadata::create_path_name(sense, gref_sample_name, locus, haplotype, phase_block, subrange);
             }
         }
 
-        // Get next augref index for this base path
-        int64_t augref_index = ++local_augref_counter[base_path_name];
-        string augref_name = make_augref_name(base_path_name, augref_index);
+        // Get next gref index for this base path
+        int64_t gref_index = ++local_gref_counter[base_path_name];
+        string gref_name = make_gref_name(base_path_name, gref_index);
 
         // Resolve source path name to full-path coordinates using cached result.
         // Parses path name once per source path to extract subrange offset and
@@ -1629,7 +1629,7 @@ void AugRefCover::write_augref_segments(ostream& os) {
         os << display_source_name << "\t"
            << display_source_start << "\t"
            << display_source_end << "\t"
-           << augref_name << "\t"
+           << gref_name << "\t"
            << ref_path_name << "\t"
            << ref_start << "\t"
            << ref_end << "\n";

--- a/src/gref.hpp
+++ b/src/gref.hpp
@@ -1,17 +1,17 @@
-#ifndef VG_AUGREF_HPP_INCLUDED
-#define VG_AUGREF_HPP_INCLUDED
+#ifndef VG_GREF_HPP_INCLUDED
+#define VG_GREF_HPP_INCLUDED
 
 /**
- * \file augref.hpp
+ * \file gref.hpp
  *
- * Interface for computing and querying augmented reference path covers.
+ * Interface for computing and querying graph reference path covers.
  *
- * An augref cover is a set of path fragments (stored as separate paths) in the graph.
+ * An gref cover is a set of path fragments (stored as separate paths) in the graph.
  * They are always relative to an existing reference sample (ie GRCh38 or CHM13).
- * Unlike rGFA paths which use complex metadata embedding, augref paths use a simple naming
+ * Unlike rGFA paths which use complex metadata embedding, gref paths use a simple naming
  * scheme: {base_path_name}_{N}_alt
  *
- * For example, if the reference path is "CHM13#0#chr1", augref paths would be named:
+ * For example, if the reference path is "CHM13#0#chr1", gref paths would be named:
  *   - CHM13#0#chr1_1_alt
  *   - CHM13#0#chr1_2_alt
  *   - etc.
@@ -31,57 +31,57 @@ namespace vg {
 
 using namespace std;
 
-class AugRefCover {
+class GrefCover {
 public:
-    // The suffix used to identify augref paths
-    static const string augref_suffix;  // "_alt"
+    // The suffix used to identify gref paths
+    static const string gref_suffix;  // "_alt"
 
-    // Create an augref path name from a base reference path name and an index.
-    // Example: make_augref_name("CHM13#0#chr1", 1) -> "CHM13#0#chr1_1_alt"
-    static string make_augref_name(const string& base_path_name, int64_t augref_index);
+    // Create an gref path name from a base reference path name and an index.
+    // Example: make_gref_name("CHM13#0#chr1", 1) -> "CHM13#0#chr1_1_alt"
+    static string make_gref_name(const string& base_path_name, int64_t gref_index);
 
-    // Test if a path name is an augref path (contains "_{N}_alt" suffix).
-    static bool is_augref_name(const string& path_name);
+    // Test if a path name is an gref path (contains "_{N}_alt" suffix).
+    static bool is_gref_name(const string& path_name);
 
-    // Parse an augref path name to extract the base reference path name.
-    // Returns the original base path name, or the input if not an augref path.
+    // Parse an gref path name to extract the base reference path name.
+    // Returns the original base path name, or the input if not an gref path.
     // Example: parse_base_path("CHM13#0#chr1_3_alt") -> "CHM13#0#chr1"
-    static string parse_base_path(const string& augref_name);
+    static string parse_base_path(const string& gref_name);
 
-    // Parse an augref path name to extract the augref index.
-    // Returns -1 if the path is not an augref path.
-    // Example: parse_augref_index("CHM13#0#chr1_3_alt") -> 3
-    static int64_t parse_augref_index(const string& augref_name);
+    // Parse an gref path name to extract the gref index.
+    // Returns -1 if the path is not an gref path.
+    // Example: parse_gref_index("CHM13#0#chr1_3_alt") -> 3
+    static int64_t parse_gref_index(const string& gref_name);
 
 public:
-    // Clear out any existing augref paths from the graph. Recommended to run this
+    // Clear out any existing gref paths from the graph. Recommended to run this
     // before compute().
     void clear(MutablePathMutableHandleGraph* graph);
 
-    // Compute the augref cover from the graph, starting with a given set of reference paths.
+    // Compute the gref cover from the graph, starting with a given set of reference paths.
     void compute(const PathHandleGraph* graph,
                  SnarlManager* snarl_manager,
                  const unordered_set<path_handle_t>& reference_paths,
                  int64_t minimum_length);
 
-    // Load existing augref paths from the graph, assuming they've been computed already.
-    // The reference_paths should be the rank-0 paths the augref paths extend from.
+    // Load existing gref paths from the graph, assuming they've been computed already.
+    // The reference_paths should be the rank-0 paths the gref paths extend from.
     void load(const PathHandleGraph* graph,
               const unordered_set<path_handle_t>& reference_paths);
 
-    // Apply the augref cover to a graph (must have been computed first), adding it
+    // Apply the gref cover to a graph (must have been computed first), adding it
     // as a bunch of REFERENCE-sense paths with the simplified naming scheme.
-    // If augref_sample_name is set, base paths are first copied to the new sample,
-    // and augref paths are created under the new sample name.
+    // If gref_sample_name is set, base paths are first copied to the new sample,
+    // and gref paths are created under the new sample name.
     void apply(MutablePathMutableHandleGraph* mutable_graph);
 
-    // Set the sample name for augref paths. When set, apply() will:
+    // Set the sample name for gref paths. When set, apply() will:
     // 1. Copy base reference paths to this new sample (CHM13#0#chr1 -> new_sample#0#chr1)
-    // 2. Create augref paths under the new sample (new_sample#0#chr1_1_alt, etc.)
-    void set_augref_sample(const string& sample_name);
+    // 2. Create gref paths under the new sample (new_sample#0#chr1_1_alt, etc.)
+    void set_gref_sample(const string& sample_name);
 
-    // Get the current augref sample name (empty string if not set).
-    const string& get_augref_sample() const;
+    // Get the current gref sample name (empty string if not set).
+    const string& get_gref_sample() const;
 
     // Enable verbose output (coverage summary, etc.)
     void set_verbose(bool verbose);
@@ -101,12 +101,12 @@ public:
     // Get the number of reference intervals (rank-0).
     int64_t get_num_ref_intervals() const;
 
-    // Write a tab-separated table describing augref segments.
-    // Each line contains: source_path, source_start, source_end, augref_path_name,
+    // Write a tab-separated table describing gref segments.
+    // Each line contains: source_path, source_start, source_end, gref_path_name,
     //                     ref_path, ref_start, ref_end
-    // Must be called after compute() and knows what augref path names will be used.
-    // If augref_sample is set, uses that for the augref path names.
-    void write_augref_segments(ostream& os);
+    // Must be called after compute() and knows what gref path names will be used.
+    // If gref_sample is set, uses that for the gref path names.
+    void write_gref_segments(ostream& os);
 
 protected:
 
@@ -114,7 +114,7 @@ protected:
     // The cover is added to the two "thread_" structures.
     // top_snarl_start/end are the boundary node IDs of the top-level snarl containing this snarl.
     void compute_snarl(const Snarl& snarl, PathTraversalFinder& path_trav_finder, int64_t minimum_length,
-                       vector<pair<step_handle_t, step_handle_t>>& thread_augref_intervals,
+                       vector<pair<step_handle_t, step_handle_t>>& thread_gref_intervals,
                        unordered_map<nid_t, int64_t>& thread_node_to_interval,
                        nid_t top_snarl_start, nid_t top_snarl_end,
                        vector<pair<nid_t, nid_t>>& thread_snarl_bounds);
@@ -124,10 +124,10 @@ protected:
     vector<pair<int64_t, int64_t>> get_uncovered_intervals(const vector<step_handle_t>& trav,
                                                            const unordered_map<nid_t, int64_t>& thread_node_to_interval);
 
-    // Add a new interval into the augref_intervals vector and update the node_to_interval map.
+    // Add a new interval into the gref_intervals vector and update the node_to_interval map.
     // If the interval can be merged into an existing, contiguous interval, do that instead.
     // Returns true if a new interval was added, false if an existing interval was updated.
-    bool add_interval(vector<pair<step_handle_t, step_handle_t>>& thread_augref_intervals,
+    bool add_interval(vector<pair<step_handle_t, step_handle_t>>& thread_gref_intervals,
                       unordered_map<nid_t, int64_t>& thread_node_to_interval,
                       const pair<step_handle_t, step_handle_t>& new_interval,
                       bool global = false,
@@ -139,7 +139,7 @@ protected:
 
     // Post-insertion cross-path merge: tries to consolidate the interval containing
     // ref_step with any cross-path neighbor at its left or right boundary.
-    // Operates on this->augref_intervals and this->node_to_interval.
+    // Operates on this->gref_intervals and this->node_to_interval.
     void try_cross_path_merge(step_handle_t ref_step);
 
     // Remove non-reference intervals shorter than minimum_length, then defragment.
@@ -196,32 +196,32 @@ protected:
     // "first" toggles returning the first interval found vs all of them.
     vector<pair<int64_t, nid_t>> get_reference_nodes(nid_t node_id, bool first) const;
 
-    // Debug function: verify that every node in the graph is covered by the augref cover.
+    // Debug function: verify that every node in the graph is covered by the gref cover.
     // Prints a summary of coverage statistics to stderr.
     void verify_cover(int64_t minimum_length) const;
 
     const PathHandleGraph* graph = nullptr;
 
     // Intervals are end-exclusive (like BED).
-    vector<pair<step_handle_t, step_handle_t>> augref_intervals;
+    vector<pair<step_handle_t, step_handle_t>> gref_intervals;
 
-    // Top-level snarl boundary nodes for each interval, parallel to augref_intervals.
+    // Top-level snarl boundary nodes for each interval, parallel to gref_intervals.
     // (0, 0) sentinel for reference intervals and fill_uncovered_nodes intervals.
     vector<pair<nid_t, nid_t>> interval_snarl_bounds;
 
-    // augref_intervals[0, num_ref_intervals-1] are all rank-0 reference intervals.
+    // gref_intervals[0, num_ref_intervals-1] are all rank-0 reference intervals.
     int64_t num_ref_intervals = 0;
 
     // Map from node ID to interval index.
     unordered_map<nid_t, int64_t> node_to_interval;
 
-    // Counter for generating unique augref indices per base path.
+    // Counter for generating unique gref indices per base path.
     // Using mutable so it can be updated in apply() which is logically const for the cover.
-    unordered_map<string, int64_t> base_path_augref_counter;
+    unordered_map<string, int64_t> base_path_gref_counter;
 
-    // Optional sample name for augref paths. When set, base paths are copied to this
-    // sample and augref paths are created under it.
-    string augref_sample_name;
+    // Optional sample name for gref paths. When set, base paths are copied to this
+    // sample and gref paths are created under it.
+    string gref_sample_name;
 
     // Whether to print verbose output (coverage summary, etc.)
     bool verbose = false;
@@ -230,7 +230,7 @@ protected:
     // This ensures deterministic output regardless of thread count.
     bool rank_by_name = false;
 
-    // Copy base reference paths to the augref sample.
+    // Copy base reference paths to the gref sample.
     // Creates new paths like "new_sample#0#chr1" from "CHM13#0#chr1".
     void copy_base_paths_to_sample(MutablePathMutableHandleGraph* mutable_graph,
                                    const unordered_set<path_handle_t>& reference_paths);

--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -17,7 +17,7 @@
 #include "../xg.hpp"
 #include "../gbzgraph.hpp"
 #include "../gbwtgraph_helper.hpp"
-#include "../augref.hpp"
+#include "../gref.hpp"
 #include "../traversal_clusters.hpp"
 #include <vg/io/stream.hpp>
 #include <vg/io/vpkg.hpp>
@@ -720,7 +720,7 @@ int main_call(int argc, char** argv) {
         constexpr size_t EXTRA_WEIGHT = 10000000000;
         for (const string& refpath_name : ref_paths) {
             // Skip altpaths (they shouldn't influence snarl decomposition)
-            if (AugRefCover::is_augref_name(refpath_name)) {
+            if (GrefCover::is_gref_name(refpath_name)) {
                 continue;
             }
             path_handle_t refpath_handle = graph->get_path_handle(refpath_name);

--- a/src/subcommand/deconstruct_main.cpp
+++ b/src/subcommand/deconstruct_main.cpp
@@ -14,7 +14,7 @@
 
 #include "../vg.hpp"
 #include "../deconstructor.hpp"
-#include "../augref.hpp"
+#include "../gref.hpp"
 #include "../integrated_snarl_finder.hpp"
 #include "../gbwtgraph_helper.hpp"
 #include "../gbwt_helper.hpp"
@@ -384,7 +384,7 @@ int main_deconstruct(int argc, char** argv) {
         constexpr size_t EXTRA_WEIGHT = 10000000000;
         for (const string& refpath_name : refpaths) {
             // Skip altpaths (they shouldn't influence snarl decomposition)
-            if (AugRefCover::is_augref_name(refpath_name)) {
+            if (GrefCover::is_gref_name(refpath_name)) {
                 continue;
             }
             path_handle_t refpath_handle = graph->get_path_handle(refpath_name);

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -19,7 +19,7 @@
 #include "../xg.hpp"
 #include "../gbwt_helper.hpp"
 #include "../traversal_clusters.hpp"
-#include "../augref.hpp"
+#include "../gref.hpp"
 #include "../integrated_snarl_finder.hpp"
 #include "../io/save_handle_graph.hpp"
 #include <bdsg/overlays/overlay_helper.hpp>
@@ -67,20 +67,20 @@ void help_paths(char** argv) {
          << "  -R, --reference-paths     select reference paths" << endl
          << "  -H, --haplotype-paths     select haplotype paths" << endl
          << "      --exclude-sample STR  exclude paths belonging to this sample" << endl
-         << "augmented reference computation:" << endl
-         << "  -u, --compute-augref      compute augmented reference path cover" << endl
+         << "graph reference computation:" << endl
+         << "  -u, --compute-gref        compute graph reference path cover" << endl
          << "                            (use -Q to select reference paths)" << endl
-         << "  -l, --min-augref-len N    minimum augref fragment length [50]" << endl
-         << "  -N, --augref-sample STR   create augref paths under a new sample" << endl
+         << "  -l, --min-gref-len N      minimum gref fragment length [50]" << endl
+         << "  -N, --gref-sample STR     create gref paths under a new sample" << endl
          << "                            (copies base paths to new sample," << endl
-         << "                            then adds augref paths)." << endl
+         << "                            then adds gref paths)." << endl
          << "                            if unspecified, paths get added to target sample." << endl
-         << "      --augref-segs FILE    write augref segment table to FILE" << endl
+         << "      --gref-segs FILE      write gref segment table to FILE" << endl
          << "configuration:" << endl
          << "  -o, --overlay             apply a ReferencePathOverlayHelper to the graph" << endl
          << "  -t, --threads N           number of threads to use [all available]" << endl
-         << "                            applies to -n (snarl finding) and -u (augref)" << endl
-         << "      --progress, --verbose print progress and augref coverage summary" << endl;
+         << "                            applies to -n (snarl finding) and -u (gref)" << endl
+         << "      --progress, --verbose print progress and gref coverage summary" << endl;
 
 }
 
@@ -148,14 +148,14 @@ int main_paths(int argc, char** argv) {
     bool normalize_paths = false;
     bool overlay = false;
     bool progress = false;
-    bool compute_augref = false;
-    int64_t min_augref_length = 50;
-    string augref_sample;
-    string augref_segments_file;
+    bool compute_gref = false;
+    int64_t min_gref_length = 50;
+    string gref_sample;
+    string gref_segments_file;
     string exclude_sample;
 
     constexpr int OPT_PROGRESS = 1001;
-    constexpr int OPT_AUGREF_SEGMENTS = 1002;
+    constexpr int OPT_GREF_SEGMENTS = 1002;
     constexpr int OPT_EXCLUDE_SAMPLE = 1003;
 
     int c;
@@ -196,11 +196,11 @@ int main_paths(int argc, char** argv) {
             {"threads-old", no_argument, 0, 'T'},
             {"threads-by", required_argument, 0, 'q'},
 
-            // Augref options
-            {"compute-augref", no_argument, 0, 'u'},
-            {"min-augref-len", required_argument, 0, 'l'},
-            {"augref-sample", required_argument, 0, 'N'},
-            {"augref-segs", required_argument, 0, OPT_AUGREF_SEGMENTS},
+            // Gref options
+            {"compute-gref", no_argument, 0, 'u'},
+            {"min-gref-len", required_argument, 0, 'l'},
+            {"gref-sample", required_argument, 0, 'N'},
+            {"gref-segs", required_argument, 0, OPT_GREF_SEGMENTS},
             {"exclude-sample", required_argument, 0, OPT_EXCLUDE_SAMPLE},
 
             {0, 0, 0, 0}
@@ -341,24 +341,24 @@ int main_paths(int argc, char** argv) {
             break;
 
         case 'u':
-            compute_augref = true;
+            compute_gref = true;
             output_formats++;
             break;
 
         case 'l':
-            min_augref_length = parse<int64_t>(optarg);
+            min_gref_length = parse<int64_t>(optarg);
             break;
 
         case 'N':
-            augref_sample = optarg;
+            gref_sample = optarg;
             break;
 
         case OPT_PROGRESS:
             progress = true;
             break;
 
-        case OPT_AUGREF_SEGMENTS:
-            augref_segments_file = ensure_writable(logger, optarg);
+        case OPT_GREF_SEGMENTS:
+            gref_segments_file = ensure_writable(logger, optarg);
             break;
 
         case OPT_EXCLUDE_SAMPLE:
@@ -430,14 +430,14 @@ int main_paths(int argc, char** argv) {
     if (coverage && !gbwt_file.empty()) {
         logger.error() << "coverage option -c only works on embedded graph paths, not GBWT threads" << std::endl;
     }
-    if (compute_augref && !gbwt_file.empty()) {
-        logger.error() << "augref computation only works on embedded graph paths, not GBWT threads" << std::endl;
+    if (compute_gref && !gbwt_file.empty()) {
+        logger.error() << "gref computation only works on embedded graph paths, not GBWT threads" << std::endl;
     }
-    if (compute_augref && path_prefix.empty()) {
-        logger.error() << "--compute-augref requires -Q to select reference path(s)" << std::endl;
+    if (compute_gref && path_prefix.empty()) {
+        logger.error() << "--compute-gref requires -Q to select reference path(s)" << std::endl;
     }
-    if (!augref_segments_file.empty() && !compute_augref) {
-        logger.error() << "--augref-segs requires --compute-augref" << std::endl;
+    if (!gref_segments_file.empty() && !compute_gref) {
+        logger.error() << "--gref-segs requires --compute-gref" << std::endl;
     }
     if (!exclude_sample.empty() && !sample_name.empty() && exclude_sample == sample_name) {
         logger.error() << "--exclude-sample and --sample cannot specify the same sample" << std::endl;
@@ -484,11 +484,11 @@ int main_paths(int argc, char** argv) {
     
     
     
-    // Handle augref computation before other operations
-    if (compute_augref && graph) {
+    // Handle gref computation before other operations
+    if (compute_gref && graph) {
         MutablePathMutableHandleGraph* mutable_graph = dynamic_cast<MutablePathMutableHandleGraph*>(graph);
         if (!mutable_graph) {
-            logger.error() << "graph cannot be modified for augref computation" << std::endl;
+            logger.error() << "graph cannot be modified for gref computation" << std::endl;
             return 1;
         }
 
@@ -496,8 +496,8 @@ int main_paths(int argc, char** argv) {
         unordered_set<path_handle_t> ref_paths;
         graph->for_each_path_handle([&](path_handle_t ph) {
             string path_name = graph->get_path_name(ph);
-            // Skip augref paths (they match prefixes but shouldn't be used as references)
-            if (AugRefCover::is_augref_name(path_name)) {
+            // Skip gref paths (they match prefixes but shouldn't be used as references)
+            if (GrefCover::is_gref_name(path_name)) {
                 return;
             }
             if (path_name.compare(0, path_prefix.size(), path_prefix) == 0) {
@@ -528,23 +528,23 @@ int main_paths(int argc, char** argv) {
         IntegratedSnarlFinder finder(*graph, extra_node_weight);
         SnarlManager snarl_manager(std::move(finder.find_snarls_parallel()));
 
-        // Compute and apply augref cover
-        AugRefCover cover;
-        if (!augref_sample.empty()) {
-            cover.set_augref_sample(augref_sample);
+        // Compute and apply gref cover
+        GrefCover cover;
+        if (!gref_sample.empty()) {
+            cover.set_gref_sample(gref_sample);
         }
         cover.set_verbose(progress);
         cover.clear(mutable_graph);
-        cover.compute(graph, &snarl_manager, ref_paths, min_augref_length);
+        cover.compute(graph, &snarl_manager, ref_paths, min_gref_length);
 
-        // Write augref segment table if requested
-        if (!augref_segments_file.empty()) {
-            ofstream segments_out(augref_segments_file);
+        // Write gref segment table if requested
+        if (!gref_segments_file.empty()) {
+            ofstream segments_out(gref_segments_file);
             if (!segments_out) {
-                logger.error() << "could not open augref-segs file: " << augref_segments_file << std::endl;
+                logger.error() << "could not open gref-segs file: " << gref_segments_file << std::endl;
                 return 1;
             }
-            cover.write_augref_segments(segments_out);
+            cover.write_gref_segments(segments_out);
         }
 
         cover.apply(mutable_graph);

--- a/test/t/11_vg_paths.t
+++ b/test/t/11_vg_paths.t
@@ -132,79 +132,79 @@ is "$(cat out.txt | wc -l)" "1" "vg paths sees the haplotype path in a GBZ with 
 rm -f norm_x4.gfa original.fa norm_x4.fa x4.path x4.norm.path out.txt err.txt
 rm -f empty.vg empty.gbwt empty.fa
 
-# Augref (augmented reference path) computation tests
-vg paths -x nesting/nested_snp_in_ins.gfa -Q x --compute-augref --min-augref-len 1 > augref_test.vg
-vg validate augref_test.vg
-is $? 0 "augref computation produces valid graph"
+# Gref (graph reference path) computation tests
+vg paths -x nesting/nested_snp_in_ins.gfa -Q x --compute-gref --min-gref-len 1 > gref_test.vg
+vg validate gref_test.vg
+is $? 0 "gref computation produces valid graph"
 
-is $(vg paths -x augref_test.vg -L | grep "_alt$" | wc -l) 2 "augref computation creates expected number of augref paths"
+is $(vg paths -x gref_test.vg -L | grep "_alt$" | wc -l) 2 "gref computation creates expected number of gref paths"
 
-is $(vg paths -x augref_test.vg -L | grep "^x$" | wc -l) 1 "original reference path is preserved after augref computation"
+is $(vg paths -x gref_test.vg -L | grep "^x$" | wc -l) 1 "original reference path is preserved after gref computation"
 
-# Test augref naming convention matches pattern x_{N}_alt
-is $(vg paths -x augref_test.vg -L | grep -E "^x_[0-9]+_alt$" | wc -l) 2 "augref paths follow naming convention path_{N}_alt"
+# Test gref naming convention matches pattern x_{N}_alt
+is $(vg paths -x gref_test.vg -L | grep -E "^x_[0-9]+_alt$" | wc -l) 2 "gref paths follow naming convention path_{N}_alt"
 
 # Test with triple_nested.gfa which has more complex structure
-vg paths -x nesting/triple_nested.gfa -Q x --compute-augref --min-augref-len 1 > triple_augref.vg
-vg validate triple_augref.vg
-is $? 0 "augref computation works on complex nested structure"
+vg paths -x nesting/triple_nested.gfa -Q x --compute-gref --min-gref-len 1 > triple_gref.vg
+vg validate triple_gref.vg
+is $? 0 "gref computation works on complex nested structure"
 
-is $(vg paths -x triple_augref.vg -L | grep "_alt$" | wc -l) 2 "correct number of augref paths for triple nested graph"
+is $(vg paths -x triple_gref.vg -L | grep "_alt$" | wc -l) 2 "correct number of gref paths for triple nested graph"
 
 # Test minimum length filter
-vg paths -x nesting/triple_nested.gfa -Q x --compute-augref --min-augref-len 100 > triple_augref_long.vg
-is $(vg paths -x triple_augref_long.vg -L | grep "_alt$" | wc -l) 0 "min-augref-len filters out short fragments"
+vg paths -x nesting/triple_nested.gfa -Q x --compute-gref --min-gref-len 100 > triple_gref_long.vg
+is $(vg paths -x triple_gref_long.vg -L | grep "_alt$" | wc -l) 0 "min-gref-len filters out short fragments"
 
 # Test second pass coverage of dangling nodes (nodes outside snarls but on haplotype paths)
-vg paths -x nesting/dangling_node.gfa -Q x --compute-augref --min-augref-len 1 > dangling_augref.vg
-vg validate dangling_augref.vg
-is $? 0 "augref computation handles dangling nodes outside snarls"
+vg paths -x nesting/dangling_node.gfa -Q x --compute-gref --min-gref-len 1 > dangling_gref.vg
+vg validate dangling_gref.vg
+is $? 0 "gref computation handles dangling nodes outside snarls"
 
-is $(vg paths -x dangling_augref.vg -L | grep "_alt$" | wc -l) 2 "augref second pass covers dangling nodes"
+is $(vg paths -x dangling_gref.vg -L | grep "_alt$" | wc -l) 2 "gref second pass covers dangling nodes"
 
-# Verify the dangling node (node 5, 8bp) is covered by checking augref path lengths include 8bp
-# Note: use -E with grep instead of -Q since augref paths are filtered from prefix matching
-is $(vg paths -x dangling_augref.vg -E | grep "_alt" | awk '{sum+=$2} END {print sum}') 12 "augref paths cover both snarl node and dangling node"
+# Verify the dangling node (node 5, 8bp) is covered by checking gref path lengths include 8bp
+# Note: use -E with grep instead of -Q since gref paths are filtered from prefix matching
+is $(vg paths -x dangling_gref.vg -E | grep "_alt" | awk '{sum+=$2} END {print sum}') 12 "gref paths cover both snarl node and dangling node"
 
-# Test --augref-segs option for writing segment table
-vg paths -x nesting/nested_snp_in_ins.gfa -Q x --compute-augref --min-augref-len 1 --augref-segs augref_test.segs > augref_segs_test.vg
-is $? 0 "augref-segs option produces no error"
+# Test --gref-segs option for writing segment table
+vg paths -x nesting/nested_snp_in_ins.gfa -Q x --compute-gref --min-gref-len 1 --gref-segs gref_test.segs > gref_segs_test.vg
+is $? 0 "gref-segs option produces no error"
 
-is $(wc -l < augref_test.segs) 2 "augref-segs produces correct number of lines"
+is $(wc -l < gref_test.segs) 2 "gref-segs produces correct number of lines"
 
-is $(cut -f4 augref_test.segs | grep -c "x_.*_alt") 2 "augref-segs contains augref path names"
+is $(cut -f4 gref_test.segs | grep -c "x_.*_alt") 2 "gref-segs contains gref path names"
 
-is $(cut -f1 augref_test.segs | grep -c "#") 2 "augref-segs contains source path names with metadata"
+is $(cut -f1 gref_test.segs | grep -c "#") 2 "gref-segs contains source path names with metadata"
 
-is $(cut -f5 augref_test.segs | grep -c "^x$") 2 "augref-segs contains reference path name"
+is $(cut -f5 gref_test.segs | grep -c "^x$") 2 "gref-segs contains reference path name"
 
-# Test that augref-segs requires compute-augref
-vg paths -x nesting/nested_snp_in_ins.gfa -Q x -L --augref-segs augref_test.segs 2>&1 | grep -q "requires --compute-augref"
-is $? 0 "augref-segs requires compute-augref option"
+# Test that gref-segs requires compute-gref
+vg paths -x nesting/nested_snp_in_ins.gfa -Q x -L --gref-segs gref_test.segs 2>&1 | grep -q "requires --compute-gref"
+is $? 0 "gref-segs requires compute-gref option"
 
-# Test augref-segs with augref-sample option
-vg paths -x nesting/nested_snp_in_ins.gfa -Q x --compute-augref --min-augref-len 1 --augref-sample TESTSAMPLE --augref-segs augref_sample_test.segs > augref_sample_test.vg
-is $(cut -f4 augref_sample_test.segs | grep -c "TESTSAMPLE") 2 "augref-segs uses augref-sample for path names"
+# Test gref-segs with gref-sample option
+vg paths -x nesting/nested_snp_in_ins.gfa -Q x --compute-gref --min-gref-len 1 --gref-sample TESTSAMPLE --gref-segs gref_sample_test.segs > gref_sample_test.vg
+is $(cut -f4 gref_sample_test.segs | grep -c "TESTSAMPLE") 2 "gref-segs uses gref-sample for path names"
 
 # Test cross-path interval merging (left merge: new interval absorbs previous from different path)
-vg paths -x nesting/cross_path_merge.gfa -Q x --compute-augref --min-augref-len 1 > cross_merge_test.vg
+vg paths -x nesting/cross_path_merge.gfa -Q x --compute-gref --min-gref-len 1 > cross_merge_test.vg
 vg validate cross_merge_test.vg
-is $? 0 "cross-path merge: augref computation produces valid graph"
+is $? 0 "cross-path merge: gref computation produces valid graph"
 
 # Cross-path merge should combine snarl interval [2,3,4] + dangling [9] into one path on hap3
-# Without merging: 3 augref paths. With merging: 2 augref paths.
-is $(vg paths -x cross_merge_test.vg -L | grep "_alt$" | wc -l) 2 "cross-path left merge reduces augref path count"
+# Without merging: 3 gref paths. With merging: 2 gref paths.
+is $(vg paths -x cross_merge_test.vg -L | grep "_alt$" | wc -l) 2 "cross-path left merge reduces gref path count"
 
 # Test cross-path interval merging (right merge: new interval absorbs following from different path)
-vg paths -x nesting/cross_path_merge_right.gfa -Q x --compute-augref --min-augref-len 1 > cross_merge_right_test.vg
+vg paths -x nesting/cross_path_merge_right.gfa -Q x --compute-gref --min-gref-len 1 > cross_merge_right_test.vg
 vg validate cross_merge_right_test.vg
-is $? 0 "cross-path right merge: augref computation produces valid graph"
+is $? 0 "cross-path right merge: gref computation produces valid graph"
 
 # Cross-path merge should combine dangling [9] + snarl interval [2,3,4] into one path on hap3
-is $(vg paths -x cross_merge_right_test.vg -L | grep "_alt$" | wc -l) 2 "cross-path right merge reduces augref path count"
+is $(vg paths -x cross_merge_right_test.vg -L | grep "_alt$" | wc -l) 2 "cross-path right merge reduces gref path count"
 
-rm -f augref_test.vg triple_augref.vg triple_augref_long.vg dangling_augref.vg x.pg x.gbwt x.gbz
-rm -f augref_test.segs augref_segs_test.vg augref_sample_test.segs augref_sample_test.vg
+rm -f gref_test.vg triple_gref.vg triple_gref_long.vg dangling_gref.vg x.pg x.gbwt x.gbz
+rm -f gref_test.segs gref_segs_test.vg gref_sample_test.segs gref_sample_test.vg
 rm -f cross_merge_test.vg cross_merge_right_test.vg
 
 

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -346,8 +346,8 @@ is "$TL_HAS_QUAL" "1" "top-level call still has non-zero QUAL"
 
 rm -f nq.gam nq.pack nq.vcf
 
-# Test: triple nested with augref paths should all have quality
-vg paths --compute-augref -Q x --min-augref-len 1 -x nesting/triple_nested.gfa > tnq_ap.gfa 2>/dev/null
+# Test: triple nested with gref paths should all have quality
+vg paths --compute-gref -Q x --min-gref-len 1 -x nesting/triple_nested.gfa > tnq_ap.gfa 2>/dev/null
 vg sim -x tnq_ap.gfa -P "a#1#y0#0" -n 200 -l 2 -a -s 51 > tnq.gam
 vg sim -x tnq_ap.gfa -P "a#2#y1#0" -n 200 -l 2 -a -s 52 >> tnq.gam
 vg pack -x tnq_ap.gfa -g tnq.gam -o tnq.pack
@@ -411,11 +411,11 @@ rm -f tnq_ap.gfa tnq.gam tnq.pack tnq.vcf
 #   y0 (a#1): 1->2->4->5->6           (insertion with SNP A, allele 1 at top, allele 1 at nested)
 #   y1 (a#2): 1->2->3->5->6           (insertion with SNP T, allele 2 at top, allele 0 at nested)
 # Top-level snarl: 1->6, Nested snarl: 2->5
-# NOTE: ref path x bypasses the nested snarl, so we need augref covers to call nested variants
+# NOTE: ref path x bypasses the nested snarl, so we need gref covers to call nested variants
 # =============================================================================
 
-# Compute augref cover first (creates x_1_alt, x_2_alt, etc. covering nodes not on x)
-vg paths --compute-augref -Q x --min-augref-len 1 -x nesting/nested_snp_in_ins.gfa > ni_ap.gfa
+# Compute gref cover first (creates x_1_alt, x_2_alt, etc. covering nodes not on x)
+vg paths --compute-gref -Q x --min-gref-len 1 -x nesting/nested_snp_in_ins.gfa > ni_ap.gfa
 
 # Test 0/0: homozygous reference - reads only from x path (short ref)
 vg sim -x ni_ap.gfa -P x -n 100 -l 2 -a -s 70 > ni_00.gam
@@ -431,25 +431,25 @@ vg sim -x ni_ap.gfa -P x -n 50 -l 2 -a -s 71 > ni_01.gam
 vg sim -x ni_ap.gfa -P "a#2#y1#0" -n 200 -l 2 -a -s 72 >> ni_01.gam
 vg pack -x ni_ap.gfa -g ni_01.gam -o ni_01.pack
 vg call ni_ap.gfa -k ni_01.pack --top-down -P x 2>/dev/null > ni_01.vcf
-# With augref paths: both top-level and nested variants emitted
+# With gref paths: both top-level and nested variants emitted
 NI_01_COUNT=$(grep -v "^#" ni_01.vcf | wc -l)
-is "$NI_01_COUNT" "2" "nested_snp_in_ins 0/1: het ref/ins produces top-level and nested variants with augref paths"
+is "$NI_01_COUNT" "2" "nested_snp_in_ins 0/1: het ref/ins produces top-level and nested variants with gref paths"
 
 # Test 1/1: homozygous insertion - reads only from y1 path
 vg sim -x ni_ap.gfa -P "a#2#y1#0" -n 100 -l 2 -a -s 73 > ni_11.gam
 vg pack -x ni_ap.gfa -g ni_11.gam -o ni_11.pack
 vg call ni_ap.gfa -k ni_11.pack --top-down -P x 2>/dev/null > ni_11.vcf
-# With augref paths: both top-level and nested variants emitted
+# With gref paths: both top-level and nested variants emitted
 NI_11_COUNT=$(grep -v "^#" ni_11.vcf | wc -l)
-is "$NI_11_COUNT" "2" "nested_snp_in_ins 1/1: homozygous ins produces top-level and nested variants with augref paths"
+is "$NI_11_COUNT" "2" "nested_snp_in_ins 1/1: homozygous ins produces top-level and nested variants with gref paths"
 
 # Test 1/2: het between two insertion alleles - reads from both y0 and y1
 vg sim -x ni_ap.gfa -m a -n 200 -l 2 -a -s 74 > ni_12.gam
 vg pack -x ni_ap.gfa -g ni_12.gam -o ni_12.pack
 vg call ni_ap.gfa -k ni_12.pack --top-down -P x 2>/dev/null > ni_12.vcf
-# With augref paths: both top-level and nested variants emitted
+# With gref paths: both top-level and nested variants emitted
 NI_12_COUNT=$(grep -v "^#" ni_12.vcf | wc -l)
-is "$NI_12_COUNT" "2" "nested_snp_in_ins 1/2: het ins/ins produces top-level and nested variants with augref paths"
+is "$NI_12_COUNT" "2" "nested_snp_in_ins 1/2: het ins/ins produces top-level and nested variants with gref paths"
 
 rm -f ni_ap.gfa ni_00.gam ni_00.pack ni_00.vcf ni_01.gam ni_01.pack ni_01.vcf
 rm -f ni_11.gam ni_11.pack ni_11.vcf ni_12.gam ni_12.pack ni_12.vcf
@@ -462,11 +462,11 @@ rm -f ni_11.gam ni_11.pack ni_11.vcf ni_12.gam ni_12.pack ni_12.vcf
 #   y1 (a#2): 1->2->3->31->311->312->32->33->34->4->5 (different at deepest level)
 #   y2 (a#3): same as y0
 # Top-level snarl: 1->5, with 4 levels of nesting inside
-# NOTE: ref path x bypasses all nesting, so we need augref covers to call nested variants
+# NOTE: ref path x bypasses all nesting, so we need gref covers to call nested variants
 # =============================================================================
 
-# Compute augref cover first (creates x_1_alt, x_2_alt, etc. covering nested nodes)
-vg paths --compute-augref -Q x --min-augref-len 1 -x nesting/triple_nested.gfa > tn_ap.gfa
+# Compute gref cover first (creates x_1_alt, x_2_alt, etc. covering nested nodes)
+vg paths --compute-gref -Q x --min-gref-len 1 -x nesting/triple_nested.gfa > tn_ap.gfa
 
 # Test 0/0: homozygous reference - reads only from x path
 vg sim -x tn_ap.gfa -P x -n 100 -l 2 -a -s 80 > tn_00.gam
@@ -481,15 +481,15 @@ vg sim -x tn_ap.gfa -P x -n 50 -l 2 -a -s 81 > tn_01.gam
 vg sim -x tn_ap.gfa -P "a#1#y0#0" -n 500 -l 2 -a -s 82 >> tn_01.gam
 vg pack -x tn_ap.gfa -g tn_01.gam -o tn_01.pack
 vg call tn_ap.gfa -k tn_01.pack --top-down -P x 2>/dev/null > tn_01.vcf
-# With augref paths: all 5 nesting levels can be emitted
+# With gref paths: all 5 nesting levels can be emitted
 TN_01_COUNT=$(grep -v "^#" tn_01.vcf | wc -l)
-is "$TN_01_COUNT" "5" "triple_nested 0/1: het ref/ins produces all 5 nesting level variants with augref paths"
+is "$TN_01_COUNT" "5" "triple_nested 0/1: het ref/ins produces all 5 nesting level variants with gref paths"
 
 # Test 1/1: homozygous insertion - reads only from y0 path
 vg sim -x tn_ap.gfa -P "a#1#y0#0" -n 200 -l 2 -a -s 83 > tn_11.gam
 vg pack -x tn_ap.gfa -g tn_11.gam -o tn_11.pack
 vg call tn_ap.gfa -k tn_11.pack --top-down -P x 2>/dev/null > tn_11.vcf
-# With augref paths: 1 variant emitted (top-level insertion only)
+# With gref paths: 1 variant emitted (top-level insertion only)
 # All nested snarls are 0/0 because y0 matches x_1_alt reference at all levels
 # (y0 goes through 313, and x_1_alt also goes through 313)
 TN_11_COUNT=$(grep -v "^#" tn_11.vcf | wc -l)
@@ -500,9 +500,9 @@ vg sim -x tn_ap.gfa -P "a#1#y0#0" -n 200 -l 2 -a -s 84 > tn_12.gam
 vg sim -x tn_ap.gfa -P "a#2#y1#0" -n 200 -l 2 -a -s 85 >> tn_12.gam
 vg pack -x tn_ap.gfa -g tn_12.gam -o tn_12.pack
 vg call tn_ap.gfa -k tn_12.pack --top-down -P x 2>/dev/null > tn_12.vcf
-# With augref paths: all 5 nesting levels can be emitted
+# With gref paths: all 5 nesting levels can be emitted
 TN_12_COUNT=$(grep -v "^#" tn_12.vcf | wc -l)
-is "$TN_12_COUNT" "5" "triple_nested 1/2: het ins/ins produces all 5 nesting level variants with augref paths"
+is "$TN_12_COUNT" "5" "triple_nested 1/2: het ins/ins produces all 5 nesting level variants with gref paths"
 
 rm -f tn_ap.gfa tn_00.gam tn_00.pack tn_00.vcf tn_01.gam tn_01.pack tn_01.vcf
 rm -f tn_11.gam tn_11.pack tn_11.vcf tn_12.gam tn_12.pack tn_12.vcf
@@ -510,12 +510,12 @@ rm -f tn_11.gam tn_11.pack tn_11.vcf tn_12.gam tn_12.pack tn_12.vcf
 # =============================================================================
 # Multi-level SNP test (triple_nested_multisnp.gfa)
 # This graph has SNPs at multiple nesting levels:
-# - y0 matches x_1_alt at all levels (will be chosen as augref reference)
+# - y0 matches x_1_alt at all levels (will be chosen as gref reference)
 # - y1 differs from x_1_alt at all nested levels
 # When simulating from y1, we should get variants at all 4 nesting levels
 # =============================================================================
 
-vg paths -x nesting/triple_nested_multisnp.gfa -Q x --compute-augref --min-augref-len 1 > tn_ms_ap.gfa
+vg paths -x nesting/triple_nested_multisnp.gfa -Q x --compute-gref --min-gref-len 1 > tn_ms_ap.gfa
 vg sim -x tn_ms_ap.gfa -P "a#2#y1#0" -n 200 -l 2 -a -s 100 > tn_ms.gam
 vg pack -x tn_ms_ap.gfa -g tn_ms.gam -o tn_ms.pack
 vg call tn_ms_ap.gfa -k tn_ms.pack --top-down -P x 2>/dev/null > tn_ms.vcf
@@ -535,17 +535,17 @@ rm -f tn_ms_ap.gfa tn_ms.gam tn_ms.pack tn_ms.vcf
 
 # =============================================================================
 # Short reference bypass tests
-# NOTE: ref path x bypasses nested structures, so we need augref covers to call nested variants
+# NOTE: ref path x bypasses nested structures, so we need gref covers to call nested variants
 # =============================================================================
 
 # Test nested_snp_in_nested_ins.gfa - ref bypasses all nested structures
-# Compute augref cover first (creates x_1_alt, etc. covering nested nodes)
-vg paths --compute-augref -Q x --min-augref-len 1 -x nesting/nested_snp_in_nested_ins.gfa > bypass_ap.gfa
+# Compute gref cover first (creates x_1_alt, etc. covering nested nodes)
+vg paths --compute-gref -Q x --min-gref-len 1 -x nesting/nested_snp_in_nested_ins.gfa > bypass_ap.gfa
 vg sim -x bypass_ap.gfa -m a -n 100 -l 2 -a -s 60 > bypass.gam
 vg pack -x bypass_ap.gfa -g bypass.gam -o bypass.pack
 vg call bypass_ap.gfa -k bypass.pack --top-down -P x 2>/dev/null > bypass.vcf
 BYPASS_EXIT=$?
-is "$BYPASS_EXIT" "0" "nested_snp_in_nested_ins: vg call handles short-ref nested graph with augref paths without crashing"
+is "$BYPASS_EXIT" "0" "nested_snp_in_nested_ins: vg call handles short-ref nested graph with gref paths without crashing"
 
 rm -f bypass_ap.gfa bypass.gam bypass.pack bypass.vcf
 
@@ -574,9 +574,9 @@ is "$NA_DEL_NEST_GT" "0/0" "--top-down -a: nested_snp_in_del nested is 0/0"
 
 rm -f na_del.gam na_del.pack na_del.vcf
 
-# Test 2: nested_snp_in_ins 0/0 with --top-down -a (with augref paths)
+# Test 2: nested_snp_in_ins 0/0 with --top-down -a (with gref paths)
 # When ref bypasses nested snarl and both alleles are ref, nested NOT emitted
-vg paths --compute-augref -Q x --min-augref-len 1 -x nesting/nested_snp_in_ins.gfa > na_ins_ap.gfa 2>/dev/null
+vg paths --compute-gref -Q x --min-gref-len 1 -x nesting/nested_snp_in_ins.gfa > na_ins_ap.gfa 2>/dev/null
 vg sim -x na_ins_ap.gfa -P x -n 100 -l 2 -a -s 200 > na_ins_00.gam
 vg pack -x na_ins_ap.gfa -g na_ins_00.gam -o na_ins_00.pack
 vg call na_ins_ap.gfa -k na_ins_00.pack --top-down -a -P x 2>/dev/null > na_ins_00.vcf
@@ -587,7 +587,7 @@ is "$NA_INS_00_COUNT" "1" "--top-down -a: nested_snp_in_ins 0/0 emits only top-l
 
 rm -f na_ins_00.gam na_ins_00.pack na_ins_00.vcf
 
-# Test 3: nested_snp_in_ins 0/1 with --top-down -a (with augref paths)
+# Test 3: nested_snp_in_ins 0/1 with --top-down -a (with gref paths)
 # When ref bypasses nested but alt traverses, nested should have ./X genotype
 vg sim -x na_ins_ap.gfa -P x -n 50 -l 2 -a -s 200 > na_ins_01.gam
 vg sim -x na_ins_ap.gfa -P "a#1#y0#0" -n 100 -l 2 -a -s 201 >> na_ins_01.gam
@@ -605,9 +605,9 @@ is "$NA_INS_01_HAS_MISSING" "1" "--top-down -a: nested_snp_in_ins 0/1 nested has
 
 rm -f na_ins_ap.gfa na_ins_01.gam na_ins_01.pack na_ins_01.vcf
 
-# Test 4: triple_nested 0/0 with --top-down -a (with augref paths)
+# Test 4: triple_nested 0/0 with --top-down -a (with gref paths)
 # When ref bypasses all nested snarls and genotype is 0/0, only top-level emitted
-vg paths --compute-augref -Q x --min-augref-len 1 -x nesting/triple_nested.gfa > na_tn_ap.gfa 2>/dev/null
+vg paths --compute-gref -Q x --min-gref-len 1 -x nesting/triple_nested.gfa > na_tn_ap.gfa 2>/dev/null
 vg sim -x na_tn_ap.gfa -P x -n 100 -l 2 -a -s 210 > na_tn_00.gam
 vg pack -x na_tn_ap.gfa -g na_tn_00.gam -o na_tn_00.pack
 vg call na_tn_ap.gfa -k na_tn_00.pack --top-down -a -P x 2>/dev/null > na_tn_00.vcf
@@ -622,7 +622,7 @@ is "$NA_TN_00_GT" "0/0" "--top-down -a: triple_nested 0/0 top-level is 0/0"
 
 rm -f na_tn_00.gam na_tn_00.pack na_tn_00.vcf
 
-# Test 5: triple_nested 0/1 with --top-down -a (with augref paths)
+# Test 5: triple_nested 0/1 with --top-down -a (with gref paths)
 # When ref bypasses nested but alt traverses, nested snarls should have ./X genotype
 vg sim -x na_tn_ap.gfa -P x -n 50 -l 2 -a -s 211 > na_tn_01.gam
 vg sim -x na_tn_ap.gfa -P "a#1#y0#0" -n 500 -l 2 -a -s 212 >> na_tn_01.gam
@@ -697,8 +697,8 @@ is "$AS_NESTED_PS" "1" "-A flag: nested variant has PS tag"
 
 rm -f as_nested.vg as_nested.gam as_nested.pack as_nested.vcf
 
-# Test: -A flag on triple nested graph with augref paths
-vg paths --compute-augref -Q x --min-augref-len 1 -x nesting/triple_nested.gfa > as_triple.gfa 2>/dev/null
+# Test: -A flag on triple nested graph with gref paths
+vg paths --compute-gref -Q x --min-gref-len 1 -x nesting/triple_nested.gfa > as_triple.gfa 2>/dev/null
 vg sim -x as_triple.gfa -P "a#1#y0#0" -n 200 -l 2 -a -s 302 > as_triple.gam
 vg sim -x as_triple.gfa -P "a#2#y1#0" -n 200 -l 2 -a -s 303 >> as_triple.gam
 vg pack -x as_triple.gfa -g as_triple.gam -o as_triple.pack
@@ -725,7 +725,7 @@ rm -f as_triple.gfa as_triple.gam as_triple.pack as_triple.vcf
 # =============================================================================
 
 # Test: RC, RS, RD headers are present
-vg paths --compute-augref -Q x --min-augref-len 1 -x nesting/triple_nested.gfa > rc_test.gfa 2>/dev/null
+vg paths --compute-gref -Q x --min-gref-len 1 -x nesting/triple_nested.gfa > rc_test.gfa 2>/dev/null
 vg sim -x rc_test.gfa -P "a#1#y0#0" -n 100 -l 2 -a -s 400 > rc_test.gam 2>/dev/null
 vg sim -x rc_test.gfa -P "a#2#y1#0" -n 100 -l 2 -a -s 401 >> rc_test.gam 2>/dev/null
 vg pack -x rc_test.gfa -g rc_test.gam -o rc_test.pack 2>/dev/null

--- a/test/t/26_deconstruct.t
+++ b/test/t/26_deconstruct.t
@@ -159,25 +159,25 @@ is "$(tail -1 small_cluster_3.vcf | awk '{print $10}')" "0:0.333:0" "clustered d
 rm -f small_cluster.gfa small_cluster_0.vcf small_cluster_3.vcf
 
 # Nesting tests now use a two-step process:
-# 1. Compute augref cover with vg paths
-# 2. Run vg deconstruct with -a to use the pre-computed augref paths
+# 1. Compute gref cover with vg paths
+# 2. Run vg deconstruct with -a to use the pre-computed gref paths
 
 # Test: SNP inside deletion
-vg paths --compute-augref --min-augref-len 0 -x nesting/nested_snp_in_del.gfa -Q x > nested_snp_in_del.augref.pg
-vg deconstruct nested_snp_in_del.augref.pg -p x -a > nested_snp_in_del.vcf
+vg paths --compute-gref --min-gref-len 0 -x nesting/nested_snp_in_del.gfa -Q x > nested_snp_in_del.gref.pg
+vg deconstruct nested_snp_in_del.gref.pg -p x -a > nested_snp_in_del.vcf
 grep -v ^# nested_snp_in_del.vcf | awk '{print $4 "\t" $5 "\t" $10}' > nested_snp_in_del.tsv
 printf "CATG\tCAAG,C\t1|2\n" > nested_snp_in_del_truth.tsv
 printf "T\tA\t1|.\n" >> nested_snp_in_del_truth.tsv
 diff nested_snp_in_del.tsv nested_snp_in_del_truth.tsv
 is "$?" 0 "nested deconstruction gets correct allele for snp inside deletion"
 
-rm -f nested_snp_in_del.augref.pg nested_snp_in_del.vcf nested_snp_in_del.tsv nested_snp_in_del_truth.tsv
+rm -f nested_snp_in_del.gref.pg nested_snp_in_del.vcf nested_snp_in_del.tsv nested_snp_in_del_truth.tsv
 
 # Test: SNP inside insertion with LV field checks
-vg paths --compute-augref --min-augref-len 0 -x nesting/nested_snp_in_ins.gfa -Q x > nested_snp_in_ins.augref.pg
-vg deconstruct nested_snp_in_ins.augref.pg -P x -a > nested_snp_in_ins.vcf
+vg paths --compute-gref --min-gref-len 0 -x nesting/nested_snp_in_ins.gfa -Q x > nested_snp_in_ins.gref.pg
+vg deconstruct nested_snp_in_ins.gref.pg -P x -a > nested_snp_in_ins.vcf
 grep -v ^# nested_snp_in_ins.vcf | awk '{print $4 "\t" $5 "\t" $10}' > nested_snp_in_ins.tsv
-# With -P x, nested variants are on augref contigs (x_1_alt), parent on x
+# With -P x, nested variants are on gref contigs (x_1_alt), parent on x
 # So order is: insertion (on x) then SNP (on x_1_alt)
 printf "C\tCAAG,CATG\t1|2\n" > nested_snp_in_ins_truth.tsv
 printf "A\tT\t0|1\n" >> nested_snp_in_ins_truth.tsv
@@ -190,64 +190,64 @@ is $(grep LV=1 nested_snp_in_ins.vcf | wc -l) 1 "LV=1 set for nested allele of n
 # With -P x, we get multiple contigs (x, x_1_alt, x_2_alt)
 is $(grep -c "^##contig" nested_snp_in_ins.vcf) 3 "nested deconstruction gets all reference contigs in vcf header"
 
-rm -f nested_snp_in_ins.augref.pg nested_snp_in_ins.vcf nested_snp_in_ins.tsv nested_snp_in_ins_truth.tsv nested_snp_in_ins_contigs.tsv
+rm -f nested_snp_in_ins.gref.pg nested_snp_in_ins.vcf nested_snp_in_ins.tsv nested_snp_in_ins_truth.tsv nested_snp_in_ins_contigs.tsv
 
 # Test: Double-nested SNP (run with -t 1, -t 2, and default threads to verify determinism)
 for thread_opt in "-t 1" "-t 2" ""; do
     thread_label=${thread_opt:- default}
-    vg paths --compute-augref --min-augref-len 0 $thread_opt -x nesting/nested_snp_in_nested_ins.gfa -Q x > nested_snp_in_nested_ins.augref.pg
-    vg deconstruct nested_snp_in_nested_ins.augref.pg -P x -a > nested_snp_in_nested_ins.vcf
+    vg paths --compute-gref --min-gref-len 0 $thread_opt -x nesting/nested_snp_in_nested_ins.gfa -Q x > nested_snp_in_nested_ins.gref.pg
+    vg deconstruct nested_snp_in_nested_ins.gref.pg -P x -a > nested_snp_in_nested_ins.vcf
     is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep LV=0 | wc -l) 1 "level 0 site found in double-nested SNP ($thread_label)"
     is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep "LV=" | wc -l) 3 "all nested sites found in double-nested SNP ($thread_label)"
     is $(grep -v ^# nested_snp_in_nested_ins.vcf | grep LV=2 | wc -l) 1 "level 2 site found in double-nested SNP ($thread_label)"
-    rm -f nested_snp_in_nested_ins.augref.pg nested_snp_in_nested_ins.vcf
+    rm -f nested_snp_in_nested_ins.gref.pg nested_snp_in_nested_ins.vcf
 done
 
 # Test: Nested site with cycle
-vg paths --compute-augref --min-augref-len 0 -x nesting/nested_snp_in_ins_cycle.gfa -Q x > nested_snp_in_ins_cycle.augref.pg
-vg deconstruct nested_snp_in_ins_cycle.augref.pg -P x -a > nested_snp_in_ins_cycle.vcf
+vg paths --compute-gref --min-gref-len 0 -x nesting/nested_snp_in_ins_cycle.gfa -Q x > nested_snp_in_ins_cycle.gref.pg
+vg deconstruct nested_snp_in_ins_cycle.gref.pg -P x -a > nested_snp_in_ins_cycle.vcf
 is $(grep -v ^# nested_snp_in_ins_cycle.vcf | grep LV=0 | wc -l) 1 "level 0 found in nested cycle"
 is $(grep -v ^# nested_snp_in_ins_cycle.vcf | grep LV=1 | wc -l) 1 "level 1 found in nested cycle"
-rm -f nested_snp_in_ins_cycle.augref.pg nested_snp_in_ins_cycle.vcf
+rm -f nested_snp_in_ins_cycle.gref.pg nested_snp_in_ins_cycle.vcf
 
 # Test: MNP handling
-vg paths --compute-augref --min-augref-len 0 -x nesting/mnp.gfa -Q x > mnp.augref.pg
-vg deconstruct mnp.augref.pg -p x -a > mnp.vcf
+vg paths --compute-gref --min-gref-len 0 -x nesting/mnp.gfa -Q x > mnp.gref.pg
+vg deconstruct mnp.gref.pg -p x -a > mnp.vcf
 printf "x\t3\t>2>7\tTCAT\tATTT\n" > mnp_truth.tsv
 grep -v ^# mnp.vcf | awk '{print $1 "\t" $2 "\t" $3 "\t" $4 "\t" $5}' > mnp.tsv
 diff  mnp_truth.tsv mnp.tsv
 is "$?" 0 "nested deconstruction handles mnp"
 
-rm -f mnp.augref.pg mnp.vcf mnp_truth.tsv mnp.tsv
+rm -f mnp.gref.pg mnp.vcf mnp_truth.tsv mnp.tsv
 
 # Test 1: Deep nesting (3+ levels) - triple nested SNP
-vg paths --compute-augref --min-augref-len 0 -x nesting/triple_nested.gfa -Q x > triple_nested.augref.pg
-vg deconstruct triple_nested.augref.pg -P x -a > triple_nested.vcf
+vg paths --compute-gref --min-gref-len 0 -x nesting/triple_nested.gfa -Q x > triple_nested.gref.pg
+vg deconstruct triple_nested.gref.pg -P x -a > triple_nested.vcf
 is $(grep -v ^# triple_nested.vcf | grep LV=0 | wc -l) 1 "level 0 site found in triple nested"
 is $(grep -v ^# triple_nested.vcf | grep "LV=" | wc -l) 5 "all nested sites found in triple nested"
 is $(grep -v ^# triple_nested.vcf | grep LV=2 | wc -l) 1 "level 2 site found in triple nested"
 is $(grep -v ^# triple_nested.vcf | grep LV=3 | wc -l) 1 "level 3 site found in triple nested"
 is $(grep -v ^# triple_nested.vcf | grep LV=4 | wc -l) 1 "level 4 site found in triple nested"
-rm -f triple_nested.augref.pg triple_nested.vcf
+rm -f triple_nested.gref.pg triple_nested.vcf
 
 # Test 2: Multiple children at same level - insertion with 2 nested SNPs
-vg paths --compute-augref --min-augref-len 0 -x nesting/insertion_with_three_snps.gfa -Q x > insertion_with_three_snps.augref.pg
-vg deconstruct insertion_with_three_snps.augref.pg -P x -a > multi_child.vcf
+vg paths --compute-gref --min-gref-len 0 -x nesting/insertion_with_three_snps.gfa -Q x > insertion_with_three_snps.gref.pg
+vg deconstruct insertion_with_three_snps.gref.pg -P x -a > multi_child.vcf
 is $(grep -v ^# multi_child.vcf | grep "LV=" | wc -l) 3 "expected number of sites with LV field"
 is $(grep -v ^# multi_child.vcf | grep LV=1 | wc -l) 2 "two child SNPs found at level 1"
-rm -f insertion_with_three_snps.augref.pg multi_child.vcf
+rm -f insertion_with_three_snps.gref.pg multi_child.vcf
 
 # Test 3: NestingInfo field propagation - verify LV field
-vg paths --compute-augref --min-augref-len 0 -x nesting/nested_snp_in_ins.gfa -Q x > field_check.augref.pg
-vg deconstruct field_check.augref.pg -P x -a > field_check.vcf
+vg paths --compute-gref --min-gref-len 0 -x nesting/nested_snp_in_ins.gfa -Q x > field_check.gref.pg
+vg deconstruct field_check.gref.pg -P x -a > field_check.vcf
 is $(grep "LV=0" field_check.vcf | wc -l) 1 "LV=0 field present for top-level site"
-rm -f field_check.augref.pg field_check.vcf
+rm -f field_check.gref.pg field_check.vcf
 
 # Test 4: Multiple reference traversals with nesting (should reduce to one)
-vg paths --compute-augref --min-augref-len 0 -x nesting/cyclic_ref_nested.gfa -Q x > cyclic_ref_nested.augref.pg
-vg deconstruct cyclic_ref_nested.augref.pg -p x -a > cyclic_ref_nested.vcf
+vg paths --compute-gref --min-gref-len 0 -x nesting/cyclic_ref_nested.gfa -Q x > cyclic_ref_nested.gref.pg
+vg deconstruct cyclic_ref_nested.gref.pg -p x -a > cyclic_ref_nested.vcf
 is $(grep -v ^# cyclic_ref_nested.vcf | wc -l) 1 "cyclic reference with nesting produces single variant"
-rm -f cyclic_ref_nested.augref.pg cyclic_ref_nested.vcf
+rm -f cyclic_ref_nested.gref.pg cyclic_ref_nested.vcf
 
 # Test 5: Cyclic reference outputs multiple variants (one per reference traversal)
 # Reference x visits the snarl twice (via node 2 then 3), alt a visits twice (via node 3 then 4)
@@ -261,8 +261,8 @@ rm -f cyclic_ref_multi.vcf
 # =============================================================================
 
 # Test: RC, RS, RD headers and tags in deconstruct output
-vg paths --compute-augref --min-augref-len 0 -x nesting/triple_nested.gfa -Q x > rc_decon_test.augref.pg
-vg deconstruct rc_decon_test.augref.pg -P x -a > rc_decon_test.vcf
+vg paths --compute-gref --min-gref-len 0 -x nesting/triple_nested.gfa -Q x > rc_decon_test.gref.pg
+vg deconstruct rc_decon_test.gref.pg -P x -a > rc_decon_test.vcf
 
 # Check for RC, RS, RD headers
 is $(grep -c "##INFO=<ID=RC" rc_decon_test.vcf) 1 "deconstruct: RC header is present in VCF"
@@ -287,4 +287,4 @@ NESTED_DECON_RC=$(grep -v "^#" rc_decon_test.vcf | awk -F'\t' '$8 ~ /LV=[1-9]/' 
 NESTED_DECON_COUNT=$(grep -v "^#" rc_decon_test.vcf | awk -F'\t' '$8 ~ /LV=[1-9]/' | grep -c "")
 is "$NESTED_DECON_RC" "$NESTED_DECON_COUNT" "deconstruct: all nested variants have RC=x (top-level contig)"
 
-rm -f rc_decon_test.augref.pg rc_decon_test.vcf
+rm -f rc_decon_test.gref.pg rc_decon_test.vcf


### PR DESCRIPTION
Rename the augref module and feature throughout vg to "graph reference" (gref) to be a bit simpler (in the process of harmonizing with cactus and various writeups).  Proper documentation in vg still pending, but interface hopefully close to final.  

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * augref-related options in vg paths renamed to be gref-related

## Description
