### PR TITLE
Avoid upgrading packages and try to update emulator

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,8 +219,7 @@ production-build-job:
     - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then DOCKER_TAG="${CI_COMMIT_TAG}" ; else DOCKER_TAG="ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"; fi
     - make version
     # Make sure ARM emulation is available.
-    # TODO: This assumes one job per host and will probably cause Trouble if trying to uninstall the emulator while something else is using it.
-    - if [[ "${CI_BUILDKIT_DRIVER}" != "kubernetes" ]] ; then docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1-65 --uninstall "qemu-*" || true ; docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1-65 --install all || true; fi
+    - if [[ "${CI_BUILDKIT_DRIVER}" != "kubernetes" ]] ; then docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1-65 --install all || true; fi
     # TODO: deduplicate this code with normal build above
     # Note that A LOCAL CACHE CAN ONLY HOLD ONE TAG/TARGET AT A TIME!
     # And Quay can't use mode=max registry caching to cache the intermediate targets with the final image, just inline caching.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,7 +219,8 @@ production-build-job:
     - if [[ ! -z "${CI_COMMIT_TAG}" ]]; then DOCKER_TAG="${CI_COMMIT_TAG}" ; else DOCKER_TAG="ci-${CI_PIPELINE_IID}-${CI_COMMIT_SHA}"; fi
     - make version
     # Make sure ARM emulation is available.
-    - if [[ "${CI_BUILDKIT_DRIVER}" != "kubernetes" ]] ; then docker run --privileged --rm tonistiigi/binfmt --install all || true ; fi
+    # TODO: This assumes one job per host and will probably cause Trouble if trying to uninstall the emulator while something else is using it.
+    - if [[ "${CI_BUILDKIT_DRIVER}" != "kubernetes" ]] ; then docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1-65 --uninstall "qemu-*" || true ; docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1-65 --install all || true; fi
     # TODO: deduplicate this code with normal build above
     # Note that A LOCAL CACHE CAN ONLY HOLD ONE TAG/TARGET AT A TIME!
     # And Quay can't use mode=max registry caching to cache the intermediate targets with the final image, just inline caching.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ ENV VG_GIT_VERSION=${VG_GIT_VERSION:-unknown}
 RUN echo packages > /stage.txt
 
 RUN apt-get -qq -y update && \
-    apt-get -qq -y upgrade && \
-    apt-get -qq -y install sudo
+    apt-get -qq -y install --no-upgrade sudo
 
 # Install all vg's dependencies.
 # The Makefile will come parse the Dockerfile to get the correct dependencies;
@@ -38,7 +37,7 @@ RUN apt-get -qq -y update && \
 # that starts with RUN, or comments. And we pull out line continuation slashes.
 # TODO: can we read them here and in the Makefile from the README instead?
 ###DEPS_BEGIN###
-RUN apt-get -qq -y update && apt-get -qq -y upgrade && apt-get -y install \
+RUN apt-get -qq -y update && apt-get -y install --no-upgrade \
     make git build-essential protobuf-compiler libprotoc-dev libjansson-dev libbz2-dev \
     libncurses5-dev automake gettext autopoint libtool jq bsdmainutils bc rs parallel npm \
     samtools curl unzip redland-utils librdf-dev cmake pkg-config wget gtk-doc-tools \
@@ -112,7 +111,6 @@ RUN echo run > /stage.txt
 # Make sure to clean so we don't ship old apt package indexes in our Docker.
 RUN ls -lah /vg && \
     apt-get -qq -y update && \
-    apt-get -qq -y upgrade && \
     apt-get -qq -y install --no-upgrade \
     curl \
     wget \

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -15,7 +15,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 
 # Install dependencies for scripts
 RUN apt-get -qq -y update && \
-    apt-get -qq -y upgrade && \
     apt-get -qq -y install --no-upgrade \
     numactl \
     python3-matplotlib \


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * vg CI builds of ARM containers should no longer segfault when upgrading libc

## Description

We've been getting CI ARM Docker build crashes like this: https://ucsc-ci.com/vgteam/vg/-/jobs/109050#L2786

This should avoid https://github.com/docker/buildx/issues/314 in two ways:
* We no longer upgrade packages from the base image when building the Docker image in CI. They *should* be up to date enough in the base image (but we might need to make sure that https://stackoverflow.com/q/77924205 is still true).
* We install a new binfmt-misc emulator that maybe won't have the crash bug. We're *supposed* to uninstall the old one and install the new one, but when we move the workload to shared machines we don't want the emulator getting uninstalled while in use.
