### PR TITLE
Add softclip_total option to vg filter

### DIFF
--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -1589,6 +1589,8 @@ inline void ReadFilter<Alignment>::emit_tsv(Alignment& read, std::ostream& out) 
             out << softclip_start(read);
         } else if (field == "softclip_end") {
             out << softclip_end(read);
+        } else if (field == "softclip_total") {
+            out << (softclip_start(read) + softclip_end(read));
         } else if (field == "identity") {
             out << read.identity();
         } else if (field == "is_perfect") {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg filter --tsv-out` has a `softclip_total` option for convenience (`softclip_end` + `softclip_start`)

## Description

Here ya go Elina. Resolves #4906. Since sometimes when people want softclip stats, they care more about the total number of bp softclipped, not the division into start/end.