### PR TITLE
Minimizer index construction speed up

### DIFF
--- a/src/algorithms/chain_items.cpp
+++ b/src/algorithms/chain_items.cpp
@@ -11,6 +11,8 @@
 #include <structures/immutable_list.hpp>
 #include <structures/min_max_heap.hpp>
 
+#include <algorithm>
+
 //#define debug_chaining
 //#define debug_transition
 //#define debug_missing_transition
@@ -1042,6 +1044,7 @@ ChainsResult find_best_chains(const VectorView<Anchor>& to_chain,
         ChainWithRec empty_entry;
         empty_entry.scored_chain = {0, vector<size_t>()};
         empty_entry.rec_positions = {};
+        empty_entry.rec_intervals = {};
         result.chains.emplace_back(std::move(empty_entry));
         return result;
     }
@@ -1061,7 +1064,7 @@ ChainsResult find_best_chains(const VectorView<Anchor>& to_chain,
                                                              points_per_possible_match,
                                                              max_indel_bases,
                                                              recomb_penalty,
-                                                             show_work);
+                                                             show_work);                                                             
 #ifdef debug_chaining
     std::cerr << "[REC INFO] Recombination number for chain: " << best_past_ending_score_ever.rec_num << "\tscore: " << best_past_ending_score_ever.score << "\tpaths: " << best_past_ending_score_ever.paths << std::endl;
 #endif
@@ -1074,6 +1077,7 @@ ChainsResult find_best_chains(const VectorView<Anchor>& to_chain,
         ChainWithRec empty_entry;
         empty_entry.scored_chain = {0, vector<size_t>()};
         empty_entry.rec_positions = {};
+        empty_entry.rec_intervals = {};
         result.chains.emplace_back(std::move(empty_entry));
         return result;
     }
@@ -1123,9 +1127,50 @@ ChainsResult find_best_chains(const VectorView<Anchor>& to_chain,
             }
         }
 
+        // Symmetric backward pass: walk the chain right-to-left to find the
+        // left boundary of each recombination event. An anchor is a left
+        // boundary when, intersecting suffix path supports, its end_paths do
+        // not overlap with the supports accumulated from anchors to its right.
+        std::vector<size_t> left_rec_positions;
+        if (chain_indexes.size() > 1) {
+            size_t last_idx = chain_indexes.back();
+            path_flags_t current_paths = to_chain[last_idx].anchor_start_paths();
+
+            for (size_t k = chain_indexes.size() - 1; k > 0; --k) {
+                size_t anchor_idx = chain_indexes[k - 1];
+                auto new_paths = to_chain[anchor_idx].anchor_paths();
+                if (new_paths.first == new_paths.second) {
+                    if ((current_paths & new_paths.second) == 0) {
+                        left_rec_positions.push_back(anchor_idx);
+                        current_paths = new_paths.second;
+                    } else {
+                        current_paths &= new_paths.second;
+                    }
+                } else {
+                    // Internally recombinant anchor: mirror the forward
+                    // logic by resetting to the "far side" (start_paths here).
+                    current_paths = new_paths.first;
+                }
+            }
+            std::reverse(left_rec_positions.begin(), left_rec_positions.end());
+        }
+
+        // Pair forward (right) and backward (left) boundaries into intervals.
+        // When counts disagree (e.g. internally recombinant anchors break
+        // the symmetry) leave rec_intervals empty so consumers fall back
+        // to rec_positions.
+        std::vector<std::pair<size_t, size_t>> rec_intervals;
+        if (left_rec_positions.size() == rec_positions.size()) {
+            rec_intervals.reserve(rec_positions.size());
+            for (size_t i = 0; i < rec_positions.size(); ++i) {
+                rec_intervals.emplace_back(left_rec_positions[i], rec_positions[i]);
+            }
+        }
+
         ChainWithRec entry;
         entry.scored_chain = {score, std::move(chain_indexes)};
         entry.rec_positions = std::move(rec_positions);
+        entry.rec_intervals = std::move(rec_intervals);
         result.chains.emplace_back(std::move(entry));
     }
     return result;

--- a/src/algorithms/chain_items.hpp
+++ b/src/algorithms/chain_items.hpp
@@ -406,6 +406,14 @@ struct ChainWithRec {
     // reset supported paths because the previous path set did not overlap
     // with the next anchor's start paths.
     std::vector<size_t> rec_positions;
+    // For each recombination event, an interval [left, right] of anchor
+    // indices bounding where the event must lie. `right` is the same anchor
+    // recorded in `rec_positions` (forward pass: first anchor incompatible
+    // with the prefix). `left` comes from a symmetric backward pass: the
+    // last anchor (going right-to-left) incompatible with the suffix.
+    // May be empty when forward and backward counts disagree, e.g. when
+    // internally recombinant anchors break the symmetry.
+    std::vector<std::pair<size_t, size_t>> rec_intervals;
 };
 
 /// Result of finding best chains: a list of chains each paired with the

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -449,7 +449,8 @@ std::vector<key_type> find_frequent_kmers(const gbwtgraph::GBZ& gbz, const Minim
 void cache_payloads(
     const gbwtgraph::GBZ& gbz,
     const SnarlDistanceIndex& distance_index,
-    hash_map<nid_t, payload_t>& node_id_to_payload,
+    std::vector<payload_t>& node_id_to_payload,
+    nid_t min_node_id,
     ZipCodeCollection* oversized_zipcodes,
     bool progress
 ) {
@@ -470,12 +471,16 @@ void cache_payloads(
             // The zipcode is too large for the payload field.
             // Add it to the oversized zipcode list.
             zipcode.fill_in_full_decoder();
-            size_t offset = oversized_zipcodes->size();
-            oversized_zipcodes->emplace_back(zipcode);
+            size_t offset;
+            #pragma omp critical (oversized_zipcodes)
+            {
+                offset = oversized_zipcodes->size();
+                oversized_zipcodes->emplace_back(zipcode);
+            }
             payload = { 0, offset };
         }
-        node_id_to_payload.emplace(node_id, payload);
-    });
+        node_id_to_payload[node_id - min_node_id] = payload;
+    }, true);
 
     if (progress) {
         double seconds = gbwt::readTimer() - start;
@@ -536,18 +541,20 @@ gbwtgraph::DefaultMinimizerIndex build_minimizer_index(
         gbwtgraph::index_haplotypes(gbz, index, [](const pos_t&) { return nullptr; });
     } else {
         // Cache payloads before building the index.
-        // A zipcode only depends on the node id.
-        hash_map<nid_t, payload_t> node_id_to_payload;
-        node_id_to_payload.reserve(gbz.graph.max_node_id() - gbz.graph.min_node_id());
-        cache_payloads(gbz, *distance_index, node_id_to_payload, oversized_zipcodes, params.progress);
+        // A zipcode only depends on the node id. The map is indexed by
+        // (node_id - min_node_id) so we can fill it in parallel without
+        // synchronisation: every node writes to a disjoint slot.
+        nid_t min_node_id = gbz.graph.min_node_id();
+        nid_t max_node_id = gbz.graph.max_node_id();
+        std::vector<payload_t> node_id_to_payload(max_node_id - min_node_id + 1, MIPayload::NO_CODE);
+        cache_payloads(gbz, *distance_index, node_id_to_payload, min_node_id, oversized_zipcodes, params.progress);
 
         auto get_payload = [&](const pos_t& pos) -> const code_type* {
-            auto iter = node_id_to_payload.find(id(pos));
-            if (iter != node_id_to_payload.end()) {
-                return reinterpret_cast<const code_type*>(&iter->second);
-            } else {
+            nid_t nid = id(pos);
+            if (nid < min_node_id || nid - min_node_id >= node_id_to_payload.size()) {
                 return reinterpret_cast<const code_type*>(&MIPayload::NO_CODE);
             }
+            return reinterpret_cast<const code_type*>(&node_id_to_payload[nid - min_node_id]);
         };
         if (params.paths_in_payload) {
             gbwtgraph::index_haplotypes_with_paths(gbz, index, get_payload);

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -445,13 +445,13 @@ std::vector<key_type> find_frequent_kmers(const gbwtgraph::GBZ& gbz, const Minim
     return frequent_kmers;
 }
 
-// Fills `payload_by_offset` with the zipcode payload for every node in `gbz`.
+// Fills `payload_by_offset` with the zipcode payload for every node.
 // The vector is dense-indexed by `(node_id - min_node_id)`, not by the node id
 // itself; it must be pre-sized so that the largest offset fits, and slots for
 // node ids that do not exist in the graph stay at `MIPayload::NO_CODE`.
-// Oversized zipcodes (those that do not fit in the payload field) are appended
-// to `oversized_zipcodes` if non-null, and the payload stores their offset
-// inside that collection. Filling runs in parallel: every node writes to a
+// Oversized zipcodes are appended to `oversized_zipcodes` if non-null, and the 
+// payload stores their offset inside that collection. 
+// Filling runs in parallel: every node writes to a
 // disjoint slot, and access to `oversized_zipcodes` is serialised.
 void cache_payloads(
     const gbwtgraph::GBZ& gbz,
@@ -548,8 +548,7 @@ gbwtgraph::DefaultMinimizerIndex build_minimizer_index(
         gbwtgraph::index_haplotypes(gbz, index, [](const pos_t&) { return nullptr; });
     } else {
         // Cache payloads before building the index.
-        // A zipcode only depends on the node id, so we precompute one payload
-        // per node and look it up later. The cache is a dense vector indexed
+        // A zipcode only depends on the node id. The cache is a dense vector indexed
         // by (node_id - min_node_id), not by the node id itself: this lets us
         // fill it in parallel without synchronisation, since every node writes
         // to a disjoint slot.

--- a/src/gbwtgraph_helper.cpp
+++ b/src/gbwtgraph_helper.cpp
@@ -445,11 +445,18 @@ std::vector<key_type> find_frequent_kmers(const gbwtgraph::GBZ& gbz, const Minim
     return frequent_kmers;
 }
 
-// TODO: Should we multithread this?
+// Fills `payload_by_offset` with the zipcode payload for every node in `gbz`.
+// The vector is dense-indexed by `(node_id - min_node_id)`, not by the node id
+// itself; it must be pre-sized so that the largest offset fits, and slots for
+// node ids that do not exist in the graph stay at `MIPayload::NO_CODE`.
+// Oversized zipcodes (those that do not fit in the payload field) are appended
+// to `oversized_zipcodes` if non-null, and the payload stores their offset
+// inside that collection. Filling runs in parallel: every node writes to a
+// disjoint slot, and access to `oversized_zipcodes` is serialised.
 void cache_payloads(
     const gbwtgraph::GBZ& gbz,
     const SnarlDistanceIndex& distance_index,
-    std::vector<payload_t>& node_id_to_payload,
+    std::vector<payload_t>& payload_by_offset,
     nid_t min_node_id,
     ZipCodeCollection* oversized_zipcodes,
     bool progress
@@ -479,7 +486,7 @@ void cache_payloads(
             }
             payload = { 0, offset };
         }
-        node_id_to_payload[node_id - min_node_id] = payload;
+        payload_by_offset[node_id - min_node_id] = payload;
     }, true);
 
     if (progress) {
@@ -541,20 +548,22 @@ gbwtgraph::DefaultMinimizerIndex build_minimizer_index(
         gbwtgraph::index_haplotypes(gbz, index, [](const pos_t&) { return nullptr; });
     } else {
         // Cache payloads before building the index.
-        // A zipcode only depends on the node id. The map is indexed by
-        // (node_id - min_node_id) so we can fill it in parallel without
-        // synchronisation: every node writes to a disjoint slot.
+        // A zipcode only depends on the node id, so we precompute one payload
+        // per node and look it up later. The cache is a dense vector indexed
+        // by (node_id - min_node_id), not by the node id itself: this lets us
+        // fill it in parallel without synchronisation, since every node writes
+        // to a disjoint slot.
         nid_t min_node_id = gbz.graph.min_node_id();
         nid_t max_node_id = gbz.graph.max_node_id();
-        std::vector<payload_t> node_id_to_payload(max_node_id - min_node_id + 1, MIPayload::NO_CODE);
-        cache_payloads(gbz, *distance_index, node_id_to_payload, min_node_id, oversized_zipcodes, params.progress);
+        std::vector<payload_t> payload_by_offset(max_node_id - min_node_id + 1, MIPayload::NO_CODE);
+        cache_payloads(gbz, *distance_index, payload_by_offset, min_node_id, oversized_zipcodes, params.progress);
 
         auto get_payload = [&](const pos_t& pos) -> const code_type* {
             nid_t nid = id(pos);
-            if (nid < min_node_id || nid - min_node_id >= node_id_to_payload.size()) {
+            if (nid < min_node_id || nid - min_node_id >= payload_by_offset.size()) {
                 return reinterpret_cast<const code_type*>(&MIPayload::NO_CODE);
             }
-            return reinterpret_cast<const code_type*>(&node_id_to_payload[nid - min_node_id]);
+            return reinterpret_cast<const code_type*>(&payload_by_offset[nid - min_node_id]);
         };
         if (params.paths_in_payload) {
             gbwtgraph::index_haplotypes_with_paths(gbz, index, get_payload);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Speed up minimizer index construction.

## Description
Change the locate in minimizer index in order to use r-index. Parallelized payload caching