### PR TITLE
Add missing filter annotation to fix `--track-provenance`

### DIFF
--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -479,7 +479,9 @@ void Funnel::for_each_filter(const function<void(const string&, const string&,
                 } else {
                     // Make sure the name is correct
                     // TODO: can we justy match on pointer value and not string value?
-                    assert(strcmp(filter_names[filter_index], item.passed_filters[filter_index]) == 0);
+                    if (strcmp(filter_names[filter_index], item.passed_filters[filter_index]) != 0) {
+                        throw std::runtime_error("Passed filter needs to be " + std::string(filter_names[filter_index]) + " but is " + std::string(item.passed_filters[filter_index]));
+                    }
                 }
                 
                 // Record passing
@@ -513,7 +515,9 @@ void Funnel::for_each_filter(const function<void(const string&, const string&,
                 } else {
                     // Make sure the name is correct
                     // TODO: can we justy match on pointer value and not string value?
-                    assert(strcmp(filter_names[filter_index], item.failed_filter) == 0);
+                    if (strcmp(filter_names[filter_index], item.failed_filter) != 0) {
+                        throw std::runtime_error("Failed filter needs to be " + std::string(filter_names[filter_index]) + " but is " + std::string(item.passed_filters[filter_index]));
+                    }
                 }
                 
                 // Record failing

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -2373,8 +2373,25 @@ void MinimizerMapper::pick_mappings_from_alignments(const Alignment& aln, const 
         return true;
     }, [&](size_t alignment_num) {
         // We already have enough alignments, although this one has a good score
-       
-        // Go back and do the unique node fraction filter first.
+
+        // TODO: We end up having to duplicate a bunch of filters here so the
+        // filters are always in order.
+        
+        // Go back and do the nonzero score filter first.
+        // Filter to alignments with strictly positive scores
+        if (alignments[alignment_num].score() <= 0) {
+            if (track_provenance) {
+                funnel.fail("nonzero-score", alignment_num);
+            }
+            // If we fail the nonzero score filter, we won't count as a secondary for MAPQ
+            return;
+        } else {
+            if (track_provenance) {
+                funnel.pass("nonzero-score", alignment_num);
+            }
+        }
+
+        // Go back and do the unique node fraction filter next.
         // TODO: Deduplicate logging code
         double unique_node_fraction = get_fraction_unique(alignment_num);
         if (unique_node_fraction < min_unique_node_fraction) {


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe --track-provenance` should no longer crash with complaints about the filters.

## Description

In #4911 I managed to break `vg giraffe --track-provenance` by creating a way for reads to get through the code visiting different sequences of filters, which isn't allowed by the funnel system.

This should fix that.