### PR TITLE
Add "is_aligned" option to --tsv-out

### DIFF
--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -1613,6 +1613,13 @@ inline void ReadFilter<Alignment>::emit_tsv(Alignment& read, std::ostream& out) 
             }
         } else if (field == "time_used") {
             out << read.time_used();
+        } else if (field == "is_aligned") {
+            // Injected alignments may have paths but no scores.
+            if (read.score() > 0 || read.path().mapping_size() > 0) {
+                out << "True";
+            } else {
+                out << "False";
+            }
         } else if (field == "annotation") {
             // Since annotation is a Protobuf Struct, it comes out as JSON
             // describing the Struct and not what the Struct describes if


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add option `vg filter --tsv-out "is_aligned"` to return whether a read has an alignment

## Description

Uses the same logic as [vg stats](https://github.com/vgteam/vg/blob/806656094cc8b5bd1fbe142c6f583bc2bb9663bb/src/subcommand/stats_main.cpp#L824-L825) to determine whether a read has an alignment.

I thought it was a crying shame there was no obvious way to figure out if a read was aligned or not. Especially if I want to look for reads that were mismapped (aligned but wrong) as opposed to unmapped (wrong due to no alignment).