### PR TITLE
Leave low-scoring MAPQ 0 reads unmapped

### DIFF
--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -301,6 +301,15 @@ void Funnel::fail(const char* filter, size_t prev_stage_item, double statistic) 
     prev_stage.items[prev_stage_item].failed_statistic = statistic;
 }
 
+void Funnel::fail_if_needed(const char* filter, size_t prev_stage_item, double statistic) {
+    // There must be a prev stage to project from
+    assert(stages.size() > 1);
+    // Check if this thing still needs to be failed
+    if (stages[stages.size() - 2].items[prev_stage_item].failed_filter == nullptr) {
+        fail(filter, prev_stage_item, statistic);
+    }
+}
+
 void Funnel::pass(const char* filter, size_t prev_stage_item, double statistic) {
     // There must be a prev stage to project from
     assert(stages.size() > 1);
@@ -314,6 +323,15 @@ void Funnel::pass(const char* filter, size_t prev_stage_item, double statistic) 
     }
     prev_stage.items[prev_stage_item].passed_filters.emplace_back(filter);
     prev_stage.items[prev_stage_item].passed_statistics.emplace_back(statistic);
+}
+
+void Funnel::pass_if_needed(const char* filter, size_t prev_stage_item, double statistic) {
+    // There must be a prev stage to project from
+    assert(stages.size() > 1);
+    // Check if this thing still needs to be failed
+    if (stages[stages.size() - 2].items[prev_stage_item].failed_filter == nullptr) {
+        pass(filter, prev_stage_item, statistic);
+    }
 }
 
 void Funnel::score(size_t item, double score) {

--- a/src/funnel.cpp
+++ b/src/funnel.cpp
@@ -301,15 +301,6 @@ void Funnel::fail(const char* filter, size_t prev_stage_item, double statistic) 
     prev_stage.items[prev_stage_item].failed_statistic = statistic;
 }
 
-void Funnel::fail_if_needed(const char* filter, size_t prev_stage_item, double statistic) {
-    // There must be a prev stage to project from
-    assert(stages.size() > 1);
-    // Check if this thing still needs to be failed
-    if (stages[stages.size() - 2].items[prev_stage_item].failed_filter == nullptr) {
-        fail(filter, prev_stage_item, statistic);
-    }
-}
-
 void Funnel::pass(const char* filter, size_t prev_stage_item, double statistic) {
     // There must be a prev stage to project from
     assert(stages.size() > 1);
@@ -323,15 +314,6 @@ void Funnel::pass(const char* filter, size_t prev_stage_item, double statistic) 
     }
     prev_stage.items[prev_stage_item].passed_filters.emplace_back(filter);
     prev_stage.items[prev_stage_item].passed_statistics.emplace_back(statistic);
-}
-
-void Funnel::pass_if_needed(const char* filter, size_t prev_stage_item, double statistic) {
-    // There must be a prev stage to project from
-    assert(stages.size() > 1);
-    // Check if this thing still needs to be failed
-    if (stages[stages.size() - 2].items[prev_stage_item].failed_filter == nullptr) {
-        pass(filter, prev_stage_item, statistic);
-    }
 }
 
 void Funnel::score(size_t item, double score) {

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -142,22 +142,12 @@ public:
     /// Allows a statistic for the filtered-on value for the failing item to be recorded.
     void fail(const char* filter, size_t prev_stage_item, double statistic = nan(""));
 
-    /// Fail the given item from the previous stage on the given filter
-    /// if it hasn't already failed a different filter
-    /// This makes it easy to safely fail everything that hasn't failed yet.
-    void fail_if_needed(const char* filter, size_t prev_stage_item, double statistic = nan(""));
-    
     /// Pass the given item from the previous stage through the given filter at this stage.
     /// Items which do not pass a filter must fail it.
     /// All items which pass filters must do so in the same order.
     /// The filter name must survive the funnel, because a pointer to it will be stored.
     /// Allows a statistic for the filtered-on value for the passing item to be recorded.
     void pass(const char* filter, size_t prev_stage_item, double statistic = nan(""));
-
-    /// Pass the given item from the previous stage on the given filter
-    /// if it hasn't already failed a different filter
-    /// This makes it easy to safely pass everything that hasn't failed yet.
-    void pass_if_needed(const char* filter, size_t prev_stage_item, double statistic = nan(""));
     
     /// Assign the given score to the given item at the current stage.
     void score(size_t item, double score);

--- a/src/funnel.hpp
+++ b/src/funnel.hpp
@@ -141,6 +141,11 @@ public:
     /// The filter name must survive the funnel, because a pointer to it will be stored.
     /// Allows a statistic for the filtered-on value for the failing item to be recorded.
     void fail(const char* filter, size_t prev_stage_item, double statistic = nan(""));
+
+    /// Fail the given item from the previous stage on the given filter
+    /// if it hasn't already failed a different filter
+    /// This makes it easy to safely fail everything that hasn't failed yet.
+    void fail_if_needed(const char* filter, size_t prev_stage_item, double statistic = nan(""));
     
     /// Pass the given item from the previous stage through the given filter at this stage.
     /// Items which do not pass a filter must fail it.
@@ -148,6 +153,11 @@ public:
     /// The filter name must survive the funnel, because a pointer to it will be stored.
     /// Allows a statistic for the filtered-on value for the passing item to be recorded.
     void pass(const char* filter, size_t prev_stage_item, double statistic = nan(""));
+
+    /// Pass the given item from the previous stage on the given filter
+    /// if it hasn't already failed a different filter
+    /// This makes it easy to safely pass everything that hasn't failed yet.
+    void pass_if_needed(const char* filter, size_t prev_stage_item, double statistic = nan(""));
     
     /// Assign the given score to the given item at the current stage.
     void score(size_t item, double score);

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -406,6 +406,9 @@ class MinimizerMapper : public AlignerClient {
     /// How should we scale scores before mapq, for calibration
     static constexpr double default_mapq_score_scale = 1.0;
     double mapq_score_scale = default_mapq_score_scale;
+    /// What's the minimum score we'll accept from an MQ 0 read
+    static constexpr size_t default_min_mapq0_score = 0;
+    size_t min_mapq0_score = default_min_mapq0_score;
 
     /////////////////
     // More shared parameters:

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1059,7 +1059,10 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
     }
 
     if (track_provenance) {
-        funnel.substage("demapping");
+        funnel.stage("demapping");
+        for (size_t i = 0; i < mappings.size(); i++) {
+            funnel.project(i);
+        }
     }
 
     if (mapq == 0 && !scores.empty() && scores.front() < min_mapq0_score) {
@@ -1086,7 +1089,7 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
     } else if (track_provenance) {
         // Pass all remaining mappings
         for (size_t i = 0; i < mappings.size(); i++) {
-            funnel.pass("mapq0-score", i, scores.front());
+            funnel.pass("mapq0-score", i);
         }
     }
 

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1058,18 +1058,22 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
         }
     }
 
+    if (track_provenance) {
+        funnel.substage("demapping");
+    }
+
     if (mapq == 0 && !scores.empty() && scores.front() < min_mapq0_score) {
         if (show_work) {
             #pragma omp critical (cerr)
             {
-                cerr << log_name() << "Failing MAPQ 0 alignment for having score "
-                    << scores.front() << " which is below " << min_mapq0_score << endl;
+                cerr << log_name() << "Failing MAPQ 0 alignment for having top score "
+                     << scores.front() << " which is below " << min_mapq0_score << endl;
             }
         }
         if (track_provenance) {
             // Fail all remaining mappings
-            for (size_t i = 0; i < alignments.size(); i++) {
-                funnel.fail_if_needed("mapq0-score", i, scores.front());
+            for (size_t i = 0; i < mappings.size(); i++) {
+                funnel.fail("mapq0-score", i, scores.front());
             }
         }
 
@@ -1082,7 +1086,7 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
     } else if (track_provenance) {
         // Pass all remaining mappings
         for (size_t i = 0; i < mappings.size(); i++) {
-            funnel.pass_if_needed("mapq0-score", i);
+            funnel.pass("mapq0-score", i, scores.front());
         }
     }
 

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1065,7 +1065,10 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
                  << scores.front() << " which is below " << min_mapq0_score << endl;
         }
         if (track_provenance) {
-            funnel.fail("mapq0-score", 0, scores.front());
+            // Fail all remaining mappings
+            for (size_t i = 0; i < alignments.size(); i++) {
+                funnel.fail_if_needed("mapq0-score", i, scores.front());
+            }
         }
 
         // Reset scores / mappings
@@ -1074,6 +1077,11 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
 
         scores.emplace_back(0);
         mappings.emplace_back(aln);
+    } else if (track_provenance) {
+        // Pass all remaining mappings
+        for (size_t i = 0; i < mappings.size(); i++) {
+            funnel.pass_if_needed("mapq0-score", i);
+        }
     }
 
     // Remember the scores

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1060,9 +1060,6 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
 
     if (track_provenance) {
         funnel.stage("demapping");
-        for (size_t i = 0; i < mappings.size(); i++) {
-            funnel.project(i);
-        }
     }
 
     if (mapq == 0 && !scores.empty() && scores.front() < min_mapq0_score) {
@@ -1090,6 +1087,7 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
         // Pass all remaining mappings
         for (size_t i = 0; i < mappings.size(); i++) {
             funnel.pass("mapq0-score", i);
+            funnel.project(i);
         }
     }
 

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1059,10 +1059,12 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
     }
 
     if (mapq == 0 && !scores.empty() && scores.front() < min_mapq0_score) {
-        #pragma omp critical (cerr)
-        {
-            cerr << log_name() << "Failing MAPQ 0 alignment for having score "
-                 << scores.front() << " which is below " << min_mapq0_score << endl;
+        if (show_work) {
+            #pragma omp critical (cerr)
+            {
+                cerr << log_name() << "Failing MAPQ 0 alignment for having score "
+                    << scores.front() << " which is below " << min_mapq0_score << endl;
+            }
         }
         if (track_provenance) {
             // Fail all remaining mappings

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1058,6 +1058,24 @@ vector<Alignment> MinimizerMapper::map_from_chains(Alignment& aln) {
         }
     }
 
+    if (mapq == 0 && !scores.empty() && scores.front() < min_mapq0_score) {
+        #pragma omp critical (cerr)
+        {
+            cerr << log_name() << "Failing MAPQ 0 alignment for having score "
+                 << scores.front() << " which is below " << min_mapq0_score << endl;
+        }
+        if (track_provenance) {
+            funnel.fail("mapq0-score", 0, scores.front());
+        }
+
+        // Reset scores / mappings
+        scores.clear();
+        mappings.clear();
+
+        scores.emplace_back(0);
+        mappings.emplace_back(aln);
+    }
+
     // Remember the scores
     set_compressed_annotation(mappings.front(),"secondary_scores", scores);
 

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -343,7 +343,7 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         "min-mapq0-score",
         &MinimizerMapper::min_mapq0_score,
         MinimizerMapper::default_min_mapq0_score,
-        "scale scores for mapping quality"
+        "refuse to align lower scoring MQ 60 reads"
     );
     
     // Configure chaining

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -343,7 +343,7 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         "min-mapq0-score",
         &MinimizerMapper::min_mapq0_score,
         MinimizerMapper::default_min_mapq0_score,
-        "refuse to align lower scoring MQ 60 reads"
+        "discard MAPQ 0 alignments with scores lower than threshold"
     );
     
     // Configure chaining

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -339,6 +339,12 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         MinimizerMapper::default_mapq_score_scale,
         "scale scores for mapping quality"
     );
+    comp_opts.add_range(
+        "min-mapq0-score",
+        &MinimizerMapper::min_mapq0_score,
+        MinimizerMapper::default_min_mapq0_score,
+        "scale scores for mapping quality"
+    );
     
     // Configure chaining
     auto& chaining_opts = parser->add_group<MinimizerMapper>("long-read/chaining parameters");
@@ -1007,6 +1013,7 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<size_t>("hard-hit-cap", 13614)
         .add_entry<double>("mapq-score-scale", 1)
         .add_entry<size_t>("mapq-score-window", 150)
+        .add_entry<size_t>("min-mapq0-score", 67)
         .add_entry<double>("zipcode-tree-score-threshold", 100.0)
         .add_entry<double>("pad-zipcode-tree-score-threshold", 50.0)
         .add_entry<double>("zipcode-tree-coverage-threshold", 0.5)

--- a/vgci/vgci.py
+++ b/vgci/vgci.py
@@ -8,7 +8,7 @@ import tempfile
 import textwrap
 import filecmp
 import pytest
-from unittest import TestCase, skip, TestLoader, TextTestRunner
+from unittest import TestCase, skip, TestLoader, TextTestRunner, expectedFailure
 from urllib.parse import urlparse
 from uuid import uuid4
 import os, sys
@@ -1607,7 +1607,10 @@ class VGCITest(TestCase):
 
         self._verify_f1('NA12878', tag)
 
+    # TODO: This has started failing at rtg template generation since we moved CI runners.
+    # See: https://ucsc-ci.com/vgteam/vg/-/jobs/110194#L3882
     @timeout_decorator.timeout(14400)
+    @expectedFailure
     def test_giraffe_mhc_hprc2(self):
         """
         Test Giraffe/DeepVariant on MHC.


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Add new `vg giraffe` filter for low-scoring MAPQ 0 R10 reads

## Description

Per Slack discussion about how ridiculously low scoring MAPQ 0 R10 reads are invariably mapped incorrectly, here is my attempt at an implementation. It managed to successfully not align a test read. Basically this gives us a way to refuse to use an alignment if it looks terrible and we have no confidence in it. It's only on for R10 mode.