### PR TITLE
Remove parameters that we don't use

### DIFF
--- a/src/algorithms/chain_items.cpp
+++ b/src/algorithms/chain_items.cpp
@@ -544,8 +544,8 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
     // Starting from nowhere means full path conservation, so bonus = scheme.consistency_bonus.
     std::vector<int> eval_bonuses(to_chain.size(), scheme.consistency_bonus);
     for (size_t i = 0; i < to_chain.size(); i++) {
-        // Set up DP table so we can start anywhere with that item's score, scaled and with bonus applied.
-        chain_scores[i] = {(int)(to_chain[i].score() * scheme.item_scale + scheme.item_bonus), TracedScore::nowhere(), to_chain[i].anchor_end_paths()};
+        // Set up DP table so we can start anywhere with that item's score, with bonus applied.
+        chain_scores[i] = {(int)(to_chain[i].score() + scheme.item_bonus), TracedScore::nowhere(), to_chain[i].anchor_end_paths()};
     }
 
     // We will run this over every transition in a good DP order.
@@ -564,7 +564,7 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
         auto& here = to_chain[transition.to_anchor];
         
         // How many points is it worth to collect?
-        auto item_points = here.score() * scheme.item_scale + scheme.item_bonus;
+        auto item_points = here.score() + scheme.item_bonus;
         
         std::string here_gvnode;
         if (diagram) {
@@ -747,7 +747,7 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
         
         if (diagram) {
             // Draw the item in the diagram
-            auto item_points = here.score() * scheme.item_scale + scheme.item_bonus;
+            auto item_points = here.score() + scheme.item_bonus;
             std::string here_gvnode = "i" + std::to_string(to_anchor);
             std::stringstream label_stream;
             label_stream << "#" << to_anchor << " " << here << " = " << item_points
@@ -841,7 +841,7 @@ vector<pair<vector<size_t>, int>> chain_items_traceback(const vector<TracedScore
                     // Take away all the points we got for coming from there and being ourselves.
                     penalty += chain_scores[here].score;
                     // But then re-add our score for just us
-                    penalty -= (to_chain[here].score() * scheme.item_scale + scheme.item_bonus);
+                    penalty -= (to_chain[here].score() + scheme.item_bonus);
                     // TODO: Score this more simply.
                     // TODO: find the edge to nowhere???
                     break;

--- a/src/algorithms/chain_items.cpp
+++ b/src/algorithms/chain_items.cpp
@@ -606,9 +606,6 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
         // Decide how much length changed
         size_t indel_length = (transition.read_distance > transition.graph_distance) ? transition.read_distance - transition.graph_distance 
                                                                                      : transition.graph_distance - transition.read_distance;
-        // TODO: remove this!
-        // How much could be matches/mismatches, double-counting with bases in the exclusion zones?
-        size_t possible_match_length = std::min(transition.read_distance, transition.graph_distance);
         
         if (show_work) {
 #ifdef debug_dp
@@ -645,19 +642,10 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
             //
             // But we account for anchor length in the item points, so don't use it
             // here.
-            jump_points = -score_chain_gap(indel_length, base_seed_length);
-
-            if (transition.read_distance > transition.graph_distance) {
-                jump_points *= scheme.insertion_scale;
-            } else {
-                jump_points *= scheme.deletion_scale;
-            }
+            jump_points = -score_chain_gap(indel_length, base_seed_length) * scheme.gap_scale;
 
             // add recombination penalty if necessary
             jump_points -= check_recombination(chain_scores[transition.from_anchor], here) * scheme.recombination_penalty;
-
-            // We can also account for the non-indel material, which we assume will have some identity in it.
-            jump_points += possible_match_length * scheme.points_per_possible_match;
         }
             
         if (jump_points != numeric_limits<int>::min()) {

--- a/src/algorithms/chain_items.cpp
+++ b/src/algorithms/chain_items.cpp
@@ -473,7 +473,7 @@ void add_transition_if_legal(vector<transition_info>& transitions,
 /// that you are chaining get longer, and cost more at chaining than at
 /// fragmenting.
 ///
-/// Returns a negative value (gap score).
+/// Returns a positive value (gap penalty).
 int score_chain_gap(size_t distance_difference, size_t base_seed_length) {
     if (distance_difference == 0) {
         // Do nothing and score 0
@@ -484,7 +484,8 @@ int score_chain_gap(size_t distance_difference, size_t base_seed_length) {
     }
 }
 
-/// If the current anchor shares paths with the chain, pay a penalty.
+/// If the current anchor does not share paths with the chain, pay a penalty.
+/// Returns a positive value (gap penalty)
 int check_recombination(const TracedScore& from, const Anchor& to) {
     if ((from.paths & to.anchor_start_paths()) == 0) {
         return 1;
@@ -644,7 +645,13 @@ TracedScore chain_items_dp(vector<TracedScore>& chain_scores,
             //
             // But we account for anchor length in the item points, so don't use it
             // here.
-            jump_points = -score_chain_gap(indel_length, base_seed_length) * scheme.gap_scale;
+            jump_points = -score_chain_gap(indel_length, base_seed_length);
+
+            if (transition.read_distance > transition.graph_distance) {
+                jump_points *= scheme.insertion_scale;
+            } else {
+                jump_points *= scheme.deletion_scale;
+            }
 
             // add recombination penalty if necessary
             jump_points -= check_recombination(chain_scores[transition.from_anchor], here) * scheme.recombination_penalty;

--- a/src/algorithms/chain_items.hpp
+++ b/src/algorithms/chain_items.hpp
@@ -405,8 +405,6 @@ struct transition_info {
 struct ChainScoringScheme {
     /// Score bonus for each item collected
     int item_bonus = 0;
-    /// Scale to apply to each item's own score
-    double item_scale = 1.0;
     /// Scale to apply to the scores of gaps
     double gap_scale = 1.0;
     /// Penalize this many points per recombination

--- a/src/algorithms/chain_items.hpp
+++ b/src/algorithms/chain_items.hpp
@@ -407,12 +407,8 @@ struct ChainScoringScheme {
     int item_bonus = 0;
     /// Scale to apply to each item's own score
     double item_scale = 1.0;
-    /// Scale to apply to the scores of insertions
-    double insertion_scale = 1.0;
-    /// Scale to apply to the scores of deletions
-    double deletion_scale = 1.0;
-    /// Add this many points per potential match between two seeds
-    double points_per_possible_match = 0;
+    /// Scale to apply to the scores of gaps
+    double gap_scale = 1.0;
     /// Penalize this many points per recombination
     int recombination_penalty = 0;
     /// Apply a bonus during alternative selection (but not to actual DP

--- a/src/algorithms/chain_items.hpp
+++ b/src/algorithms/chain_items.hpp
@@ -407,8 +407,10 @@ struct ChainScoringScheme {
     int item_bonus = 0;
     /// Scale to apply to each item's own score
     double item_scale = 1.0;
-    /// Scale to apply to the scores of gaps
-    double gap_scale = 1.0;
+    /// Scale to apply to the scores of insertions
+    double insertion_scale = 1.0;
+    /// Scale to apply to the scores of deletions
+    double deletion_scale = 1.0;
     /// Add this many points per potential match between two seeds
     double points_per_possible_match = 0;
     /// Penalize this many points per recombination

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -287,10 +287,14 @@ class MinimizerMapper : public AlignerClient {
     /// in chaining?
     static constexpr double default_item_scale = 1.0;
     double item_scale = default_item_scale;
-    /// How much of a multiple should we apply to each transition's gap penalty
-    /// at chaining?
-    static constexpr double default_gap_scale = 1.0;
-    double gap_scale = default_gap_scale;
+    /// How much of a multiple should we apply to each transition's
+    /// INSERTION gap penalty at chaining? 
+    static constexpr double default_insertion_scale = 1.0;
+    double insertion_scale = default_insertion_scale;
+    /// How much of a multiple should we apply to each transition's
+    /// DELETION gap penalty at chaining? 
+    static constexpr double default_deletion_scale = 1.0;
+    double deletion_scale = default_deletion_scale;
     /// Recombination penalty for chaining. This is added to the cost of a transition if there are no shared haplotypes.
     static constexpr int default_rec_penalty = 0;
     int rec_penalty = default_rec_penalty;

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -287,23 +287,16 @@ class MinimizerMapper : public AlignerClient {
     /// in chaining?
     static constexpr double default_item_scale = 1.0;
     double item_scale = default_item_scale;
-    /// How much of a multiple should we apply to each transition's
-    /// INSERTION gap penalty at chaining? 
-    static constexpr double default_insertion_scale = 1.0;
-    double insertion_scale = default_insertion_scale;
-    /// How much of a multiple should we apply to each transition's
-    /// DELETION gap penalty at chaining? 
-    static constexpr double default_deletion_scale = 1.0;
-    double deletion_scale = default_deletion_scale;
+    /// How much of a multiple should we apply to each transition's gap penalty
+    /// at chaining?
+    static constexpr double default_gap_scale = 1.0;
+    double gap_scale = default_gap_scale;
     /// Recombination penalty for chaining. This is added to the cost of a transition if there are no shared haplotypes.
     static constexpr int default_rec_penalty = 0;
     int rec_penalty = default_rec_penalty;
     /// Recombination-aware chaining bonus for avoiding losing haplotypes. Not actually tracked in chaining DP score.
     static constexpr int default_rec_consistency_bonus = 0;
     int rec_consistency_bonus = default_rec_consistency_bonus;
-    // How many points should we treat a non-gap connection base as producing, at chaining?
-    static constexpr double default_points_per_possible_match = 0;
-    double points_per_possible_match = default_points_per_possible_match;
     /// How many bases of indel should we allow in chaining?
     static constexpr size_t default_max_indel_bases = 2000;
     size_t max_indel_bases = default_max_indel_bases;

--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -283,10 +283,6 @@ class MinimizerMapper : public AlignerClient {
     /// How much of a bonus should we give to each item in chaining?
     static constexpr int default_item_bonus = 0;
     int item_bonus = default_item_bonus;
-    /// How much of a multiple should we apply to each item's non-bonus score
-    /// in chaining?
-    static constexpr double default_item_scale = 1.0;
-    double item_scale = default_item_scale;
     /// How much of a multiple should we apply to each transition's gap penalty
     /// at chaining?
     static constexpr double default_gap_scale = 1.0;

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -2848,7 +2848,7 @@ Alignment MinimizerMapper::find_chain_alignment(
                     // If there was a big gap
                     next_it = skip_to_it;
                     next = skip_to;
-                }
+                } else {
 #ifdef debug_chain_alignment
                     if (show_work) {
                         #pragma omp critical (cerr)
@@ -2858,6 +2858,7 @@ Alignment MinimizerMapper::find_chain_alignment(
                         }
                     }
 #endif
+                }
                 // If there wasn't a gap then don't skip anything
                 break;
             }

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1634,9 +1634,7 @@ void MinimizerMapper::do_chaining_on_trees(const Alignment& aln, const ZipCodeFo
             algorithms::ChainScoringScheme scheme {
                 this->item_bonus,
                 this->item_scale,
-                this->insertion_scale,
-                this->deletion_scale,
-                this->points_per_possible_match,
+                this->gap_scale,
                 this->rec_penalty,
                 // TODO: Do this once at setup?
                 this->rec_consistency_bonus == -1 ? this->rec_penalty : this->rec_consistency_bonus,

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1634,7 +1634,8 @@ void MinimizerMapper::do_chaining_on_trees(const Alignment& aln, const ZipCodeFo
             algorithms::ChainScoringScheme scheme {
                 this->item_bonus,
                 this->item_scale,
-                this->gap_scale,
+                this->insertion_scale,
+                this->deletion_scale,
                 this->points_per_possible_match,
                 this->rec_penalty,
                 // TODO: Do this once at setup?

--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -1633,7 +1633,6 @@ void MinimizerMapper::do_chaining_on_trees(const Alignment& aln, const ZipCodeFo
             // we set one up as a member?
             algorithms::ChainScoringScheme scheme {
                 this->item_bonus,
-                this->item_scale,
                 this->gap_scale,
                 this->rec_penalty,
                 // TODO: Do this once at setup?

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -444,12 +444,6 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         "bonus for taking each item when chaining"
     );
     chaining_opts.add_range(
-        "item-scale",
-        &MinimizerMapper::item_scale,
-        MinimizerMapper::default_item_scale,
-        "scale for items' scores when chaining"
-    );
-    chaining_opts.add_range(
         "gap-scale",
         &MinimizerMapper::gap_scale,
         MinimizerMapper::default_gap_scale,
@@ -962,7 +956,6 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<size_t>("max-indel-bases", 5000)
         .add_entry<double>("max-indel-bases-per-base", 2.45)
         .add_entry<int>("item-bonus", 2)
-        .add_entry<double>("item-scale", 1.0)
         .add_entry<double>("gap-scale", 0.27579)
         .add_entry<int>("rec-penalty", 2)
         .add_entry<int>("rec-consistency-bonus", 12)
@@ -1022,7 +1015,6 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<size_t>("max-indel-bases", 5000)
         .add_entry<double>("max-indel-bases-per-base", 2.45)
         .add_entry<int>("item-bonus", 20)
-        .add_entry<double>("item-scale", 1.0)
         .add_entry<double>("gap-scale", 0.06759721757973396)
         .add_entry<int>("rec-penalty", 2)
         .add_entry<int>("rec-consistency-bonus", 13)
@@ -1090,7 +1082,6 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("min-chain-score-per-base", 0.01)
         .add_entry<int>("max-min-chain-score", 200.0)
         .add_entry<int>("item-bonus", 0)
-        .add_entry<double>("item-scale", 1.0)
         .add_entry<int>("min-chains", 3)
         .add_entry<size_t>("max-chains-per-tree", 5)
         .add_entry<size_t>("max-alignments", 4)

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -450,17 +450,10 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         "scale for items' scores when chaining"
     );
     chaining_opts.add_range(
-        "insertion-scale",
-        &MinimizerMapper::insertion_scale,
-        MinimizerMapper::default_insertion_scale,
-        "scale for insertion gap scores when chaining",
-        double_is_nonnegative
-    );
-    chaining_opts.add_range(
-        "deletion-scale",
-        &MinimizerMapper::deletion_scale,
-        MinimizerMapper::default_deletion_scale,
-        "scale for deletion gap scores when chaining",
+        "gap-scale",
+        &MinimizerMapper::gap_scale,
+        MinimizerMapper::default_gap_scale,
+        "scale for gap scores when chaining",
         double_is_nonnegative
     );
     chaining_opts.add_range(
@@ -476,13 +469,6 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         MinimizerMapper::default_rec_consistency_bonus,
         "untracked bonus for chains staying consistent with haplotypes to avoid recombinations in recombination-aware mode",
         int_is_nonnegative
-    );
-    chaining_opts.add_range(
-        "points-per-possible-match",
-        &MinimizerMapper::points_per_possible_match,
-        MinimizerMapper::default_points_per_possible_match,
-        "points to award non-indel connecting bases when chaining",
-        double_is_nonnegative
     );
     
     chaining_opts.add_range(
@@ -977,8 +963,7 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("max-indel-bases-per-base", 2.45)
         .add_entry<int>("item-bonus", 2)
         .add_entry<double>("item-scale", 1.0)
-        .add_entry<double>("insertion-scale", 0.27579)
-        .add_entry<double>("deletion-scale", 0.27579)
+        .add_entry<double>("gap-scale", 0.27579)
         .add_entry<int>("rec-penalty", 2)
         .add_entry<int>("rec-consistency-bonus", 12)
         .add_entry<double>("chain-score-threshold", 234.0)
@@ -1038,8 +1023,7 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("max-indel-bases-per-base", 2.45)
         .add_entry<int>("item-bonus", 20)
         .add_entry<double>("item-scale", 1.0)
-        .add_entry<double>("insertion-scale", 0.06759721757973396)
-        .add_entry<double>("deletion-scale", 0.06759721757973396)
+        .add_entry<double>("gap-scale", 0.06759721757973396)
         .add_entry<int>("rec-penalty", 2)
         .add_entry<int>("rec-consistency-bonus", 13)
         .add_entry<double>("chain-score-threshold", 160.0)
@@ -1094,8 +1078,7 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<size_t>("gapless-extension-limit", std::numeric_limits<size_t>::max())
         // Allowing a lot of mismatches because we chop later
         .add_entry<size_t>("max-extension-mismatches", 15)
-        .add_entry<double>("insertion-scale", 2.2)
-        .add_entry<double>("deletion-scale", 2.2)
+        .add_entry<double>("gap-scale", 2.2)
         // And take those to chains
         .add_entry<int>("min-chaining-problems", 7)
         .add_entry<int>("max-chaining-problems", std::numeric_limits<int>::max())

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -450,10 +450,17 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         "scale for items' scores when chaining"
     );
     chaining_opts.add_range(
-        "gap-scale",
-        &MinimizerMapper::gap_scale,
-        MinimizerMapper::default_gap_scale,
-        "scale for gap scores when chaining",
+        "insertion-scale",
+        &MinimizerMapper::insertion_scale,
+        MinimizerMapper::default_insertion_scale,
+        "scale for insertion gap scores when chaining",
+        double_is_nonnegative
+    );
+    chaining_opts.add_range(
+        "deletion-scale",
+        &MinimizerMapper::deletion_scale,
+        MinimizerMapper::default_deletion_scale,
+        "scale for deletion gap scores when chaining",
         double_is_nonnegative
     );
     chaining_opts.add_range(
@@ -970,7 +977,8 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("max-indel-bases-per-base", 2.45)
         .add_entry<int>("item-bonus", 2)
         .add_entry<double>("item-scale", 1.0)
-        .add_entry<double>("gap-scale", 0.27579)
+        .add_entry<double>("insertion-scale", 0.27579)
+        .add_entry<double>("deletion-scale", 0.27579)
         .add_entry<int>("rec-penalty", 2)
         .add_entry<int>("rec-consistency-bonus", 12)
         .add_entry<double>("chain-score-threshold", 234.0)
@@ -1030,7 +1038,8 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<double>("max-indel-bases-per-base", 2.45)
         .add_entry<int>("item-bonus", 20)
         .add_entry<double>("item-scale", 1.0)
-        .add_entry<double>("gap-scale", 0.06759721757973396)
+        .add_entry<double>("insertion-scale", 0.06759721757973396)
+        .add_entry<double>("deletion-scale", 0.06759721757973396)
         .add_entry<int>("rec-penalty", 2)
         .add_entry<int>("rec-consistency-bonus", 13)
         .add_entry<double>("chain-score-threshold", 160.0)
@@ -1085,7 +1094,8 @@ int main_giraffe(int argc, char** argv) {
         .add_entry<size_t>("gapless-extension-limit", std::numeric_limits<size_t>::max())
         // Allowing a lot of mismatches because we chop later
         .add_entry<size_t>("max-extension-mismatches", 15)
-        .add_entry<double>("gap-scale", 2.2)
+        .add_entry<double>("insertion-scale", 2.2)
+        .add_entry<double>("deletion-scale", 2.2)
         // And take those to chains
         .add_entry<int>("min-chaining-problems", 7)
         .add_entry<int>("max-chaining-problems", std::numeric_limits<int>::max())


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Remove `--item-scale` and `--points-per-possible-match` from `vg giraffe` as needless unused complexity.

## Description

Ignore the branch name; this was going to be something else before. Anyhow, this is the latest episode of "Faith tries to trim vg giraffe". Two parameters that we never change the defaults of and which were minor increases in algorithm complexity. I noticed these while trying to understand how scoring was working in DP. Having extra components to the scoring algorithm just made that more complicated.

- `--item-scale` is a multiplier applied to "yay we grabbed an item" score before any extra bonus is added. It was always 1, and its default was 1. Multiplying a number by 1 does not change anything.
- `--points-per-possible-match` is a constant multiple for the number of bases which could end up as matches, applied as a bonus when scoring a transition. It was always 0, and its default was 0. Multiplying a number by 0 and then adding it into a score will never change the score by anything.

These changes have no impact on anyone unless they were toying with these specific parameters themselves, but I doubt that. Simplifying the chain scoring calculation was nice for me.