### PR TITLE
Report per-aln stats as per-aligned, ignoring unmapped reads

### DIFF
--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -1119,13 +1119,13 @@ int main_stats(int argc, char** argv) {
         }
         cout << "Matches: " << combined.total_matched_bases << " bp";
         if (combined.total_alignments > 0) {
-            cout << " (" << combined.total_matched_bases / static_cast<double>(combined.total_aligned) << " bp/alignment)";
+            cout << " (" << combined.total_matched_bases / static_cast<double>(combined.total_aligned) << " bp/aligned)";
         }
         cout << endl;
         cout << "Softclips: " << combined.total_softclipped_bases << " bp";
         if (combined.total_alignments > 0) {
             cout << " (" << 100 * combined.total_softclipped_bases / static_cast<double>(combined.total_bases) << "% of bases, "
-                 << combined.total_softclipped_bases / static_cast<double>(combined.total_aligned) << " bp/alignment)";
+                 << combined.total_softclipped_bases / static_cast<double>(combined.total_aligned) << " bp/aligned)";
         } 
         cout << " in " << combined.total_softclips << " read events" << endl;
         if(verbose) {

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -1119,13 +1119,13 @@ int main_stats(int argc, char** argv) {
         }
         cout << "Matches: " << combined.total_matched_bases << " bp";
         if (combined.total_alignments > 0) {
-            cout << " (" << combined.total_matched_bases / static_cast<double>(combined.total_alignments) << " bp/alignment)";
+            cout << " (" << combined.total_matched_bases / static_cast<double>(combined.total_aligned) << " bp/alignment)";
         }
         cout << endl;
         cout << "Softclips: " << combined.total_softclipped_bases << " bp";
         if (combined.total_alignments > 0) {
             cout << " (" << 100 * combined.total_softclipped_bases / static_cast<double>(combined.total_bases) << "% of bases, "
-                 << combined.total_softclipped_bases / static_cast<double>(combined.total_alignments) << " bp/alignment)";
+                 << combined.total_softclipped_bases / static_cast<double>(combined.total_aligned) << " bp/alignment)";
         } 
         cout << " in " << combined.total_softclips << " read events" << endl;
         if(verbose) {

--- a/test/correct/10_vg_stats/15.txt
+++ b/test/correct/10_vg_stats/15.txt
@@ -11,8 +11,8 @@ Mapping quality: mean 60, median 60, stdev 0, max 60 (100 reads)
 Insertions: 0 bp in 0 read events
 Deletions: 0 bp in 0 read events
 Substitutions: 0 bp in 0 read events
-Matches: 10000 bp (100 bp/alignment)
-Softclips: 0 bp (0% of bases, 0 bp/alignment) in 0 read events
+Matches: 10000 bp (100 bp/aligned)
+Softclips: 0 bp (0% of bases, 0 bp/aligned) in 0 read events
 Unvisited nodes: 4/208 (4 bp)
 Single-visited nodes: 11/208 (18 bp)
 Significantly biased heterozygous sites: 2/62 (3.22581%)


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg stats -a` reports aggregate bp/alignment stats as per aligned reads, ignoring unmapped reads

## Description

The match bp/alignment and softclip bp/alignment stats would go up if you just aligned more reads, even if those alignments actually brought down the average bp per *successful* alignment. This change makes the denominator of the calculation be the count of reads with a primary alignment, instead of the count of reads period. Seems more meaningful.
