### PR TITLE
retain more alignments

### DIFF
--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -2183,17 +2183,12 @@ void MinimizerMapper::do_alignment_on_chains(const Alignment& aln, const std::ve
                 }
             };
             
-            if (!best_alignments.empty() && best_alignments[0].score() <= 0) {
-                if (show_work) {
-                    // Alignment won't be observed but log it anyway.
-                    #pragma omp critical (cerr)
-                    {
-                        cerr << log_name() << "Produced terrible best alignment from chain " << processed_num << ": " << log_alignment(best_alignments[0]) << endl;
-                    }
-                }
-            }
-            for(auto aln_it = best_alignments.begin() ; aln_it != best_alignments.end() && aln_it->score() != 0 && aln_it->score() >= best_alignments[0].score() * 0.8; ++aln_it) {
+            for(auto aln_it = best_alignments.begin() ; 
+                aln_it != best_alignments.end() && aln_it->score() != 0 
+                    && (aln_it->score() >= best_alignments[0].score() * 0.8 || aln_it->score() == best_alignments[0].score()) ;
+                ++aln_it) {
                 //For each additional alignment with score at least 0.8 of the best score
+                //Guarantee that all alignments with top score (even if negative) are used
                 observe_alignment(*aln_it);
             }
            


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` chaining mode allows negative affine-gap alignment scores to be log-gap rescored before tossing out negatively scoring alignments (minor accuracy improvement)

## Description

I have confirmed that this improves read mapping for R10 reads at least (thousands of more reads aligned out of 1m) by rescuing many unmapped reads which can survive so long as their gaps get rescored. Correctness % stays about the same so these are good alignments we're rescuing.

Variant calling errors also tick down; for HiFi both indels and SNPs got better, and for R10 indels got better by more than SNPs got worse.
