### PR TITLE
Fix integrated kmer counting

### DIFF
--- a/src/index_registry.cpp
+++ b/src/index_registry.cpp
@@ -4526,6 +4526,10 @@ IndexRegistry VGIndexes::get_vg_index_registry() {
                     dup2(devnull, STDERR_FILENO);
                     close(devnull);
                 }
+            } else {
+                // KMC prints statistics to stdout, which conflicts with many vg subcommands
+                // that write their output to stdout. So we redirect them to stderr.
+                dup2(STDERR_FILENO, STDOUT_FILENO);
             }
             
             // Allow enough open files for kmc to work; see

--- a/test/t/54_vg_haplotypes.t
+++ b/test/t/54_vg_haplotypes.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 44
+plan tests 45
 
 # The test graph consists of two subgraphs of the HPRC Minigraph-Cactus v1.1 graph:
 # - GRCh38#chr6:31498145-31511124 (micb)
@@ -111,9 +111,14 @@ is "$(vg gbwt -H -Z auto_hapl.HG003.gbz)" 4 "auto-built hapl produces 2 diploid 
 rm -f auto_kff.HG003.* auto_kff.gam
 vg giraffe --progress -Z full.gbz --haplotype-name full.hapl \
     --index-basename auto_kff -N HG003 \
-    -f haplotype-sampling/HG003.fq.gz > auto_kff.gam 2> /dev/null
+    -f haplotype-sampling/HG003.fq.gz -o gaf > auto_kff.gaf 2> /dev/null
 is $? 0 "Giraffe counts kmers from reads automatically"
 is "$(vg gbwt -H -Z auto_kff.HG003.gbz)" 4 "auto kmer counting produces 2 diploid + 2 reference haplotypes"
+
+# KMC prints statistics to stdout.
+# Check that the stats are not included in the alignment output.
+is "$(head -n 1 auto_kff.gaf | cut -f 1)" "@HD" "auto kmer counting does not output KMC stats"
+rm -f auto_kff.gaf
 
 # Giraffe integration, fully automatic: both hapl and kff are built by the
 # IndexRegistry. Triggered by --haplotype-sampling without either input file.


### PR DESCRIPTION
## Changelog Entry

To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Correct alignment output when `vg giraffe` does kmer counting for haplotype sampling.

## Description

KMC prints in status messages to stdout. When `vg giraffe` does kmer counting as part of haplotype sampling, those status messages end up in the alignment output. This PR redirects the status messages to stderr, fixing the alignment output.