### PR TITLE
Only log work in paired supplementary alignment with show_work

### DIFF
--- a/src/minimizer_mapper.cpp
+++ b/src/minimizer_mapper.cpp
@@ -3689,9 +3689,11 @@ MinimizerMapper::identify_supplementary_alignments(vector<std::array<vector<Alig
                 }
             }
             else {
-                #pragma omp critical (cerr)
-                {
-                    cerr << log_name() << "Did not identify any supplementary alignments for read " << r << endl;
+                if (show_work) {
+                    #pragma omp critical (cerr)
+                    {
+                        cerr << log_name() << "Did not identify any supplementary alignments for read " << r << endl;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

Removes an unprotected logging statement that I missed earlier.