### PR TITLE
expose vg describe to vg help

### DIFF
--- a/src/subcommand/describe_main.cpp
+++ b/src/subcommand/describe_main.cpp
@@ -33,6 +33,7 @@
 #include <arpa/inet.h>
 
 using namespace vg;
+using namespace vg::subcommand;
 
 //----------------------------------------------------------------------------
 
@@ -315,3 +316,6 @@ void describe_haplotypes(std::ifstream& in, const std::string& index_type, std::
 }
 
 //----------------------------------------------------------------------------
+
+// Register subcommand
+static Subcommand vg_describe("describe", "describe the type of one or more vg-universe files (similar to htsfile)", DEVELOPMENT, main_describe);

--- a/src/subcommand/describe_main.cpp
+++ b/src/subcommand/describe_main.cpp
@@ -182,8 +182,6 @@ int main_describe(int argc, char** argv) {
     return 0;
 }
 
-static vg::subcommand::Subcommand vg_chains("describe", "identify and describe files", vg::subcommand::WIDGET, main_describe);
-
 //----------------------------------------------------------------------------
 
 void list_tags(std::ifstream& in, bool simple_sds, const std::string& index_type, std::ostream& out) {
@@ -318,4 +316,4 @@ void describe_haplotypes(std::ifstream& in, const std::string& index_type, std::
 //----------------------------------------------------------------------------
 
 // Register subcommand
-static Subcommand vg_describe("describe", "describe the type of one or more vg-universe files (similar to htsfile)", DEVELOPMENT, main_describe);
+static Subcommand vg_describe("describe", "identify and describe files", WIDGET, main_describe);


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Exposes the development tool to `vg describe`, useful for detecting file types, through `vg help`

## Description

Addresses a discussion in #4430 about the new `vg describe` subcommand.