### PR TITLE
Add partially synthetic validation of option pairs that represent ranges

### DIFF
--- a/src/minimizer_mapper.hpp
+++ b/src/minimizer_mapper.hpp
@@ -252,7 +252,7 @@ class MinimizerMapper : public AlignerClient {
     /// When converting chains to alignments, what's the longest gap between
     /// items we will try to WFA align? Passing strings longer than ~100bp
     /// can cause WFAAligner to run for a pathologically long amount of time.
-    /// May not be 0.
+    /// Set to 0 to not use WFA alignment between items.
     static constexpr size_t default_max_chain_connection = 100;
     size_t max_chain_connection = default_max_chain_connection;
     /// Similarly, what is the maximum tail length we will try to WFA align?

--- a/src/subcommand/giraffe_main.cpp
+++ b/src/subcommand/giraffe_main.cpp
@@ -67,6 +67,8 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+static Logger logger("vg giraffe");
+
 /// Options struct for options for the Giraffe driver (i.e. this file)
 struct GiraffeMainOptions {
     /// How long should we wait while mapping a read before complaining, in seconds.
@@ -182,7 +184,8 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         "hard-hit-cap", 'C',
         &MinimizerMapper::hard_hit_cap,
         MinimizerMapper::default_hard_hit_cap,
-        "ignore all minimizers with more than INT hits"
+        "ignore all minimizers with more than INT hits",
+        size_t_is_positive
     );
     comp_opts.add_range(
         "score-fraction", 'F',
@@ -227,10 +230,18 @@ static std::unique_ptr<GroupedOptionGroup> get_options() {
         "cluster using this distance limit"
     );
     comp_opts.add_range(
+        "min-extensions",
+        &MinimizerMapper::min_extensions,
+        MinimizerMapper::default_min_extensions,
+        "extend at least INT clusters",
+        size_t_is_positive
+    );
+    comp_opts.add_range(
         "max-extensions", 'e',
         &MinimizerMapper::max_extensions,
         MinimizerMapper::default_max_extensions,
-        "extend up to INT clusters"
+        "extend up to INT clusters",
+        size_t_is_positive
     );
     comp_opts.add_range(
         "max-alignments", 'a',
@@ -634,6 +645,16 @@ std::string strip_suffixes(std::string filename, const std::vector<std::string>&
     return filename;
 }
 
+/**
+ * Make sure that variables set by options independently controlling the min
+ * and max of something actually make sense as a min and max.
+ */
+template<typename T> void enforce_min_max(const T& low, const std::string& low_option, const T& high, const std::string& high_option) {
+    if (low > high) {
+        logger.error() << "Empty range: --" << low_option << " of " << low << " exceeds --" << high_option << " of " << high << std::endl;
+    }
+}
+
 //----------------------------------------------------------------------------
 
 void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std::string, Preset>& presets, bool full_help) {
@@ -752,7 +773,6 @@ void help_giraffe(char** argv, const BaseOptionGroup& parser, const std::map<std
 //----------------------------------------------------------------------------
 
 int main_giraffe(int argc, char** argv) {
-    Logger logger("vg giraffe");
 
     std::chrono::time_point<std::chrono::system_clock> launch = std::chrono::system_clock::now();
 
@@ -1970,6 +1990,22 @@ int main_giraffe(int argc, char** argv) {
         parser->apply(minimizer_mapper);
         parser->apply(main_options);
         parser->apply(scoring_options);
+
+        // Make sure that options that represent ranges are sensible, nonempty
+        // ranges.
+        //
+        // TODO: It would be nice if we did this earlier when setting up the
+        // option ranges to iterate, to make it happen before indexing/index
+        // loading, but then we'd have to know how to do the comparison on the
+        // range objects themselves.
+        enforce_min_max(minimizer_mapper.wfa_max_mismatches, "wfa-max-mismatches",
+                        minimizer_mapper.wfa_max_max_mismatches, "wfa-max-max-mismatches");
+        enforce_min_max(minimizer_mapper.wfa_distance, "wfa-distance",
+                        minimizer_mapper.wfa_max_distance, "wfa-max-distance");
+        enforce_min_max(minimizer_mapper.min_chaining_problems, "min-chaining-problems",
+                        minimizer_mapper.max_chaining_problems, "max-chaining-problems");
+        enforce_min_max(minimizer_mapper.min_extensions, "min-extensions",
+                        minimizer_mapper.max_extensions, "max-extensions");
 
         // Make a line of JSON about our command line options.
         // We may embed it in the output file later.

--- a/test/t/50_vg_giraffe.t
+++ b/test/t/50_vg_giraffe.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 87
+plan tests 89
 
 vg construct -a -r small/x.fa -v small/x.vcf.gz >x.vg
 vg index -x x.xg x.vg
@@ -47,6 +47,12 @@ is "$(vg view -aj mapped1.gam | grep 'time_used' | wc -l | sed 's/^[[:space:]]*/
 
 is "$(vg view -aj mapped1.gam | jq '.score')" "73" "Mapping produces the correct score"
 
+vg giraffe -Z x.giraffe.gbz -d x.dist -f reads/small.middle.ref.fq --min-extensions 2 --max-extensions 1 >/dev/null 2>error.txt
+is "${?}" "1" "mapping with conflicting values for parameters representing a range fails"
+grep -E -- "(--min-extensions.*--max-extensions|--max-extensions.*--min-extensions)" error.txt >/dev/null
+is "${?}" "0" "error message mentions offending parameters"
+rm -f error.txt
+
 vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq -b fast >/dev/null
 is "${?}" "0" "a read can be mapped with the fast preset"
 
@@ -58,7 +64,7 @@ is "${?}" "0" "a read can be mapped with the short read chaining preset"
 
 vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.fq -f reads/small.middle.ref.fq -b chaining-sr >/dev/null 2>log.txt
 is "${?}" "1" "a read pair cannot be mapped with the short read chaining preset"
-is "$(cat log.txt | grep "not yet implemented" | wc -l)" "1" "trying to map paired-end data with chaining produces an informative error"
+is "$(cat log.txt | grep "not yet implemented" | wc -l | sed 's/^[[:space:]]*//')" "1" "trying to map paired-end data with chaining produces an informative error"
 rm -f log.txt
 
 vg giraffe -Z x.giraffe.gbz -f reads/small.middle.ref.mismatched.fq -b chaining-sr >/dev/null


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg giraffe` now validates more options, including pairs of options describing min and max values of ranges

## Description
Someone mentioned somewhere that Giraffe was able to crash instead of actually validating the values of some of the options that control mapping algorithm parameters.

This adds a couple more validation guards on individual options, and adds a new system for validating that paired min and max options actually describe a nonempty interval, though right now this happens after index loading, which is not ideal. Validating earlier would require exciting comparisons on the (unrelated) `Range` objects used for ticking through option combinations to make sure they're non-overlapping, in a way that the option parsing logic is not architected to support well. The right answer there might be telling the option parsing/range stuff when two options form a pair like this.

This set of options missing validation was identified by the rigorous process of "asking Anthropic Claude Opus to find them", and so may be incomplete. I also let it write the calls to the validation function (and I then had to fix a missing min option it wanted to validate), and fix my syntax.

