### PR TITLE
fix vg snarls helptext

### DIFF
--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -52,8 +52,8 @@ void help_snarl(char** argv) {
          << "  -i, --ins-fasta FILE      insertions as FASTA (required for SVs by -v)" << endl
          << "  -w, --upweight-node N     upweight the node with ID N to push it to be part" << endl
          << "                            of a top-level chain (may repeat)" << endl
-         << "  -P, --path-prefix NAME    upweight tips of paths with given prefix to orient"
-         << "                            snarl tree. often necessary when running vg"
+         << "  -P, --path-prefix NAME    upweight tips of paths with given prefix to orient" << endl
+         << "                            snarl tree. often necessary when running vg" << endl
          << "                            haplotypes downstream" << endl
          << "  -t, --threads N           number of threads to use [all available]" << endl
          << "  -h, --help                print this help message to stderr and exit" << endl;


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg snarls --path-prefix` helptext no longer borked

## Description

Noticed this while I was doing something else.