### PR TITLE
Add `quality` as a field in `vg filter --tsv-out`

### DIFF
--- a/src/readfilter.hpp
+++ b/src/readfilter.hpp
@@ -1597,6 +1597,8 @@ inline void ReadFilter<Alignment>::emit_tsv(Alignment& read, std::ostream& out) 
             out << is_perfect(read);
         } else if (field == "mapping_quality") {
             out << get_mapq(read); 
+        } else if (field == "quality") {
+            out << string_quality_short_to_char(read.quality());
         } else if (field == "sequence") {
             out << read.sequence();
         } else if (field == "length") {

--- a/test/t/15_vg_surject.t
+++ b/test/t/15_vg_surject.t
@@ -90,7 +90,7 @@ printf "@read\n${SEQ_RC}\n+\n${QUAL_R}\n" > rev.fq
 vg map -f fwd.fq -g x.gcsa -x x.xg > mapped.fwd.gam
 vg map -f rev.fq -g x.gcsa -x x.xg > mapped.rev.gam
 
-is "$(vg view -aj mapped.rev.gam | jq -r '.quality' | base64 -d | xxd -p -c1 | tac | xxd -p -r | xxd)" "$(vg view -aj mapped.fwd.gam | jq -r '.quality' | base64 -d | xxd)" "quality strings we will use for testing are oriented correctly"
+is "$(vg filter --tsv-out quality mapped.rev.gam | tac -rs 'x\|[^x]' | head -2 | tail -1)" "$(vg filter --tsv-out quality mapped.fwd.gam | tail -1)" "quality strings we will use for testing are oriented correctly"
 
 is "$(vg surject -p x -x x.xg mapped.fwd.gam -s | cut -f1,3,4,5,6,7,8,9,10,11)" "$(vg surject -p x -x x.xg mapped.rev.gam -s | cut -f1,3,4,5,6,7,8,9,10,11)" "forward and reverse orientations of a read produce the same surjected SAM, ignoring flags"
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg filter --tsv-out` can output PHRED base quality scores (lets us get rid of xxd dependency in tests)

## Description

Resolves #3466 removing `xxd` usage in the tests. It was doing some sort of magic that I don't entirely understand, but since the point of the test was just to compare base-level quality scores, I simplified things by adding that functionality to `vg filter --tsv-out`. Which now outputs non-base64-encoded PHRED base quality scores. Probably will be generally useful for other applications too as this is also what people understand from e.g. FASTQ files.