### PR TITLE
Forcibly normalize all sequences when reading in a GFA

### DIFF
--- a/src/algorithms/gfa_to_handle.cpp
+++ b/src/algorithms/gfa_to_handle.cpp
@@ -49,7 +49,7 @@ static void write_gfa_translation(const GFAIDMapInfo& id_map_info, const string&
 /// Add listeners which let a GFA parser fill in a handle graph with nodes and edges.
 static void add_graph_listeners(GFAParser& parser, MutableHandleGraph* graph) {
     parser.node_listeners.push_back([&parser, graph](nid_t id, const GFAParser::chars_t& sequence, const GFAParser::tag_list_t& tags) {
-        graph->create_handle(GFAParser::extract(sequence), id);
+        graph->create_handle(nonATGCNtoN(to_upper(GFAParser::extract(sequence))), id);
     });
     parser.edge_listeners.push_back([&parser, graph](nid_t from, bool from_is_reverse, nid_t to, bool to_is_reverse, const GFAParser::chars_t& overlap, const GFAParser::tag_list_t& tags) {
         static const string not_blunt = ("error:[gfa_to_handle_graph] Can only load blunt-ended GFAs. "


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * When reading in a GFA, node sequences are normalized (uppercased, non-ACGT converted to N) even if not strictly required for output format

## Description

Resolves #3871 by forcing even `vg convert -g <lowercase.gfa> -v` to output with normalized base sequences. (We could also make this warn, e.g. with [`sanitize_sequence_in_place()`](https://github.com/vgteam/vg/blob/6193310e3bc538bcb56baa281528f940db3d109e/src/constructor.hpp#L327), but since it doesn't warn on conversion to PG I kept everything silent.)