### PR TITLE
Make `vg view` invocation hint more generic

### DIFF
--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -32,7 +32,7 @@ using namespace vg::subcommand;
 using namespace vg::io;
 
 void help_view(char** argv) {
-    cerr << "usage: " << argv[0] << " view [options] [ <graph.vg> | <graph.json> | <aln.gam> | <read1.fq> [<read2.fq>] ]" << endl
+    cerr << "usage: " << argv[0] << " view [options] [ <graph> | <aln.gam> | <read1.fq> [<read2.fq>] ]" << endl
          << "options:" << endl
          << "  -g, --gfa                 output GFA format (default)" << endl
          << "  -F, --gfa-in              input GFA format, reducing overlaps if they occur" << endl


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg view` hint no longer makes it seem that it only takes `.vg`

## Description

Resolves #3116. I didn't see a point in cluttering an already long line by adding a bunch of other extensions, so now it's just generic "graph".