### PR TITLE
pad enough for bench-dist-query

### DIFF
--- a/src/subcommand/help_main.cpp
+++ b/src/subcommand/help_main.cpp
@@ -39,7 +39,7 @@ int main_help(int argc, char** argv) {
             
             // Pad all the names so the descriptions line up
             string name = command.get_name();
-            name.resize(14, ' ');
+            name.resize(18, ' ');
             cerr << "  -- " << name << command.get_description() << endl;
          });
          


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * No more overlap in `vg help` output

## Description

They say a picture is worth a thousand words. Here is from `vg help` on the master branch:

```
developer commands:
  -- bench-dist-quebenchmark distance query speed across multiple indexes
```

And on this branch:
```
developer commands:
  -- bench-dist-query  benchmark distance query speed across multiple indexes
```

I didn't bother adding a check for this because I really doubt we're going to need a longer command name.