### PR TITLE
Fix `make clean` and put under CI test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1108,29 +1108,8 @@ clean: clean-vcflib
 	$(RM) -r $(OBJ_DIR)
 	$(RM) -r $(INC_DIR)
 	$(RM) -r share/
-	cd $(DEP_DIR) && cd htslib && $(MAKE) clean
-	cd $(DEP_DIR) && cd tabixpp && rm -f tabix.o libtabixpp.a
-	cd $(DEP_DIR) && cd sonLib && $(MAKE) clean
-	cd $(DEP_DIR) && cd sparsehash && $(MAKE) clean || true
-	cd $(DEP_DIR) && cd gcsa2 && $(MAKE) clean
-	cd $(DEP_DIR) && cd gbwt && $(MAKE) clean
-	cd $(DEP_DIR) && cd gbwtgraph && $(MAKE) clean
-	cd $(DEP_DIR) && cd kff-cpp-api && rm -Rf build
-	cd $(DEP_DIR) && cd gssw && $(MAKE) clean
-	cd $(DEP_DIR) && cd ssw && cd src && $(MAKE) clean
-	cd $(DEP_DIR) && cd progress_bar && $(MAKE) clean
-	cd $(DEP_DIR) && cd sdsl-lite && ./uninstall.sh || true
-	cd $(DEP_DIR) && cd vcflib && $(MAKE) clean
-	cd $(DEP_DIR) && cd sha1 && $(MAKE) clean
-	cd $(DEP_DIR) && cd structures && $(MAKE) clean
-	cd $(DEP_DIR) && cd mimalloc && rm -Rf build CMakeCache.txt CMakeFiles
-	cd $(DEP_DIR) && cd jemalloc && $(MAKE) clean || true
-	cd $(DEP_DIR) && cd sublinear-Li-Stephens && $(MAKE) clean
-	cd $(DEP_DIR) && cd libhandlegraph && rm -Rf build CMakeCache.txt CMakeFiles
-	cd $(DEP_DIR) && cd libvgio && rm -Rf build CMakeCache.txt CMakeFiles
-	cd $(DEP_DIR) && cd raptor && cd build && find . -not \( -name '.gitignore' -or -name 'pkg.m4' \) -delete
-	# lru_cache is never built because it is header-only
-	# bash-tap is never built either
+	$(RM) -r $(DEP_DIR)
+	git submodule update --recursive
 
 clean-vcflib:
 	cd $(DEP_DIR) && cd vcflib && $(MAKE) clean

--- a/README.md
+++ b/README.md
@@ -204,12 +204,12 @@ So, after migrating to an ARM Mac using e.g. Apple's migration tools:
 2. Uninstall Homebrew and its packages, if they were migrated. Similarly, only an ARM Homebrew install will work.
 3. Reinstall one of MacPorts or Homebrew. Make sure to use the M1 or ARM version.
 4. Use the package manager you installed to install system dependencies of vg, such as CMake, [as documented above](#mac-install-dependencies).
-5. Clean vg with `make clean`. This *should* remove all build artefacts.
+5. Clean vg with `make clean`.
 6. Build vg again with `make`.
 
-If you still experience build problems after this, delete the whole checkout and check out the code again; `make clean` is not under CI test and is not always up to date with the rest of the build system.
+If you still experience build problems after this, delete the whole checkout and check out the code again.
 
-Whether or not that helps, please then [open an issue](https://github.com/vgteam/vg/issues/new) so we can help fix the build or fix `make clean`.
+Whether or not that helps, please then [open an issue](https://github.com/vgteam/vg/issues/new) so we can help fix the build.
 
 ## Usage
 

--- a/test/t/98_make_clean.t
+++ b/test/t/98_make_clean.t
@@ -9,7 +9,7 @@ cd ..
 
 make clean
 is "$?" "0" "make clean completes without errors"
-make -j20
+make
 is "$?" "0" "we can make after make clean"
 bin/vg help
 is "$?" "0" "vg builds successfully"

--- a/test/t/98_make_clean.t
+++ b/test/t/98_make_clean.t
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+BASH_TAP_ROOT=../deps/bash-tap
+. ../deps/bash-tap/bash-tap-bootstrap
+
+plan tests 3
+
+cd ..
+
+make clean
+is "$?" "0" "make clean completes without errors"
+make -j20
+is "$?" "0" "we can make after make clean"
+bin/vg help
+is "$?" "0" "vg builds successfully"


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Fix `make clean` and put under CI test

## Description

Resolves #1536. Instead of having to keep track of dependencies and hoping that each can clean itself up properly, now `make clean` takes the nuclear option of deleting everything and re-cloning. It may take longer, but at least it works.
