### PR TITLE
Harden vg stats -R --snarl-sample

### DIFF
--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -67,7 +67,7 @@ void help_stats(char** argv) {
          << "  -O, --overlap-all        print overlap table for cartesian product of paths" << endl
          << "  -R, --snarls             print statistics for each snarl" << endl
          << "      --snarl-contents     print table of <snarl, depth, parent, node ids>" << endl
-         << "      --snarl-sample NAME  print reference coordinates on given sample" << endl
+         << "      --snarl-sample NAME  print BED-like reference coordinates on given sample" << endl
          << "  -C, --chains             print statistics for each chain" << endl
          << "  -F, --format             graph type {VG-Protobuf, PackedGraph, HashGraph, XG}" << endl
          << "                           Can't detect Protobuf if graph read from stdin" << endl
@@ -1303,7 +1303,12 @@ int main_stats(int argc, char** argv) {
                             travs.push_back(make_pair(end_steps.begin()->second.front(), end_steps.begin()->second.front()));
                         }
                     }
-                    if (travs.empty()) {
+                    if (travs.empty() || travs.front().first == travs.front().second) {
+                        // either we found nothing on the reference at all, or only one end of the snarl
+                        // reached it, in which case the fallback above paired a step with itself.  a lone
+                        // anchor tells us which node the snarl hangs off but not which side of that node
+                        // it attaches to, so there is no interval to report.  say so, rather than invent
+                        // one that would be indistinguishable from a genuinely empty snarl.
                         cout << ".\t.\t.\t";
                     } else {
                         // note: in case of a cycle, we're just taking the first found
@@ -1313,19 +1318,23 @@ int main_stats(int argc, char** argv) {
                         int64_t end_pos = pp_graph->get_position_of_step(end_step);
                         if (end_pos < start_pos) {
                             swap(start_pos, end_pos);
-                            swap(start_step, end_step);                            
+                            swap(start_step, end_step);
                         }
-                        // we don't want the boundaries counting toward the snarl length
-                        // so if the start step is forward in the traversal, then subtract its lefnth
-                        if (!graph->get_is_reverse(graph->get_handle_of_step(start_step))) {
-                            start_pos += graph->get_length(graph->get_handle_of_step(start_step));
-                        }
-                        // and if the last step is backwards in the traversal, subtract its length
-                        if (graph->get_is_reverse(graph->get_handle_of_step(end_step))) {
-                            end_pos -= graph->get_length(graph->get_handle_of_step(end_step));
-                        }
-                        cout << graph->get_path_name(pp_graph->get_path_handle_of_step(start_step)) << "\t" << start_pos << "\t"
-                             << end_pos << "\t";
+                        // we don't want the boundaries counting toward the snarl length.  the two steps
+                        // are distinct and so occupy disjoint stretches of the path, and
+                        // get_position_of_step always gives the leftmost base of a step's visit whatever
+                        // its orientation.  so the interior runs from one past the end of the leftmost
+                        // boundary node up to (but not including) the first base of the rightmost one,
+                        // giving a 0-based, half-open (BED-like) interval.  note that on a cyclic path
+                        // the traversal can wrap past the path origin, in which case the two steps don't
+                        // bracket the interior and the interval isn't meaningful.
+                        start_pos += graph->get_length(graph->get_handle_of_step(start_step));
+                        // report against the base path, so that coordinates on a subpath are still
+                        // relative to the full contig rather than to the start of the subrange
+                        path_handle_t ref_path = pp_graph->get_path_handle_of_step(start_step);
+                        int64_t base_offset = get_path_base_offset(*pp_graph, ref_path);
+                        cout << get_path_base_name(*pp_graph, ref_path) << "\t" << (start_pos + base_offset) << "\t"
+                             << (end_pos + base_offset) << "\t";
 
                         // use this interval for off-reference children
                         snarl_to_ref[snarl] = travs.front();

--- a/test/graphs/snarl_ref_coords.gfa
+++ b/test/graphs/snarl_ref_coords.gfa
@@ -1,0 +1,14 @@
+H	VN:Z:1.0
+S	5	AAAA
+S	1	CCCCCCCCCC
+S	2	GGG
+S	3	T
+S	4	AAAAAAA
+S	6	CCCCC
+L	5	+	1	+	0M
+L	1	+	2	+	0M
+L	1	+	3	+	0M
+L	2	+	4	+	0M
+L	3	+	4	+	0M
+L	4	+	6	+	0M
+P	GRCh38#0#chr1	5+,1+,2+,4+,6+	*,*,*,*

--- a/test/graphs/snarl_ref_coords_chopped.gfa
+++ b/test/graphs/snarl_ref_coords_chopped.gfa
@@ -1,0 +1,15 @@
+H	VN:Z:1.1
+S	5	AAAA
+S	1	CCCCCCCCCC
+S	2	GGG
+S	3	T
+S	4	AAAAAAA
+S	6	CCCCC
+L	5	+	1	+	0M
+L	1	+	2	+	0M
+L	1	+	3	+	0M
+L	2	+	4	+	0M
+L	3	+	4	+	0M
+L	4	+	6	+	0M
+W	GRCh38	0	chr1	1000	1014	>5>1
+W	GRCh38	0	chr1	1014	1029	>2>4>6

--- a/test/graphs/snarl_ref_coords_offref.gfa
+++ b/test/graphs/snarl_ref_coords_offref.gfa
@@ -1,0 +1,23 @@
+H	VN:Z:1.0
+S	5	AAAA
+S	1	CCCCCCCCCC
+S	2	GGG
+S	3	T
+S	4	AAAAAAA
+S	6	CCCCC
+S	10	GG
+S	11	TTT
+S	12	A
+S	13	CC
+L	5	+	1	+	0M
+L	1	+	2	+	0M
+L	1	+	3	+	0M
+L	2	+	4	+	0M
+L	3	+	4	+	0M
+L	4	+	6	+	0M
+L	6	+	10	+	0M
+L	10	+	11	+	0M
+L	10	+	12	+	0M
+L	11	+	13	+	0M
+L	12	+	13	+	0M
+P	GRCh38#0#chr1	5+,1+,2+,4+,6+	*,*,*,*

--- a/test/graphs/snarl_ref_coords_offref_rev.gfa
+++ b/test/graphs/snarl_ref_coords_offref_rev.gfa
@@ -1,0 +1,23 @@
+H	VN:Z:1.0
+S	5	AAAA
+S	1	CCCCCCCCCC
+S	2	GGG
+S	3	T
+S	4	AAAAAAA
+S	6	CCCCC
+S	10	GG
+S	11	TTT
+S	12	A
+S	13	CC
+L	5	+	1	+	0M
+L	1	+	2	+	0M
+L	1	+	3	+	0M
+L	2	+	4	+	0M
+L	3	+	4	+	0M
+L	4	+	6	+	0M
+L	6	+	10	+	0M
+L	10	+	11	+	0M
+L	10	+	12	+	0M
+L	11	+	13	+	0M
+L	12	+	13	+	0M
+P	GRCh38#0#chr1	6-,4-,2-,1-,5-	*,*,*,*

--- a/test/graphs/snarl_ref_coords_rev.gfa
+++ b/test/graphs/snarl_ref_coords_rev.gfa
@@ -1,0 +1,14 @@
+H	VN:Z:1.0
+S	5	AAAA
+S	1	CCCCCCCCCC
+S	2	GGG
+S	3	T
+S	4	AAAAAAA
+S	6	CCCCC
+L	5	+	1	+	0M
+L	1	+	2	+	0M
+L	1	+	3	+	0M
+L	2	+	4	+	0M
+L	3	+	4	+	0M
+L	4	+	6	+	0M
+P	GRCh38#0#chr1	6-,4-,2-,1-,5-	*,*,*,*

--- a/test/graphs/snarl_ref_coords_sub.gfa
+++ b/test/graphs/snarl_ref_coords_sub.gfa
@@ -1,0 +1,14 @@
+H	VN:Z:1.1
+S	5	AAAA
+S	1	CCCCCCCCCC
+S	2	GGG
+S	3	T
+S	4	AAAAAAA
+S	6	CCCCC
+L	5	+	1	+	0M
+L	1	+	2	+	0M
+L	1	+	3	+	0M
+L	2	+	4	+	0M
+L	3	+	4	+	0M
+L	4	+	6	+	0M
+W	GRCh38	0	chr1	1000	1029	>5>1>2>4>6

--- a/test/graphs/snarl_ref_coords_sub_rev.gfa
+++ b/test/graphs/snarl_ref_coords_sub_rev.gfa
@@ -1,0 +1,14 @@
+H	VN:Z:1.1
+S	5	AAAA
+S	1	CCCCCCCCCC
+S	2	GGG
+S	3	T
+S	4	AAAAAAA
+S	6	CCCCC
+L	5	+	1	+	0M
+L	1	+	2	+	0M
+L	1	+	3	+	0M
+L	2	+	4	+	0M
+L	3	+	4	+	0M
+L	4	+	6	+	0M
+W	GRCh38	0	chr1	1000	1029	<6<4<2<1<5

--- a/test/t/10_vg_stats.t
+++ b/test/t/10_vg_stats.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 23
+plan tests 30
 
 vg construct -r 1mb1kgp/z.fa -v 1mb1kgp/z.vcf.gz >z.vg
 #is $? 0 "construction of a 1 megabase graph from the 1000 Genomes succeeds"
@@ -94,3 +94,90 @@ is $? 0 "vg stats -e finds the right nondeterministic edge sets"
 
 rm -f weird.vg
 rm -f expected.txt loops.txt nondeterministic.txt
+
+
+# Reference coordinates for snarls (--snarl-sample).  All four graphs below share the
+# topology 5(4bp) -> 1(10bp) -> {2(3bp), 3(1bp)} -> 4(7bp) -> 6(5bp), and a 29bp reference
+# path visiting 5,1,2,4,6.  The reported coordinates are 0-based and half-open, and cover
+# only the interior of each snarl: the boundary nodes are excluded, so the two trivial
+# snarls (5,1) and (4,6) come out as empty intervals.
+
+# Forward path: node 5 is at [0,4), 1 at [4,14), 2 at [14,17), 4 at [17,24), 6 at [24,29),
+# so the bubble between 1 and 4 has its interior at [14,17).
+printf "GRCh38#0#chr1#0\t4\t4\t5\t1\n" > expected.txt
+printf "GRCh38#0#chr1#0\t14\t17\t1\t4\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t24\t24\t4\t6\n" >> expected.txt
+sort expected.txt > expected.sorted.txt
+vg stats -R --snarl-sample GRCh38 graphs/snarl_ref_coords.gfa | tail -n +2 | cut -f1-4,6 | sort > coords.txt
+cmp coords.txt expected.sorted.txt
+is "$?" 0 "vg stats --snarl-sample gives half-open interior coordinates on a forward reference path"
+
+# The same graph with the reference path walking every node in reverse.  The path is the
+# reverse complement of the forward case, so each interval mirrors around the 29bp length:
+# the bubble interior [14,17) becomes [29-17, 29-14) = [12,15).
+printf "GRCh38#0#chr1#0\t5\t5\t4\t6\n" > expected.txt
+printf "GRCh38#0#chr1#0\t12\t15\t1\t4\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t25\t25\t5\t1\n" >> expected.txt
+sort expected.txt > expected.sorted.txt
+vg stats -R --snarl-sample GRCh38 graphs/snarl_ref_coords_rev.gfa | tail -n +2 | cut -f1-4,6 | sort > coords.txt
+cmp coords.txt expected.sorted.txt
+is "$?" 0 "vg stats --snarl-sample gives half-open interior coordinates on a reverse reference path"
+
+# A reference path that is a subpath starting at 1000.  Coordinates must be reported against
+# the full contig, and the contig name must not keep the subrange suffix.
+printf "GRCh38#0#chr1#0\t1004\t1004\t5\t1\n" > expected.txt
+printf "GRCh38#0#chr1#0\t1014\t1017\t1\t4\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t1024\t1024\t4\t6\n" >> expected.txt
+sort expected.txt > expected.sorted.txt
+vg stats -R --snarl-sample GRCh38 graphs/snarl_ref_coords_sub.gfa | tail -n +2 | cut -f1-4,6 | sort > coords.txt
+cmp coords.txt expected.sorted.txt
+is "$?" 0 "vg stats --snarl-sample offsets coordinates by the subrange of a forward subpath"
+
+# Both at once: a subpath starting at 1000 that also walks every node in reverse.
+printf "GRCh38#0#chr1#0\t1005\t1005\t4\t6\n" > expected.txt
+printf "GRCh38#0#chr1#0\t1012\t1015\t1\t4\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t1025\t1025\t5\t1\n" >> expected.txt
+sort expected.txt > expected.sorted.txt
+vg stats -R --snarl-sample GRCh38 graphs/snarl_ref_coords_sub_rev.gfa | tail -n +2 | cut -f1-4,6 | sort > coords.txt
+cmp coords.txt expected.sorted.txt
+is "$?" 0 "vg stats --snarl-sample offsets coordinates by the subrange of a reverse subpath"
+
+# Snarls that only touch the reference at one end can't be bracketed, so they get no
+# coordinates at all rather than a made-up empty interval.  These graphs bolt an off-reference
+# bubble 6 -> 10 -> {11,12} -> 13 onto the end of the reference path, putting snarls (6,10)
+# and (10,13) off the reference.  The answer must not depend on which way the path runs: the
+# lone anchor is node 6 either way, and which side of it the bubble attaches to is exactly
+# what we cannot tell.
+printf ".\t.\t.\t10\t13\n" > expected.txt
+printf ".\t.\t.\t6\t10\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t4\t4\t5\t1\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t14\t17\t1\t4\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t24\t24\t4\t6\n" >> expected.txt
+sort expected.txt > expected.sorted.txt
+vg stats -R --snarl-sample GRCh38 graphs/snarl_ref_coords_offref.gfa | tail -n +2 | cut -f1-4,6 | sort > coords.txt
+cmp coords.txt expected.sorted.txt
+is "$?" 0 "vg stats --snarl-sample reports no coordinates for snarls that only reach a forward reference at one end"
+
+printf ".\t.\t.\t10\t13\n" > expected.txt
+printf ".\t.\t.\t6\t10\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t5\t5\t4\t6\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t12\t15\t1\t4\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t25\t25\t5\t1\n" >> expected.txt
+sort expected.txt > expected.sorted.txt
+vg stats -R --snarl-sample GRCh38 graphs/snarl_ref_coords_offref_rev.gfa | tail -n +2 | cut -f1-4,6 | sort > coords.txt
+cmp coords.txt expected.sorted.txt
+is "$?" 0 "vg stats --snarl-sample reports no coordinates for snarls that only reach a reverse reference at one end"
+
+# The same one-anchor situation arises when a contig is split into several subpaths, as in a
+# GBZ from minigraph-cactus: snarl (1,4) straddles the junction between the two W-lines, so
+# its boundaries land on different path handles and it cannot be bracketed.  The snarls that
+# sit wholly within one subpath still get real coordinates, offset onto the full contig.
+printf ".\t.\t.\t1\t4\n" > expected.txt
+printf "GRCh38#0#chr1#0\t1004\t1004\t5\t1\n" >> expected.txt
+printf "GRCh38#0#chr1#0\t1024\t1024\t4\t6\n" >> expected.txt
+sort expected.txt > expected.sorted.txt
+vg stats -R --snarl-sample GRCh38 graphs/snarl_ref_coords_chopped.gfa | tail -n +2 | cut -f1-4,6 | sort > coords.txt
+cmp coords.txt expected.sorted.txt
+is "$?" 0 "vg stats --snarl-sample reports no coordinates for a snarl straddling two subpaths of a contig"
+
+rm -f expected.txt expected.sorted.txt coords.txt


### PR DESCRIPTION
Fix to work on reverse-strand reference paths. 
Also, apply subpath information where appropriate.

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg stats -R --snarl-sample` more robust for reverse-strand or chopped up references. 
 
# Description
