### PR TITLE
Better vg call errors when no reference paths are found

### DIFF
--- a/src/subcommand/call_main.cpp
+++ b/src/subcommand/call_main.cpp
@@ -593,7 +593,8 @@ int main_call(int argc, char** argv) {
             }
         });
         if (ref_paths.empty()) {
-            logger.error() << "No paths found matching prefix(es)" << endl;
+            logger.error() << "No REFERENCE or GENERIC paths (see vg paths -M) found matching prefix(es)\n"
+                           << "Also see: https://github.com/vgteam/vg/wiki/Changing-References" << endl;
         }
     }
 
@@ -677,8 +678,9 @@ int main_call(int argc, char** argv) {
         // Check our paths
         for (const auto& ref_path_used : ref_path_set) {
             if (!ref_path_used.second) {
-                logger.error() << "Reference path \"" << ref_path_used.first 
-                               << "\" not found in graph" << endl;
+                logger.error() << "Path \"" << ref_path_used.first 
+                               << "\" not found in graph as REFERENCE or GENERIC sense (see vg paths -M)\n"
+                               << "Also see: https://github.com/vgteam/vg/wiki/Changing-References" << endl;
             }
         }
         
@@ -688,10 +690,12 @@ int main_call(int argc, char** argv) {
     // make sure we have some ref paths
     if (ref_paths.empty()) {
         if (!ref_sample.empty()) {
-            logger.error() << "No paths with selected reference sample \"" << ref_sample << "\" found." 
-                           << "Try using vg paths -M to see which samples are in your graph" << endl;
+            logger.error() << "No REFERENCE paths for \"" << ref_sample << "\" found.\n" 
+                           << "Also see: https://github.com/vgteam/vg/wiki/Changing-References" << endl;
         }
-        logger.error() << "No reference paths found" << endl;
+        logger.error() << "No reference paths found. "
+                       << "Paths must be REFERENCE or GENERIC sense (see vg paths -M)\n"
+                       << "Also see: https://github.com/vgteam/vg/wiki/Changing-References" << endl;
     }
 
     // build table of ploidys

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 86
+plan tests 98
 
 # Toy example of hand-made pileup (and hand inspected truth) to make sure some
 # obvious (and only obvious) SNPs are detected by vg call
@@ -21,7 +21,40 @@ vg call tiny_aug.xg -k tiny_aug.pack > tiny_aug.vcf
 
 is $(grep -v '#' tiny_aug.vcf | wc -l) 0 "calling empty gam gives empty VCF"
 
-rm -f tiny.vg tiny_aug.vg tiny_aug.xg empty_aug.gam tiny_aug.pack tiny_aug.vcf empty.gam
+# No ref paths test
+grep -v CHM13 graphs/haplotypes.gfa > only_haps.gfa
+vg convert --gfa-in only_haps.gfa > only_haps.vg
+vg index only_haps.vg -x only_haps.xg
+
+vg call only_haps.xg -k tiny_aug.pack 2> error.txt
+is "$?" 1 "Must be a non-reference path to call against"
+grep "REFERENCE or GENERIC" error.txt
+is "$?" 0 "Problem is explained in some detail"
+grep "Changing-References" error.txt
+is "$?" 0 "Hint towards solution provided"
+
+vg call only_haps.xg -k tiny_aug.pack -p "KOLF2.1J#1#chr1_1#0" 2> error.txt
+is "$?" 1 "-p path must be a reference"
+grep "REFERENCE or GENERIC" error.txt
+is "$?" 0 "Problem is explained in some detail"
+grep "Changing-References" error.txt
+is "$?" 0 "Hint towards solution provided"
+
+vg call only_haps.xg -k tiny_aug.pack -P "KOLF2.1J" 2> error.txt
+is "$?" 1 "-P paths must be references"
+grep "REFERENCE or GENERIC" error.txt
+is "$?" 0 "Problem is explained in some detail"
+grep "Changing-References" error.txt
+is "$?" 0 "Hint towards solution provided"
+
+vg call only_haps.xg -k tiny_aug.pack -S "KOLF2.1J" 2> error.txt
+is "$?" 1 "-P paths must be references"
+grep "REFERENCE" error.txt
+is "$?" 0 "Problem is explained in some detail"
+grep "Changing-References" error.txt
+is "$?" 0 "Hint towards solution provided"
+
+rm -f tiny.vg tiny_aug.vg tiny_aug.xg empty_aug.gam tiny_aug.pack tiny_aug.vcf empty.gam only_haps.vg only_haps.xg error.txt
 
 vg construct -r inverting/miniFasta.fa -v inverting/miniFasta_VCFinversion.vcf.gz -S > miniFastaGraph.vg
 vg index -x miniFastaGraph.xg -g miniFastaGraph.gcsa miniFastaGraph.vg

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -48,7 +48,7 @@ grep "Changing-References" error.txt
 is "$?" 0 "Hint towards solution provided"
 
 vg call only_haps.xg -k tiny_aug.pack -S "KOLF2.1J" 2> error.txt
-is "$?" 1 "-P paths must be references"
+is "$?" 1 "-S sample must have reference paths"
 grep "REFERENCE" error.txt
 is "$?" 0 "Problem is explained in some detail"
 grep "Changing-References" error.txt


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg call` errors about not finding reference paths are more descriptive

## Description

For #4974 the error message is rather unhelpfully vague. Now the errors should be more specific about what exactly is the problem, why it is still a problem even if you've helpfully passed e.g. a `--ref-sample` which lacks REFERENCE sense paths, and also how to fix the problem (i.e. the wiki page).