### PR TITLE
Have `chunked_call` note that it's deprecated

### DIFF
--- a/scripts/chunked_call
+++ b/scripts/chunked_call
@@ -290,6 +290,8 @@ def merge_vcf_chunks(out_dir, path_name, path_size, chunks, overwrite):
         run("tabix -f -p vcf {}".format(vcf_path + ".gz"))
 
 def main(args):
+    print("THIS SCRIPT IS DEPRECATED. Please use vg call or DeepVariant instead")
+    print("https://github.com/vgteam/vg/wiki/SV-Genotyping-and-variant-calling")
     
     options = parse_args(args)
 

--- a/scripts/chunked_call
+++ b/scripts/chunked_call
@@ -290,7 +290,8 @@ def merge_vcf_chunks(out_dir, path_name, path_size, chunks, overwrite):
         run("tabix -f -p vcf {}".format(vcf_path + ".gz"))
 
 def main(args):
-    print("THIS SCRIPT IS DEPRECATED. Please use vg call or DeepVariant instead")
+    print("THIS SCRIPT IS DEPRECATED. It has become out of date.")
+    print("Please use toil-vg call or DeepVariant instead.")
     print("https://github.com/vgteam/vg/wiki/SV-Genotyping-and-variant-calling")
     
     options = parse_args(args)


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `scripts/chunked_call` prints out a deprecation warning

## Description

As an alternative to something like #510 where we were trying to improve documentation for this script, I think now we want people to just not use it. Hasn't been touched in over half a decade.