### PR TITLE
add warning to `vg augment -i` for nameless paths

### DIFF
--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -302,6 +302,10 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
             Path added = add_nodes_and_edges(graph, simplified_path, node_translation, added_seqs,
                                              added_nodes, orig_node_sizes);
 
+            if (aln.name() == "") {
+                cerr << "warning[augment] embedding a path with no name; downstream operations may fail." << endl;
+            }
+
             // Copy over the name
             *added.mutable_name() = aln.name();
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg augment -i` warns when it is told to embed a path without a name

## Description

Resolves #500 (the `-i` option moved from `vg mod` to `vg augment` in the interim). I could easily be convinced that this should be an error instead.