### PR TITLE
deprecate vg mcmc

### DIFF
--- a/src/subcommand/mcmc_main.cpp
+++ b/src/subcommand/mcmc_main.cpp
@@ -29,6 +29,7 @@ using namespace vg::subcommand;
 void help_mcmc(char** argv) {
     cerr << "usage: " << argv[0] << " mcmc [options] multipath_alns.mgam graph.vg sites.snarls > graph_with_paths.vg" << endl
          << "Finds haplotypes based on reads using MCMC methods" << endl
+         << "DEPRECATED: known to have issues but not under development" << endl
          << endl
          << "basic options:" << endl
          << "  -i, --iteration-number INT  run mcmc_genotyper with INT iterations" << endl
@@ -260,6 +261,6 @@ int main_mcmc(int argc, char** argv) {
 }
 
 // Register subcommand
-static Subcommand vg_mcmc("mcmc", "find haplotypes based on reads using MCMC methods", DEVELOPMENT, main_mcmc);
+static Subcommand vg_mcmc("mcmc", "find haplotypes based on reads using MCMC methods", DEPRECATED, main_mcmc);
 
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg mcmc` marked as deprecated

## Description

Resolves #3486 inasmuch as it makes it clear we're not going to try to fix it. In 2021 Glenn responded https://github.com/vgteam/vg/issues/3486#issuecomment-978189521

> `vg mcmc` neither works nor is under active development at the moment, unfortunately. 
>
> we should probably make this more clear in `vg help and/or vg mcmc -h`.  

And I think that's still true now, five years later.