### PR TITLE
Better helptext and errors for `vg snarls`

### DIFF
--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -27,36 +27,40 @@ using namespace std;
 using namespace vg;
 using namespace vg::subcommand;
 
+const size_t DEFAULT_SNARLS_MAX_NODES = 10;
+
 void help_snarl(char** argv) {
     cerr << "usage: " << argv[0] << " snarls [options] graph > snarls.pb" << endl
          << "       By default, a list of protobuf Snarls is written" << endl
-         << "options:" << endl
+         << "general options:" << endl
          << "  -A, --algorithm NAME      snarl algorithm {cactus/integrated} [integrated]" << endl
          << "  -p, --pathnames           output variant paths as SnarlTraversals to stdout" << endl
-         << "  -r, --traversals FILE     output SnarlTraversals for ultrabubbles" << endl
-         << "  -e, --path-traversals     only consider traversals that correspond to paths in" << endl
-         << "                            the graph (-m ignored)" << endl
-         << "  -l, --leaf-only           restrict traversals to leaf ultrabubbles" << endl
-         << "  -o, --top-level           restrict traversals to top level ultrabubbles" << endl
-         << "  -a, --any-snarl-type      compute traversals for any snarl type" << endl
-         << "                            (not limiting to ultrabubbles)" << endl
-         << "  -m, --max-nodes N         only compute traversals for snarls with <= N nodes" << endl
-         << "                            (with degree > 1) [10]" << endl
          << "  -n, --named-coordinates   produce all outputs in named-segment (GFA) space" << endl
          << "  -T, --include-trivial     report snarls that consist of a single edge" << endl
          << "  -s, --sort-snarls         return snarls in sorted order by node ID" << endl
          << "                            (for topologically ordered graphs)" << endl
-         << "  -v, --vcf FILE            for -r, use VCF-based traversal finder instead of" << endl
-         << "                            exhaustive traversal finder with -r" << endl
-         << "  -f, --fasta FILE          reference as FASTA (required for SVs by -v)" << endl
-         << "  -i, --ins-fasta FILE      insertions as FASTA (required for SVs by -v)" << endl
          << "  -w, --upweight-node N     upweight the node with ID N to push it to be part" << endl
          << "                            of a top-level chain (may repeat)" << endl
          << "  -P, --path-prefix NAME    upweight tips of paths with given prefix to orient" << endl
          << "                            snarl tree. often necessary when running vg" << endl
          << "                            haplotypes downstream" << endl
          << "  -t, --threads N           number of threads to use [all available]" << endl
-         << "  -h, --help                print this help message to stderr and exit" << endl;
+         << "  -h, --help                print this help message to stderr and exit" << endl
+         << "traversals output options (inspect with vg view -Ej):" << endl
+         << "note that these have no effect on the stdout .pb file"
+         << "  -r, --traversals FILE     output SnarlTraversals for ultrabubbles" << endl
+         << "  -e, --path-traversals     only consider traversals that correspond to paths in" << endl
+         << "                            the graph (-m ignored)" << endl
+         << "  -l, --leaf-only           limit --traversals output to leaf ultrabubbles" << endl
+         << "  -o, --top-level           limit --traversals output to top level ultrabubbles" << endl
+         << "  -a, --any-snarl-type      include any snarl type in --traversals output" << endl
+         << "                            (not limiting to ultrabubbles)" << endl
+         << "  -m, --max-nodes N         only compute traversals for snarls with <= N nodes" << endl
+         << "                            (with degree > 1) [" << DEFAULT_SNARLS_MAX_NODES << "]" << endl
+         << "  -v, --vcf FILE            for -r, use VCF-based traversal finder instead of" << endl
+         << "                            exhaustive traversal finder with -r" << endl
+         << "  -f, --fasta FILE          reference as FASTA (required for SVs by -v)" << endl
+         << "  -i, --ins-fasta FILE      insertions as FASTA (required for SVs by -v)" << endl;
 }
 
 int main_snarl(int argc, char** argv) {
@@ -74,7 +78,7 @@ int main_snarl(int argc, char** argv) {
     bool leaf_only = false;
     bool top_level_only = false;
     bool ultrabubble_only = true;
-    int max_nodes = 10;
+    int max_nodes = DEFAULT_SNARLS_MAX_NODES;
     bool named_coordinates = false;
     bool filter_trivial_snarls = true;
     bool sort_snarls = false;
@@ -201,15 +205,42 @@ int main_snarl(int argc, char** argv) {
         }
     }
 
+    if (path_traversals) {
+        if (!vcf_filename.empty()) {
+            logger.error() << "--vcf (-v) cannot be used with --path-traversals (-e)" << endl;
+        }
+        if (max_nodes != DEFAULT_SNARLS_MAX_NODES) {
+            logger.warn() << "--max-nodes (-m) ignored due to --path-traversals (-e)" << endl;
+        }
+    }
+
+    if (vcf_filename.empty()) {
+        if (!ref_fasta_filename.empty()) {
+            logger.error() << "--fasta (-f) requires --vcf (-v) file" << endl;
+        }
+        if (!ins_fasta_filename.empty()) {
+            logger.error() << "--ins-fasta (-i) requires --vcf (-v) file" << endl;
+        }
+    }
+
     if (traversal_file.empty()) {
         if (!ultrabubble_only) {
-            cerr << "warning:[vg snarls] --any-snarl-type (-a) has no effect without --traversals file" << endl;
+            logger.error() << "--any-snarl-type (-a) requires --traversals (-r) file" << endl;
         }
         if (top_level_only) {
-            cerr << "warning:[vg snarls] --top-level (-o) has no effect without --traversals file" << endl;
+            logger.error() << "--top-level (-o) requires --traversals (-r) file" << endl;
         }
         if (leaf_only) {
-            cerr << "warning:[vg snarls] --leaf-only (-l) has no effect without --traversals file" << endl;
+            logger.error() << "--leaf-only (-l) requires --traversals (-r) file" << endl;
+        }
+        if (max_nodes != DEFAULT_SNARLS_MAX_NODES) {
+            logger.error() << "--max-nodes (-m) requires --traversals (-r) file" << endl;
+        }
+        if (path_traversals) {
+            logger.error() << "--path-traversals (-e) requires --traversals (-r) file" << endl;
+        }
+        if (!vcf_filename.empty()) {
+            logger.error() << "--vcf (-v) requires --traversals (-r) file" << endl;
         }
     }
 
@@ -237,7 +268,7 @@ int main_snarl(int argc, char** argv) {
     // non-path HandleGraph, but we don't really have any of those implemented
     // anymore, so we don't bother supporting them.
         
-    // Pick a SnalrFinder
+    // Pick a SnarlFinder
     unique_ptr<SnarlFinder> snarl_finder;
 
     if ((!extra_node_weight.empty() || !ref_prefix.empty()) && algorithm != "integrated") {
@@ -260,15 +291,6 @@ int main_snarl(int argc, char** argv) {
     } else {
         logger.error() << "Algorithm must be 'cactus' or 'integrated', not '"
                        << algorithm << "'" << endl;
-    }
-    if (!vcf_filename.empty() && path_traversals) {
-        logger.error() << "-v cannot be used with -e" << endl;
-    }
-    if (path_traversals && traversal_file.empty()) {
-        logger.error() << "-e requires -r" << endl;
-    }
-    if (!vcf_filename.empty() && traversal_file.empty()) {
-        logger.error() << "-v requires -r" << endl;
     }
 
     unique_ptr<TraversalFinder> trav_finder;

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -46,9 +46,10 @@ void help_snarl(char** argv) {
          << "                            haplotypes downstream" << endl
          << "  -t, --threads N           number of threads to use [all available]" << endl
          << "  -h, --help                print this help message to stderr and exit" << endl
-         << "traversals output options (inspect with vg view -Ej):" << endl
-         << "note that these have no effect on the stdout .pb file"
+         << "traversals output options (note that these have no effect on the " << endl
+         << "stdout .pb file):" << endl
          << "  -r, --traversals FILE     output SnarlTraversals for ultrabubbles" << endl
+         << "                            to FILE (inspect with vg view -Ej)" << endl
          << "  -e, --path-traversals     only consider traversals that correspond to paths in" << endl
          << "                            the graph (-m ignored)" << endl
          << "  -l, --leaf-only           limit --traversals output to leaf ultrabubbles" << endl

--- a/src/subcommand/snarls_main.cpp
+++ b/src/subcommand/snarls_main.cpp
@@ -34,7 +34,6 @@ void help_snarl(char** argv) {
          << "       By default, a list of protobuf Snarls is written" << endl
          << "general options:" << endl
          << "  -A, --algorithm NAME      snarl algorithm {cactus/integrated} [integrated]" << endl
-         << "  -p, --pathnames           output variant paths as SnarlTraversals to stdout" << endl
          << "  -n, --named-coordinates   produce all outputs in named-segment (GFA) space" << endl
          << "  -T, --include-trivial     report snarls that consist of a single edge" << endl
          << "  -s, --sort-snarls         return snarls in sorted order by node ID" << endl
@@ -48,8 +47,8 @@ void help_snarl(char** argv) {
          << "  -h, --help                print this help message to stderr and exit" << endl
          << "traversals output options (note that these have no effect on the " << endl
          << "stdout .pb file):" << endl
-         << "  -r, --traversals FILE     output SnarlTraversals for ultrabubbles" << endl
-         << "                            to FILE (inspect with vg view -Ej)" << endl
+         << "  -r, --traversals OUTFILE  output SnarlTraversals for ultrabubbles" << endl
+         << "                            to OUTFILE (inspect with vg view -Ej)" << endl
          << "  -e, --path-traversals     only consider traversals that correspond to paths in" << endl
          << "                            the graph (-m ignored)" << endl
          << "  -l, --leaf-only           limit --traversals output to leaf ultrabubbles" << endl
@@ -83,7 +82,6 @@ int main_snarl(int argc, char** argv) {
     bool named_coordinates = false;
     bool filter_trivial_snarls = true;
     bool sort_snarls = false;
-    bool fill_path_names = false;
     string vcf_filename;
     string ref_fasta_filename;
     string ins_fasta_filename;
@@ -169,7 +167,7 @@ int main_snarl(int argc, char** argv) {
             sort_snarls = true;
             break;
         case 'p':
-            fill_path_names = true;
+            logger.error() << "vg snarls --pathnames has been removed" << endl;
             break;
         case 'v':
             vcf_filename = require_exists(logger, optarg);
@@ -331,30 +329,6 @@ int main_snarl(int argc, char** argv) {
             snarl_roots.push_back(here->first);
         }
     });
-    
-    if (fill_path_names){
-        // This finder needs a vg::VG
-        trav_finder.reset(new PathBasedTraversalFinder(*graph, snarl_manager));
-        for (const Snarl* snarl : snarl_roots ){
-            if (filter_trivial_snarls) {
-                auto contents = snarl_manager.shallow_contents(snarl, *graph, false);
-                if (contents.first.empty()) {
-                    // Nothing but the boundary nodes in this snarl
-                    continue;
-                }
-            }
-            vector<SnarlTraversal> travs =  trav_finder->find_traversals(*snarl);
-            if (translation) {
-                for (auto& trav : travs) {
-                    // Bring all the output traversals into named segment space.
-                    vg::algorithms::back_translate_in_place(translation, trav);
-                }
-            }
-            vg::io::write_buffered(cout, travs, 0);
-        }
-
-        exit(0);
-    }
 
     if (path_traversals) {
         // Limit traversals to embedded paths

--- a/test/t/32_vg_snarls.t
+++ b/test/t/32_vg_snarls.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 25
+plan tests 42
 
 vg view -J -v snarls/snarls.json > snarls.vg
 vg snarls -t 1 snarls.vg -r st.pb > snarls.pb
@@ -13,22 +13,39 @@ is $(vg view -R snarls.pb | wc -l) 3 "vg snarls made right number of protobuf Sn
 is $(vg view -E st.pb | wc -l) 6 "vg snarls made right number of protobuf SnarlTraversals"
 is $(vg view -R snarls.pb | jq -r '[(.start.node_id | tonumber), (.end.node_id | tonumber)] | min' | tr '\n' ',') "1,3,7," "vg snarls made snarls in the right order"
 
-vg snarls -l -t 1 snarls.vg > leaf_only.pb 2> warnings.txt
-is "$(grep 'has no effect without --traversals file' warnings.txt | wc -l)" "1" "vg snarls warns when -l is used without --traversals"
+vg snarls -l -t 1 snarls.vg > /dev/null 2> error.txt
+is $? 1 "vg snarls does not allow --leaf-only to be used without --traversals"
+grep "requires --traversals" error.txt
+is $? 0 "the problem is explained"
+vg snarls -l -t 1 snarls.vg -r /dev/null > leaf_only.pb
 diff leaf_only.pb snarls.pb
-is $? 0 "vg snarls -l matches full snarls"
+is $? 0 "vg snarls --leaf-only matches full snarls"
 
-vg snarls -o -t 1 snarls.vg > top_level.pb 2> warnings.txt
-is "$(grep 'has no effect without --traversals file' warnings.txt | wc -l)" "1" "vg snarls warns when -o is used without --traversals"
+vg snarls -o -t 1 snarls.vg > /dev/null 2> error.txt
+is $? 1 "vg snarls does not allow --top-level to be used without --traversals"
+grep "requires --traversals" error.txt
+is $? 0 "the problem is explained"
+vg snarls -o -t 1 snarls.vg -r /dev/null > top_level.pb
 diff top_level.pb snarls.pb
-is $? 0 "vg snarls -o matches full snarls"
+is $? 0 "vg snarls --top-level matches full snarls"
 
-vg snarls -a -t 1 snarls.vg > any.pb 2> warnings.txt
-is "$(grep 'has no effect without --traversals file' warnings.txt | wc -l)" "1" "vg snarls warns when -a is used without --traversals"
+vg snarls -a -t 1 snarls.vg > /dev/null 2> error.txt
+is $? 1 "vg snarls does not allow --any-snarl-type to be used without --traversals"
+grep "requires --traversals" error.txt
+is $? 0 "the problem is explained"
+vg snarls -a -t 1 snarls.vg -r /dev/null > any.pb
 diff any.pb snarls.pb
-is $? 0 "vg snarls -a matches full snarls"
+is $? 0 "vg snarls --any-snarl-type matches full snarls"
 
-rm -f snarls.pb st.pb leaf_only.pb top_level.pb any.pb warnings.txt
+vg snarls -m 5 -t 1 snarls.vg > /dev/null 2> error.txt
+is $? 1 "vg snarls does not allow --max-nodes to be used without --traversals"
+grep "requires --traversals" error.txt
+is $? 0 "the problem is explained"
+vg snarls -m 5 -t 1 snarls.vg -r /dev/null > small.pb
+diff small.pb snarls.pb
+is $? 0 "vg snarls with --max-nodes changed matches full snarls"
+
+rm -f snarls.pb st.pb leaf_only.pb top_level.pb any.pb small.pb error.txt
 
 vg index snarls.vg -x snarls.xg
 is $(vg snarls snarls.xg -r st.pb | vg view -R - | wc -l) 3 "vg snarls on xg made right number of protobuf Snarls"
@@ -45,7 +62,26 @@ vg view -E tiny.vcf.trav | sort > tiny.vcf.trav.sort
 diff tiny.exhaustive.trav.sort tiny.vcf.trav.sort
 is $? 0 "vcf traversals are the same as exhaustive traversals for tiny graph"
 
-rm -f tiny.vg tiny.exhaustive.trav.sort tiny.exhaustive.trav tiny.vcf.trav.sort tiny.vcf.trav
+vg snarls tiny.vg -v tiny/tiny.vcf.gz > /dev/null 2> error.txt
+is $? 1 "vg snarls requires --traversals to be given if --vcf is"
+grep "requires --traversals" error.txt
+is $? 0 "the problem is explained"
+
+vg snarls tiny.vg -r tiny.vcf.trav -v tiny/tiny.vcf.gz -e > /dev/null 2> error.txt
+is $? 1 "vg snarls does not allow both --vcf and --path-traversals"
+grep "cannot be used with" error.txt
+is $? 0 "the problem is explained"
+
+vg snarls tiny.vg -e > /dev/null 2> error.txt
+is $? 1 "vg snarls requires --traversals to be given if --path-traversals is"
+grep "requires --traversals" error.txt
+is $? 0 "the problem is explained"
+
+vg snarls tiny.vg -e -m 5 -r /dev/null > /dev/null 2> warning.txt
+grep "ignored" warning.txt
+is $? 0 "warning about ignoring is given"
+
+rm -f tiny.vg tiny.exhaustive.trav.sort tiny.exhaustive.trav tiny.vcf.trav.sort tiny.vcf.trav error.txt warning.txt
 
 # vcf alt traversals on an inversion
 vg construct -Saf -v sv/x.inv.vcf -r sv/x.fa > x.inv.vg
@@ -56,7 +92,17 @@ vg view -E x.inv.vcf.trav | sort > x.inv.vcf.trav.sort
 diff x.inv.exhaustive.trav.sort x.inv.vcf.trav.sort
 is $? 0 "vcf traversals are the same as exhaustive traversals for inversion"
 
-rm -f x.inv.vg x.inv.exhaustive.trav.sort x.inv.exhaustive.trav x.inv.vcf.trav.sort x.inv.vcf.trav
+vg snarls x.inv.vg -a -r x.inv.vcf.trav -f sv/x.fa > /dev/null 2> error.txt
+is $? 1 "vg snarls requires --vcf to be given if --fasta is"
+grep "requires --vcf" error.txt
+is $? 0 "the problem is explained"
+
+vg snarls x.inv.vg -a -r x.inv.vcf.trav -i sv/x.fa > /dev/null 2> error.txt
+is $? 1 "vg snarls requires --vcf to be given if --ins-fasta is"
+grep "requires --vcf" error.txt
+is $? 0 "the problem is explained"
+
+rm -f x.inv.vg x.inv.exhaustive.trav.sort x.inv.exhaustive.trav x.inv.vcf.trav.sort x.inv.vcf.trav error.txt
 
 # vcf alt traversals on ins_and_del
 vg construct -Saf -v ins_and_del/ins_and_del.vcf.gz -r ins_and_del/ins_and_del.fa > ins_and_del.vg


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg snarls --traversals` related helptext improved and useful errors added
 * `vg snarls --pathnames` option removed (didn't really work)

## Description

Should resolve #4957 by reorganizing the helptext to make it clearer which options do what, and by adding a bunch of errors to slap you if you seem to be trying to do something which doesn't actually work.