### PR TITLE
Make `vg augment` warning about nameless paths into an error instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,12 @@ vg index -x x.xg -g x.gcsa -k 16 x.vg
 
 # align a read to the indexed version of the graph
 # note that the graph file is not opened, but x.vg.index is assumed
-vg map --seq-name read -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa > read.gam
+vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa > read.gam
 
 # simulate a bunch of 150bp reads from the graph, one per line
-vg sim -n 1000 -l 150 -x x.xg > x.sim.txt
+vg sim -n 1000 -l 150 -x x.xg --fastq-out > x.sim.fq
 # now map these reads against the graph to get a GAM
-vg map -T x.sim.txt -x x.xg -g x.gcsa > aln.gam
+vg map -f x.sim.fq -x x.xg -g x.gcsa > aln.gam
 
 # surject the alignments back into the reference space of sequence "x", yielding a BAM file
 vg surject -x x.xg -b aln.gam > aln.bam

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ vg index -x x.xg -g x.gcsa -k 16 x.vg
 
 # align a read to the indexed version of the graph
 # note that the graph file is not opened, but x.vg.index is assumed
-vg map -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa > read.gam
+vg map --seq-name read -s CTACTGACAGCAGAAGTTTGCTGTGAAGATTAAATTAGGTGATGCTTG -x x.xg -g x.gcsa > read.gam
 
 # simulate a bunch of 150bp reads from the graph, one per line
 vg sim -n 1000 -l 150 -x x.xg > x.sim.txt

--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -303,7 +303,9 @@ void augment_impl(MutablePathMutableHandleGraph* graph,
                                              added_nodes, orig_node_sizes);
 
             if (aln.name() == "") {
-                cerr << "warning[augment] embedding a path with no name; downstream operations may fail." << endl;
+                cerr << "error[augment] attempting to embed a path with no name; "
+                     << "make sure all items (alignments, annotations) are named" << endl;
+                exit(1);
             }
 
             // Copy over the name

--- a/src/transcriptome.cpp
+++ b/src/transcriptome.cpp
@@ -2156,6 +2156,7 @@ void Transcriptome::augment_graph(const list<EditedTranscriptPath> & edited_tran
         for (auto & transcript_path: edited_transcript_paths) {
 
             exon_boundary_paths.emplace_back(transcript_path.path);
+            exon_boundary_paths.back().set_name(transcript_path.get_name() + "_splice");
         }
 
     } else {
@@ -2177,6 +2178,7 @@ void Transcriptome::augment_graph(const list<EditedTranscriptPath> & edited_tran
                     exon_boundary_paths.emplace_back(Path());
                     *(exon_boundary_paths.back().add_mapping()) = mapping; 
                     exon_boundary_paths.back().mutable_mapping(0)->set_rank(1);
+                    exon_boundary_paths.back().set_name(transcript_path.get_name() + "_exon_boundary");
 
                     // Remove if already added.
                     if (!exon_boundary_mapping_index.emplace(exon_boundary_paths.back().mapping(0)).second) {

--- a/src/unittest/haplotypes.cpp
+++ b/src/unittest/haplotypes.cpp
@@ -385,7 +385,7 @@ TEST_CASE("We can score haplotypes using GBWT", "[haplo-score][gbwt]") {
   delete gbwt_index;
 }
 
-TEST_CASE("We can recognize a required crossover", "[hapo-score][gbwt]") {
+TEST_CASE("We can recognize a required crossover", "[haplo-score][gbwt]") {
   // This graph is the start of xy2 from test/small
   string graph_json = R"({"node": [{"id": 1, "sequence": "CAAATAAGGCTT"}, {"id": 2, "sequence": "G"}, {"id": 3, "sequence": "GGAAATTTTC"}, {"id": 4, "sequence": "C"}, {"id": 5, "sequence": "TGGAGTTCTATTATATTCC"}, {"id": 6, "sequence": "G"}, {"id": 7, "sequence": "A"}, {"id": 8, "sequence": "ACTCTCTGGTTCCTG"}, {"id": 9, "sequence": "A"}, {"id": 10, "sequence": "G"}, {"id": 11, "sequence": "TGCTATGTGTAACTAGTAATGGTAATGGATATGTTGGGCTTTTTTCTTTGATTTATTTGAAGTGACGTTTGACAATCTATCACTAGGGGTAATGTGGGGAAATGGAAAGAATACAAGATTTGGAGCCA"}], "edge": [{"from": 1, "to": 2}, {"from": 1, "to": 3}, {"from": 2, "to": 3}, {"from": 3, "to": 4}, {"from": 3, "to": 5}, {"from": 4, "to": 5}, {"from": 5, "to": 6}, {"from": 5, "to": 7}, {"from": 6, "to": 8}, {"from": 7, "to": 8}, {"from": 8, "to": 9}, {"from": 8, "to": 10}, {"from": 9, "to": 11}, {"from": 10, "to": 11}]})";
 

--- a/test/pileup/edit.json
+++ b/test/pileup/edit.json
@@ -1,1 +1,1 @@
-{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"name": "seq1", "sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}

--- a/test/pileup/edits.json
+++ b/test/pileup/edits.json
@@ -1,12 +1,12 @@
-{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
-{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
-{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
-{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
-{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
-{"sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
-{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
-{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
-{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
-{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
-{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
-{"sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"name": "seq1", "sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"name": "seq2", "sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"name": "seq3", "sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"name": "seq4", "sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"name": "seq5", "sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"name": "seq6", "sequence": "AAATTTTCTTGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 9, "to_length": 9},{"from_length": 1, "to_length": 1, "sequence": "T"},{"from_length": 9, "to_length": 9}]}]}}
+{"name": "seq7", "sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"name": "seq8", "sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"name": "seq9", "sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"name": "seq10", "sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"name": "seq11", "sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}
+{"name": "seq12", "sequence": "AAATTTTCTGGAGTTCTAT", "path": {"mapping": [{"rank": 1, "position": {"node_id": 9}, "edit": [{"from_length": 19, "to_length": 19}]}]}}

--- a/test/t/04_vg_align.t
+++ b/test/t/04_vg_align.t
@@ -37,7 +37,7 @@ is $(vg align -js GGCTATGTCTGAACTAGGAGGGTAGAAAGAATATTCATTTTGGTTGCCACAAACCATCGAAA
 
 vg construct -m 1000 -r tiny/tiny.fa >t.vg
 seq=CAAATAAGGCTTGGAAATGTTCTGGAGTTCTATTATATTCCAACTCTCTT
-vg align -s $seq t.vg | vg augment t.vg - -i -S >t2.vg
+vg align -s $seq -Q first t.vg | vg augment t.vg - -i -S >t2.vg
 is $(vg align -s $seq -Q query t2.vg | vg augment t2.vg - -i -B -S | vg view - | grep "query" | cut -f 3 | grep -o "[0-9]\+" | wc -l) 4 "align can use query names and outputs GAM"
 rm t.vg t2.vg
 

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -12,19 +12,19 @@ vg view -J -v pileup/tiny.json > tiny.vg
 
 # Make sure well-supported edits are augmented in
 vg view -J -a -G pileup/edits.json > edits.gam
-vg augment -a direct tiny.vg edits.gam -A edits-embedded.gam > augmented.vg
+vg augment tiny.vg edits.gam -A edits-embedded.gam > augmented.vg
 
 # We want 3 edits with no sequence per read, and we have 12 reads in this file.
 is "$(vg view -aj edits-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "36" "direct augmentation embeds reads fully for well-supported SNPs"
 is "$(vg stats -N augmented.vg)" "18" "adding a well-supported SNP by direct augmentation adds 3 more nodes"
 
 # Run again but with packed logic.  output should be identical with min threshold of 1
-vg augment -a direct tiny.vg edits.gam -A edits-embedded.gam -m 1 > augmented.m1.vg
+vg augment tiny.vg edits.gam -A edits-embedded.gam -m 1 > augmented.m1.vg
 is "$(vg stats -N augmented.m1.vg)" "18" "adding a well-supported SNP by direct augmentation adds 3 more nodes with -m 1"
 
 # run again but with GAF
 vg convert tiny.vg -G edits.gam > edits.gaf
-vg augment -a direct tiny.vg edits.gaf -F -A edits-embedded.gaf > augmented.gaf.vg
+vg augment tiny.vg edits.gaf -F -A edits-embedded.gaf > augmented.gaf.vg
 vg convert augmented.gaf.vg -F edits-embedded.gaf > edits-embedded.gaf.gam
 is "$(vg view -aj edits-embedded.gaf.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "36" "direct augmentation embeds with GAF reads fully for well-supported SNPs"
 is "$(vg stats -N augmented.gaf.vg)" "18" "adding a well-supported SNP by direct augmentation with GAF adds 3 more nodes"
@@ -33,7 +33,7 @@ rm -f edits.gam edits-embedded.gam augmented.vg augmented.m1.vg edits.gaf edits-
 
 # Make sure every edit is augmented in
 vg view -J -a -G pileup/edit.json > edit.gam
-vg augment -a direct tiny.vg edit.gam -A edit-embedded.gam > augmented.vg
+vg augment tiny.vg edit.gam -A edit-embedded.gam > augmented.vg
 
 # This file only has one read.
 is "$(vg view -aj edit-embedded.gam | jq -c '.path.mapping[].edit[].sequence' | grep null | wc -l)" "3" "direct augmentation embeds reads fully for probable errors"

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 PATH=../bin:$PATH # for vg
 
 
-plan tests 39
+plan tests 41
 
 vg view -J -v pileup/tiny.json > tiny.vg
 
@@ -48,6 +48,11 @@ rm -f tiny.vg
 vg construct -m 1000 -r tiny/tiny.fa >t.vg
 vg index -k 11 -g t.idx.gcsa -x t.idx.xg t.vg
 
+vg map -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i > /dev/null 2> error.txt
+is $? 1 "not allowed to augment with a nameless path"
+grep "attempting to embed a path with no name" error.txt
+is $? 0 "problem is explained"
+
 is $(vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | wc -l) 1 "path inclusion does not modify the graph when alignment is a perfect match"
 
 is $(vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTAATATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i -m 2 | vg view - | grep ^S | wc -l) 1 "path inclusion does not modify the graph when alignment has a SNP but doesnt meet the coverage threshold"
@@ -64,7 +69,7 @@ is $(vg map --seq-name seq -s CAAAAAGGCTTGGAAAGGGTTTCTGGAGTTCTATTATATTCCAACTCTCT
 is $(vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTTCTGCAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | wc -l) 4 "SNPs can be included in the graph"
 
 rm t.vg
-rm -rf t.idx.xg t.idx.gcsa read_aug.gam
+rm -rf t.idx.xg t.idx.gcsa read_aug.gam error.txt
 
 vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa >t.vg
 vg align --seq-name seq -s GGGGGGGAAATTTTCTGGAGTTCTATTATATTCCAAAAAAAAAA t.vg >t.gam

--- a/test/t/17_vg_augment.t
+++ b/test/t/17_vg_augment.t
@@ -48,29 +48,29 @@ rm -f tiny.vg
 vg construct -m 1000 -r tiny/tiny.fa >t.vg
 vg index -k 11 -g t.idx.gcsa -x t.idx.xg t.vg
 
-is $(vg map -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | wc -l) 1 "path inclusion does not modify the graph when alignment is a perfect match"
+is $(vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | wc -l) 1 "path inclusion does not modify the graph when alignment is a perfect match"
 
-is $(vg map -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTAATATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i -m 2 | vg view - | grep ^S | wc -l) 1 "path inclusion does not modify the graph when alignment has a SNP but doesnt meet the coverage threshold"
+is $(vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTAATATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i -m 2 | vg view - | grep ^S | wc -l) 1 "path inclusion does not modify the graph when alignment has a SNP but doesnt meet the coverage threshold"
 
-is $(vg map -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTAATATATTCCAACTCTCTG -V read -d t.idx | vg augment t.vg - -i -m 2 -A read_aug.gam | vg view - | grep ^P | awk '{print $3}' | uniq) "1+" "path inclusion does not modify the included path when alignment has a SNP but doesnt meet the coverage threshold"
+is $(vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTTCTGGAGTTCTAATATATTCCAACTCTCTG -V read -d t.idx | vg augment t.vg - -i -m 2 -A read_aug.gam | vg view - | grep ^P | awk '{print $3}' | uniq) "1+" "path inclusion does not modify the included path when alignment has a SNP but doesnt meet the coverage threshold"
 
 is $(vg view -a read_aug.gam | jq . | grep edit | wc -l) 1 "output GAM has single edit when SNP was filtered out due to coverage"
 
-is $(vg map -s CAAATAAGGCTTGGAAAGGGTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | wc -l) 5 "path inclusion with a complex variant introduces the right number of nodes"
+is $(vg map --seq-name seq -s CAAATAAGGCTTGGAAAGGGTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | wc -l) 5 "path inclusion with a complex variant introduces the right number of nodes"
 
 # checks that we get a node with the id 4, which is the ref-matching dual to the deletion
-is $(vg map -s CAAAAAGGCTTGGAAAGGGTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | grep 4 | grep T | wc -l) 1 "path inclusion works for deletions"
+is $(vg map --seq-name seq -s CAAAAAGGCTTGGAAAGGGTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | grep 4 | grep T | wc -l) 1 "path inclusion works for deletions"
 
-is $(vg map -s CAAATAAGGCTTGGAAATTTTCTGCAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | wc -l) 4 "SNPs can be included in the graph"
+is $(vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTTCTGCAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -i | vg view - | grep ^S | wc -l) 4 "SNPs can be included in the graph"
 
 rm t.vg
 rm -rf t.idx.xg t.idx.gcsa read_aug.gam
 
 vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa >t.vg
-vg align -s GGGGGGGAAATTTTCTGGAGTTCTATTATATTCCAAAAAAAAAA t.vg >t.gam
+vg align --seq-name seq -s GGGGGGGAAATTTTCTGGAGTTCTATTATATTCCAAAAAAAAAA t.vg >t.gam
 is $(vg augment -i -S t.vg t.gam | vg view - | grep ^S | grep $(vg augment -i -S t.vg t.gam | vg stats  -H - | awk '{ print $3}') | cut -f 3) GGGGG "a soft clip at read start becomes a new head of the graph"
 is $(vg augment -i -S t.vg t.gam | vg view - | grep ^S | grep $(vg augment -i -S t.vg t.gam | vg stats  -T - | awk '{ print $3}') | cut -f 3) AAAAAAAA "a soft clip at read end becomes a new tail of the graph"
-vg align -s AAATTTTCTGGAGTTCTAT t.vg >> t.gam
+vg align --seq-name seq -s AAATTTTCTGGAGTTCTAT t.vg >> t.gam
 vg find -x t.vg -n 9 -c 1 > n9.vg
 vg augment n9.vg t.gam -s -A n9_aug.gam > /dev/null
 is $(vg view -a n9_aug.gam | wc -l) "1" "augment -s works as desired"
@@ -137,69 +137,69 @@ vg index -k 11 -g t.idx.gcsa -x t.idx.xg t.vg
 vg view t.vg | grep ^S | awk '{print $3}' | sort > t.nodes
 ( vg view t.vg | grep ^S | awk '{print $3}' ; echo "GGNGG" ) | sort > t.aug.nodes
 
-vg map -s CAAATAAGGCTTGGAAATTTGGNGGTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.aug1.vg
+vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTGGNGGTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.aug1.vg
 vg view t.aug1.vg | grep ^S | awk '{print $3}' | sort > t.aug1.nodes
 diff t.aug1.nodes t.aug.nodes
 is "$?" 0 "augmenting between nodes without filters works as expected"
 
-vg map -s CAAATAAGGCTTGGAAATTTGGNGGTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.aug1f.vg
+vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTGGNGGTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.aug1f.vg
 vg view t.aug1f.vg | grep ^S | awk '{print $3}' | sort > t.aug1f.nodes
 diff t.aug1f.nodes t.aug.nodes
 is "$?" 0 "augmenting between nodes with inactive filters works as expected"
 
-vg map -s CAAATAAGGCTTGGAAATTTGGNGGTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.1 > t.aug1nf.vg
+vg map --seq-name seq -s CAAATAAGGCTTGGAAATTTGGNGGTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.1 > t.aug1nf.vg
 vg view t.aug1nf.vg | grep ^S | awk '{print $3}' | sort > t.aug1nf.nodes
 diff t.aug1nf.nodes t.nodes
 is "$?" 0 "augmenting between nodes N filter works as expected"
 
 rm -f t.aug1.vg t.aug1.nodes t.aug1f.vg t.aug1f.nodes t.aug1nf.vg t.aug1nf.nodes
 
-vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGACCNCCAAATTTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.augr1.vg
+vg map --seq-name seq -s CAGAGAGTTGGAATATAATAGAACTCCAGACCNCCAAATTTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.augr1.vg
 vg view t.augr1.vg | grep ^S | awk '{print $3}' | sort > t.augr1.nodes
 diff t.augr1.nodes t.aug.nodes
 is "$?" 0 "augmenting between nodes without filters works as expected on reverse strand"
 
-vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGACCNCCAAATTTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.augr1f.vg
+vg map --seq-name seq -s CAGAGAGTTGGAATATAATAGAACTCCAGACCNCCAAATTTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.augr1f.vg
 vg view t.augr1f.vg | grep ^S | awk '{print $3}' | sort > t.augr1f.nodes
 diff t.augr1f.nodes t.aug.nodes
 is "$?" 0 "augmenting between nodes with inactive filters works as expected on reverse strand"
 
-vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGACCNCCAAATTTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.1 > t.augr1nf.vg
+vg map --seq-name seq -s CAGAGAGTTGGAATATAATAGAACTCCAGACCNCCAAATTTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.1 > t.augr1nf.vg
 vg view t.augr1nf.vg | grep ^S | awk '{print $3}' | sort > t.augr1nf.nodes
 diff t.augr1nf.nodes t.nodes
 is "$?" 0 "augmenting between nodes N filter works as expected on reverse strand"
 
 rm -f t.augr1.vg t.augr1.nodes t.augr1f.vg t.augr1f.nodes t.augr1nf.vg t.augr1nf.nodes
 
-vg map -s CAAATAAGGCTTGGAGGNGGAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.aug1.vg
+vg map --seq-name seq -s CAAATAAGGCTTGGAGGNGGAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.aug1.vg
 is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 1 "augmenting within node without filters works as expected"
 
-vg map -s CAAATAAGGCTTGGAGGNGGAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.aug1.vg
+vg map --seq-name seq -s CAAATAAGGCTTGGAGGNGGAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.aug1.vg
 is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 1 "augmenting within node with inactive filters works as expected"
 
-vg map -s CAAATAAGGCTTGGAGGNGGAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.1  > t.aug1.vg
+vg map --seq-name seq -s CAAATAAGGCTTGGAGGNGGAATTTTCTGGAGTTCTATTATATTCCAACTCTCTG -d t.idx | vg augment t.vg - -N 0.1  > t.aug1.vg
 is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 0 "augmenting within node with N filter  works as expected"
 
 rm -f t.aug.nodes t.aug1.vg t.aug1.nodes t.aug1f.vg t.aug1f.nodes t.aug1nf.vg t.aug1nf.nodes
 
-vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTCCNCCTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.aug1.vg
+vg map --seq-name seq -s CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTCCNCCTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 1 -m 0 > t.aug1.vg
 is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 1 "augmenting within node without filters works as expected on reverse strand"
 
-vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTCCNCCTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.aug1.vg
+vg map --seq-name seq -s CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTCCNCCTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.5 -m 1 > t.aug1.vg
 is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 1 "augmenting within node with inactive filters works as expected on reverse strand"
 
-vg map -s CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTCCNCCTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.1  > t.aug1.vg
+vg map --seq-name seq -s CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTCCNCCTCCAAGCCTTATTTG -d t.idx | vg augment t.vg - -N 0.1  > t.aug1.vg
 is $(vg view t.aug1.vg | grep ^S | awk '{print $3}' | grep ^GGNGG | wc -l) 0 "augmenting within node with N filter  works as expected on reverse strand"
 
 rm -f t.augr1.vg t.augr1.nodes t.augr1f.vg t.augr1f.nodes t.augr1nf.vg t.augr1nf.nodes
 
-vg map -s CAAATANNNAGGCTTGGAAATTTTCTGGAGTTCTATTATATNNNNNTCCAACTCTCTG -d t.idx > t.gam
+vg map --seq-name seq -s CAAATANNNAGGCTTGGAAATTTTCTGGAGTTCTATTATATNNNNNTCCAACTCTCTG -d t.idx > t.gam
 vg augment t.vg t.gam -N 0.5 -A t.aug1.gam > t.aug1.vg
 is $(vg view -a t.aug1.gam | jq -c '.sequence' | sed 's/\"//g') $(tail -1 tiny/tiny.fa) "sequence in filtered alignment has removed insertion"
 
 rm -f t.gam t.aug1.gam t.aug1.vg
 
-vg map -s CAGAGAGTTGGANNNNNATATAATAGAACTCCAGAAAATTTCCAAGCCTNNNTATTTG -d t.idx > t.gam
+vg map --seq-name seq -s CAGAGAGTTGGANNNNNATATAATAGAACTCCAGAAAATTTCCAAGCCTNNNTATTTG -d t.idx > t.gam
 vg augment t.vg t.gam -N 0.5 -A t.aug1.gam > t.aug1.vg
 is $(vg view -a t.aug1.gam | jq -c '.sequence' | sed 's/\"//g') CAGAGAGTTGGAATATAATAGAACTCCAGAAAATTTCCAAGCCTTATTTG "sequence in filtered alignment has removed insertion on reverse strand"
 


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg augment -i` <strike>warns</strike> errors when it is told to embed a path without a name

## Description

Per discussion in #4984 I swapped this to an error.