### PR TITLE
surject: classify disjoint interval alignments

### DIFF
--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -5251,9 +5251,10 @@ using namespace std;
         size_t curr_interval_strict_right_bound = -1;
         for (const auto& chunk_interval : chunk_intervals) {
             
-            // check for sufficient separation to start a new supplementary using the directly attested intervals
+            // Preserve sufficiently separated reference regions as distinct alignment
+            // candidates; supplementary reporting is decided after alignment.
             if (disjoint_path_intervals.empty() ||
-                (report_supplementary && curr_interval_strict_right_bound + max_gap + 1 < get<0>(chunk_interval))) {
+                curr_interval_strict_right_bound + max_gap + 1 < get<0>(chunk_interval)) {
                 // make new interval
                 curr_interval_strict_right_bound = get<1>(chunk_interval);
                 disjoint_path_intervals.emplace_back(get<2>(chunk_interval), get<3>(chunk_interval),

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -282,17 +282,29 @@ using namespace std;
         template<class AlnType>
         string path_score_annotations(const unordered_map<pair<path_handle_t, bool>, vector<pair<AlnType, pair<step_handle_t, step_handle_t>>>>& surjections) const;
         
-        // helpers to choose one among supplementary alignments to be the primary
+        // helpers to choose one alignment as primary and classify the alternatives
+        /// Select the highest-scoring surjection as primary.
+        ///
+        /// Non-primary surjections that overlap the primary's query interval by more
+        /// than disjoint_interval_allowable_overlap are retained as secondary.
+        /// Disjoint surjections are retained as supplementary when
+        /// report_supplementary is enabled and are otherwise omitted.
+        ///
+        /// Modifies surjections in place by annotating retained alternatives and
+        /// removing supplementaries that were not requested.
         template<class AlnType>
         void choose_primary_internal(vector<pair<AlnType, pair<step_handle_t, step_handle_t>>>& surjections,
-                                     const function<void(AlnType&)>& annotate_supplementary) const;
+                                     const function<void(AlnType&)>& annotate_supplementary,
+                                     const function<void(AlnType&)>& annotate_secondary) const;
         void choose_primary(vector<pair<Alignment, pair<step_handle_t, step_handle_t>>>& surjections) const {
             function<void(Alignment&)> annotate_supplementary = [](Alignment& aln) { set_annotation<bool>(aln, "supplementary", true); };
-            choose_primary_internal(surjections, annotate_supplementary);
+            function<void(Alignment&)> annotate_secondary = [](Alignment& aln) { aln.set_is_secondary(true); };
+            choose_primary_internal(surjections, annotate_supplementary, annotate_secondary);
         }
         void choose_primary(vector<pair<multipath_alignment_t, pair<step_handle_t, step_handle_t>>>& surjections) const {
             function<void(multipath_alignment_t&)> annotate_supplementary = [](multipath_alignment_t& mp_aln) { mp_aln.set_annotation("supplementary", true); };
-            choose_primary_internal(surjections, annotate_supplementary);
+            function<void(multipath_alignment_t&)> annotate_secondary = [](multipath_alignment_t& mp_aln) { mp_aln.set_annotation("secondary", true); };
+            choose_primary_internal(surjections, annotate_supplementary, annotate_secondary);
         }
         
         vector<tuple<Alignment, size_t, size_t>> generate_hard_clipped_alignments(const Alignment& source) const;
@@ -452,7 +464,8 @@ using namespace std;
 
     template<class AlnType>
     void Surjector::choose_primary_internal(vector<pair<AlnType, pair<step_handle_t, step_handle_t>>>& surjections,
-                                            const function<void(AlnType&)>& annotate_supplementary) const {
+                                            const function<void(AlnType&)>& annotate_supplementary,
+                                            const function<void(AlnType&)>& annotate_secondary) const {
         if (surjections.size() > 1) {
             size_t opt_idx = 0;
             int32_t opt_score = get_score(surjections.front().first);
@@ -463,10 +476,29 @@ using namespace std;
                     opt_idx = i;
                 }
             }
-            
-            for (size_t i = 0; i < surjections.size(); ++i) {
-                if (i != opt_idx) {
+
+            const auto best_interval = aligned_interval(surjections[opt_idx].first);
+
+            // Iterate backward so supplementaries can be removed safely.
+            for (size_t i = surjections.size(); i-- > 0;) {
+                if (i == opt_idx) {
+                    continue;
+                }
+                // Compare query coverage
+                const auto interval = aligned_interval(surjections[i].first);
+                const int64_t query_overlap = max<int64_t>(
+                    0,
+                    min(best_interval.second, interval.second)
+                    - max(best_interval.first, interval.first));
+
+                if (query_overlap > disjoint_interval_allowable_overlap) {
+                    annotate_secondary(surjections[i].first);
+                }
+                else if (report_supplementary) {
                     annotate_supplementary(surjections[i].first);
+                }
+                else {
+                    surjections.erase(surjections.begin() + i);
                 }
             }
         }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg surject -u` related changes 

## Description

- discover separated surjection intervals independently of supplementary option
- classify non-best alignments with more than 4 bp of query overlap as secondary
- emit supplementary alignments only when requested

## Motivation

Interval discovery was conditional on supplementary reporting, coupling alignment
candidate generation to output selection. This separates those decisions and
classifies the resulting alignments according to their query overlap. Before, alignments 
to distant but similar regions on the same path, such as segmental duplications 
merged unless -u was used. When separated, every non-best alignment was labeled 
supplementary, even if it covered the same part of the read and was really an alternative 
mapping. Now, distant regions are always evaluated separately. A non-best alignment 
overlapping the best by more than 4 bp of the read is secondary; a mostly disjoint alignment 
is supplementary and emitted only with -u.