### PR TITLE
Diploid map long read changes

### DIFF
--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -41,7 +41,8 @@ void help_surject(char** argv) {
          << "  -x, --xg-name FILE        use this graph or XG index (required)" << endl
          << "  -t, --threads N           number of threads to use" << endl
          << "  -d, --diploid-map NAME    like --into-ref, but also turns on --multimap and" << endl
-         << "                            emits hp/hq/aq tags for haplotype-aware diploid surjection" << endl
+         << "                            emits hp/hq/aq tags for haplotype-aware" << endl
+         << "                            diploid surjection" << endl
          << "  -D, --read-length TYPE    read length preset: {short, long}" << endl
          << "  -p, --into-path NAME      surject into this path or its subpaths (may repeat)" << endl
          << "                            default: reference, then non-alt generic" << endl

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -40,6 +40,8 @@ void help_surject(char** argv) {
          << "options:" << endl
          << "  -x, --xg-name FILE        use this graph or XG index (required)" << endl
          << "  -t, --threads N           number of threads to use" << endl
+         << "  -d, --diploid-map NAME    like --into-ref, but also turns on --multimap and" << endl
+         << "                            emits hp/hq/aq tags for haplotype-aware diploid surjection" << endl
          << "  -D, --read-length TYPE    read length preset: {short, long}" << endl
          << "  -p, --into-path NAME      surject into this path or its subpaths (may repeat)" << endl
          << "                            default: reference, then non-alt generic" << endl
@@ -165,6 +167,7 @@ int main_surject(int argc, char** argv) {
     string input_format = "GAM";
     bool spliced = false;
     bool interleaved = false;
+    bool diploid_map = false;
     string sample_name;
     string read_group;
     int32_t max_frag_len = 0;
@@ -208,6 +211,7 @@ int main_surject(int argc, char** argv) {
             {"max-tail-len", required_argument, 0, 'T'},
             {"max-graph-scale", required_argument, 0, 'g'},
             {"interleaved", no_argument, 0, 'i'},
+            {"diploid-map", required_argument, 0, 'd'},
             {"multimap", no_argument, 0, 'M'},
             {"gaf-input", no_argument, 0, 'G'},
             {"gamp-input", no_argument, 0, 'm'},
@@ -239,7 +243,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuBN:R:f:C:t:D:SPjI:a:AE:LHMVw:r",
+        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuBN:R:f:C:t:D:d:SPjI:a:AE:LHMVw:r",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -314,6 +318,12 @@ int main_surject(int argc, char** argv) {
             left_align = true;
             break;
                 
+        case 'd':
+            reference_assembly_names.insert(optarg);
+            diploid_map = true;
+            multimap = true;
+            break;
+
         case 'D':
             read_length = optarg;
             break;
@@ -718,16 +728,88 @@ int main_surject(int argc, char** argv) {
                     report_exception(ex);
                 }
             };
+
+            // For --diploid-map, all graph placements sharing a read name (the
+            // primary placement plus any secondaries already in the input) need
+            // to be surjected and compared together, so that haplotype quality
+            // and the single overall primary are chosen across all of them, not
+            // independently per input record.
+            std::function<void(std::vector<Alignment>&)> set_lambda = [&](std::vector<Alignment>& placements) {
+                try {
+                    if (placements.empty()) {
+                        return;
+                    }
+
+                    set_crash_context(placements.front().name());
+                    size_t thread_num = omp_get_thread_num();
+                    if (watchdog) {
+                        watchdog->check_in(thread_num, placements.front().name());
+                    }
+
+                    vector<Alignment> all_surjected;
+                    all_surjected.reserve(placements.size() * 2);
+
+                    for (auto& placement : placements) {
+                        if (validate) {
+                            ensure_alignment_is_for_graph(logger, placement, *xgidx);
+                        }
+                        set_metadata(placement);
+
+                        // multimap_to_all_paths is forced on for diploid mode, so this
+                        // already returns one surjection per overlapping haplotype path
+                        // for this one graph placement.
+                        vector<Alignment> surjected = surjector.surject(placement, paths, subpath_global, spliced);
+
+                        // Assign hp/hq by comparing this graph placement's
+                        // haplotype-path surjections with each other.
+                        surjector.annotate_hap_tags(placement, surjected);
+
+                        all_surjected.insert(all_surjected.end(),
+                                             std::make_move_iterator(surjected.begin()),
+                                             std::make_move_iterator(surjected.end()));
+                    }
+
+                    // Global Quality and single overall primary, chosen across every
+                    // haplotype-path surjection from every graph placement pooled
+                    // together.
+                    surjector.annotate_global_mapq_and_primary(placements.front(), all_surjected);
+
+                    alignment_emitter->emit_singles(std::move(all_surjected));
+                    total_reads_surjected++;
+
+                    if (watchdog) {
+                        watchdog->check_out(thread_num);
+                    }
+                    clear_crash_context();
+                } catch (const std::exception& ex) {
+                    report_exception(ex);
+                }
+            };
+
             if (input_format == "GAM") {
                 get_input_file(file_name, [&](istream& in) {
-                    vg::io::for_each_parallel<Alignment>(in,lambda);
+                    if (diploid_map) {
+                        vg::io::gam_grouped_for_each_parallel(in, set_lambda);
+                    } else {
+                        vg::io::for_each_parallel<Alignment>(in, lambda);
+                    }
                 });
             } else {
-                auto gaf_checking_lambda = [&](Alignment& src) {
-                    check_gaf_aln(src);
-                    return lambda(src);
-                };
-                vg::io::gaf_unpaired_for_each_parallel(*xgidx, file_name, gaf_checking_lambda);
+                if (diploid_map) {
+                    std::function<void(std::vector<Alignment>&)> gaf_set_lambda = [&](std::vector<Alignment>& placements) {
+                        for (auto& p : placements) {
+                            check_gaf_aln(p);
+                        }
+                        set_lambda(placements);
+                    };
+                    vg::io::gaf_grouped_for_each_parallel(*xgidx, file_name, gaf_set_lambda);
+                } else {
+                    auto gaf_checking_lambda = [&](Alignment& src) {
+                        check_gaf_aln(src);
+                        return lambda(src);
+                    };
+                    vg::io::gaf_unpaired_for_each_parallel(*xgidx, file_name, gaf_checking_lambda);
+                }
             }
         }
     } else if (input_format == "GAMP") {

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -67,6 +67,8 @@ void help_surject(char** argv) {
          << "  -P, --prune-low-cplx      prune short/low complexity anchors in realignment" << endl
          << "                            (on by default for long reads)" << endl
          << "      --no-prune-low-cplx   disable anchor pruning" << endl
+         << "  -j, --prune-tail-region   prune anchors lying fully inside mapper-declared" << endl
+         << "                            tail regions" << endl
          << "  -I, --max-slide N         look for offset duplicates of anchors up to N bp" << endl
          << "                            away when pruning "
                                      << "(default: " << Surjector::DEFAULT_MAX_SLIDE << ")" << endl
@@ -187,6 +189,7 @@ int main_surject(int argc, char** argv) {
     bool validate = true;
     bool show_progress = false;
     bool left_align = false;
+    bool prune_tail_region = false;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -218,6 +221,7 @@ int main_surject(int argc, char** argv) {
             {"spliced", no_argument, 0, 'S'},
             {"prune-low-cplx", no_argument, 0, 'P'},
             {"no-prune-low-cplx", no_argument, 0, OPT_NO_PRUNE_LOW_CPLX},
+            {"prune-tail-region", no_argument, 0, 'j'},
             {"max-slide", required_argument, 0, 'I'},
             {"max-anchors", required_argument, 0, 'a'},
             {"qual-adj", no_argument, 0, 'A'},
@@ -235,7 +239,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuBN:R:f:C:t:D:SPI:a:AE:LHMVw:r",
+        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuBN:R:f:C:t:D:SPjI:a:AE:LHMVw:r",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -324,6 +328,10 @@ int main_surject(int argc, char** argv) {
 
         case OPT_NO_PRUNE_LOW_CPLX: // --no-prune-low-cplx
             prune_anchors = false;
+            break;
+
+        case 'j':
+            prune_tail_region = true; //remove surject anchors from tails
             break;
 
         case 'I':
@@ -482,6 +490,7 @@ int main_surject(int argc, char** argv) {
                                        default_full_length_bonus); 
     }
     surjector.prune_suspicious_anchors = *prune_anchors;
+    surjector.prune_tail_region_anchors = prune_tail_region;
     surjector.max_slide = max_slide;
     surjector.max_anchors = max_anchors;
     if (spliced) {

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -23,6 +23,8 @@
 
 #include "bdsg/hash_graph.hpp"
 
+#include <numeric>
+
 // #define debug_spliced_surject
 // #define debug_anchored_surject
 // #define debug_multipath_surject
@@ -115,6 +117,184 @@ using namespace std;
             dp_aligner.reset();
         }
         
+    }
+
+    int32_t Surjector::compute_mapping_quality_from_scores(
+        const Alignment& source,
+        const std::vector<double>& scores,
+        size_t best_idx,
+        bool fast_approximation) const {
+
+        if (scores.empty() || best_idx >= scores.size()) {
+            return 0;
+        }
+        if (scores.size() == 1) {
+            return 60;
+        }
+
+        // compute_first_mapping_quality scores the first candidate, so place
+        // the selected candidate first while preserving the other scores.
+        std::vector<double> reordered;
+        reordered.reserve(scores.size());
+        reordered.push_back(scores[best_idx]);
+
+        for (size_t i = 0; i < scores.size(); ++i) {
+            if (i != best_idx) {
+                reordered.push_back(scores[i]);
+            }
+        }
+
+        const GSSWAligner* aligner = get_aligner(!source.quality().empty());
+        return aligner->mapq_calc->compute_first_mapping_quality(
+            reordered, fast_approximation);
+    }
+
+    void Surjector::set_sam_tag_annotation(Alignment& aln,
+                                            const std::string& tag,
+                                            char type,
+                                            const std::string& value) {
+        std::string old_tags;
+        if (has_annotation(aln, "tags")) {
+            old_tags = get_annotation<std::string>(aln, "tags");
+        }
+
+        const std::string prefix = tag + ":";
+        std::string new_tags;
+
+        size_t begin = 0;
+        while (begin < old_tags.size()) {
+            size_t end = old_tags.find('\t', begin);
+            if (end == std::string::npos) {
+                end = old_tags.size();
+            }
+
+            const std::string token = old_tags.substr(begin, end - begin);
+            if (token.compare(0, prefix.size(), prefix) != 0) {
+                if (!new_tags.empty()) {
+                    new_tags.push_back('\t');
+                }
+                new_tags += token;
+            }
+
+            begin = end + 1;
+        }
+
+        if (!new_tags.empty()) {
+            new_tags.push_back('\t');
+        }
+        new_tags += tag + ":" + type + ":" + value;
+
+        set_annotation<std::string>(aln, "tags", new_tags);
+    }
+
+    void Surjector::annotate_hap_tags(
+        const Alignment& source,
+        std::vector<Alignment>& alns) const {
+
+        if (alns.empty()) {
+            return;
+        }
+
+        std::vector<double> scores;
+        std::vector<size_t> indices;
+        scores.reserve(alns.size());
+        indices.reserve(alns.size());
+
+        // Supplementary segments do not compete for haplotype assignment.
+        for (size_t i = 0; i < alns.size(); ++i) {
+            if (!is_supplementary(alns[i])) {
+                scores.push_back(alns[i].score());
+                indices.push_back(i);
+            }
+        }
+
+        if (indices.empty()) {
+            return;
+        }
+
+        std::vector<size_t> score_order(scores.size());
+        std::iota(score_order.begin(), score_order.end(), 0);
+        LazyRNG rng([&]() { return source.sequence(); });
+        sort_shuffling_ties(score_order.begin(), score_order.end(),
+                            [&](size_t a, size_t b) { return scores[a] > scores[b]; }, rng);
+        const size_t best_k = score_order.front();
+
+        const size_t best_i = indices[best_k];
+        int32_t hq = compute_mapping_quality_from_scores(
+            source, scores, best_k);
+        hq = std::max<int32_t>(0, std::min<int32_t>(60, hq));
+
+        for (size_t i : indices) {
+            set_sam_tag_annotation(
+                alns[i],
+                "hp",
+                'Z',
+                i == best_i ? "pri_hap" : "sec_hap");
+
+            set_sam_tag_annotation(
+                alns[i],
+                "hq",
+                'i',
+                std::to_string(hq));
+        }
+    }
+
+    void Surjector::annotate_global_mapq_and_primary(
+        const Alignment& source,
+        std::vector<Alignment>& alns) const {
+
+        if (alns.empty()) {
+            return;
+        }
+
+        std::vector<double> scores;
+        std::vector<size_t> indices;
+        scores.reserve(alns.size());
+        indices.reserve(alns.size());
+
+        // Supplementary segments do not compete for the overall primary.
+        for (size_t i = 0; i < alns.size(); ++i) {
+            if (!is_supplementary(alns[i])) {
+                scores.push_back(alns[i].score());
+                indices.push_back(i);
+            }
+        }
+
+        if (indices.empty()) {
+            return;
+        }
+
+        std::vector<size_t> score_order(scores.size());
+        std::iota(score_order.begin(), score_order.end(), 0);
+        LazyRNG rng([&]() { return source.sequence(); });
+        sort_shuffling_ties(score_order.begin(), score_order.end(),
+                            [&](size_t a, size_t b) { return scores[a] > scores[b]; }, rng);
+        const size_t best_k = score_order.front();
+
+        const size_t best_i = indices[best_k];
+
+        for (size_t i : indices) {
+            alns[i].set_is_secondary(i != best_i);
+        }
+
+        int32_t global_mapq = compute_mapping_quality_from_scores(
+            source, scores, best_k);
+        global_mapq = std::max<int32_t>(
+            0, std::min<int32_t>(60, global_mapq));
+
+        // The first grouped input record is the original Giraffe primary.
+        const int32_t alignment_quality = source.mapping_quality();
+        global_mapq = std::min(global_mapq, alignment_quality);
+
+        for (size_t i : indices) {
+            set_sam_tag_annotation(
+                alns[i],
+                "aq",
+                'i',
+                std::to_string(alignment_quality));
+
+            alns[i].set_mapping_quality(global_mapq);
+        }
     }
 
     vector<Alignment> Surjector::surject(const Alignment& source, const unordered_set<path_handle_t>& paths,
@@ -5872,5 +6052,3 @@ using namespace std;
         return return_val;
     }
 }
-
-

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -5306,9 +5306,10 @@ using namespace std;
         size_t curr_interval_strict_right_bound = -1;
         for (const auto& chunk_interval : chunk_intervals) {
             
-            // check for sufficient separation to start a new supplementary using the directly attested intervals
+            // Preserve sufficiently separated reference regions as distinct alignment
+            // candidates; supplementary reporting is decided after alignment.
             if (disjoint_path_intervals.empty() ||
-                (report_supplementary && curr_interval_strict_right_bound + max_gap + 1 < get<0>(chunk_interval))) {
+                curr_interval_strict_right_bound + max_gap + 1 < get<0>(chunk_interval)) {
                 // make new interval
                 curr_interval_strict_right_bound = get<1>(chunk_interval);
                 disjoint_path_intervals.emplace_back(get<2>(chunk_interval), get<3>(chunk_interval),

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -336,11 +336,30 @@ using namespace std;
         }
 #endif
         
-        // we want to remove anchors that can be error-prone: short anchors in the tails and anchors in
-        // low complexity sequences
+        // Read mapper-declared tail lengths. These coordinates are
+        // relative to the stored read sequence and independent of path orientation.
+        // Missing annotations remain zero, making tail-region pruning a no-op.
+        size_t left_tail_length = 0, right_tail_length = 0;
+        if (source_aln) {
+            if (has_annotation(*source_aln, "left_tail_length")) {
+                left_tail_length = static_cast<size_t>(get_annotation<double>(*source_aln, "left_tail_length"));
+            }
+            if (has_annotation(*source_aln, "right_tail_length")) {
+                right_tail_length = static_cast<size_t>(get_annotation<double>(*source_aln, "right_tail_length"));
+            }
+        }
+        else {
+            if (source_mp_aln->has_annotation("left_tail_length")) {
+                left_tail_length = static_cast<size_t>(*((const double*) source_mp_aln->get_annotation("left_tail_length").second));
+            }
+            if (source_mp_aln->has_annotation("right_tail_length")) {
+                right_tail_length = static_cast<size_t>(*((const double*) source_mp_aln->get_annotation("right_tail_length").second));
+            }
+        }
         for (auto it = path_overlapping_anchors.begin(); it != path_overlapping_anchors.end(); ++it) {
             prune_and_trim_anchors(source_aln ? source_aln->sequence() : source_mp_aln->sequence(),
-                                   it->second.first, it->second.second);
+                                   it->second.first, it->second.second,
+                                   left_tail_length, right_tail_length);
         }
         
         // the surjected alignment for each path we overlapped
@@ -4643,10 +4662,11 @@ using namespace std;
     }
 
     void Surjector::prune_and_trim_anchors(const string& sequence, vector<path_chunk_t>& path_chunks,
-                                           vector<pair<step_handle_t, step_handle_t>>& step_ranges) const {
-        
-        if (!prune_suspicious_anchors && max_anchors > path_chunks.size()) {
-            // the setting don't require us to prune anything here
+                                           vector<pair<step_handle_t, step_handle_t>>& step_ranges,
+                                           size_t left_tail_length, size_t right_tail_length) const {
+
+        if (!prune_suspicious_anchors && !prune_tail_region_anchors && max_anchors > path_chunks.size()) {
+            // the settings don't require us to prune anything here
             return;
         }
         
@@ -4670,7 +4690,37 @@ using namespace std;
         }
         
         vector<bool> keep(path_chunks.size(), true);
-        
+
+        // Clamp tail lengths to the read length
+        size_t read_length = sequence.size();
+        left_tail_length = std::min(left_tail_length, read_length);
+        right_tail_length = std::min(right_tail_length, read_length);
+        size_t right_tail_begin = read_length - right_tail_length;
+
+        if (prune_tail_region_anchors) {
+            // Drop anchors whose entire read interval lies inside a mapper-declared tail region.
+            for (int i = 0; i < path_chunks.size(); ++i) {
+                auto& chunk = path_chunks[i];
+                size_t anchor_read_start = chunk.first.first - sequence.begin();
+                size_t anchor_read_end = chunk.first.second - sequence.begin();
+
+                bool fully_in_left_tail = (left_tail_length > 0 && anchor_read_end <= left_tail_length);
+                bool fully_in_right_tail = (right_tail_length > 0 && anchor_read_start >= right_tail_begin);
+
+                if (fully_in_left_tail || fully_in_right_tail) {
+#ifdef debug_anchored_surject
+                    cerr << "anchor " << i << " (read[" << anchor_read_start << ":" << anchor_read_end
+                        << "]) pruned for lying fully inside "
+                        << (fully_in_left_tail ? "left" : "right")
+                        << " tail region"
+                        << " (left_tail_length=" << left_tail_length
+                        << ", right_tail_length=" << right_tail_length << ")" << endl;
+#endif
+                    keep[i] = false;
+                }
+            }
+        }
+
         if (prune_suspicious_anchors) {
 #ifdef debug_anchored_surject
             cerr << "pruning suspicious anchors";
@@ -4682,7 +4732,12 @@ using namespace std;
             for (int i = 0; i < path_chunks.size(); ++i) {
                 auto& chunk = path_chunks[i];
                 // Mark anchors that are themselves suspicious as not to be kept.
-                
+
+                if (!keep[i]) {
+                    // Already pruned by the tail-region check above; skip remaining checks.
+                    continue;
+                }
+
                 // Short tails
                 if ((chunk.first.first == path_chunks.front().first.first || chunk.first.second == path_chunks.back().first.second) // Is at either tail
                     && (anchor_lengths[i] <= max_tail_anchor_prune || chunk.first.second - chunk.first.first <= max_tail_anchor_prune)) { // And is too short

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -90,7 +90,31 @@ using namespace std;
                                               vector<tuple<string, int64_t, bool>>& positions_out,
                                               bool allow_negative_scores = false,
                                               bool preserve_deletions = false) const;
-        
+
+        /// Compute mapping quality for the candidate at best_idx relative to the
+        /// other candidate scores.
+        int32_t compute_mapping_quality_from_scores(const Alignment& source,
+                                                    const std::vector<double>& scores,
+                                                    size_t best_idx,
+                                                    bool fast_approximation = false) const;
+
+        /// Mark the best non-supplementary haplotype surjection with hp:Z:pri_hap,
+        /// mark the others with hp:Z:sec_hap, and record haplotype quality in hq.
+        void annotate_hap_tags(const Alignment& source,
+                               std::vector<Alignment>& alns) const;
+
+        /// Choose one overall primary from all non-supplementary surjections,
+        /// mark the remaining candidates secondary, and compute their Global Quality.
+        /// The source primary's original Giraffe MAPQ is retained in aq.
+        void annotate_global_mapq_and_primary(const Alignment& source,
+                                              std::vector<Alignment>& alns) const;
+
+        /// Set a SAM-style tag, replacing an existing tag with the same name.
+        static void set_sam_tag_annotation(Alignment& aln,
+                                           const std::string& tag,
+                                           char type,
+                                           const std::string& value);
+
         /// a local type that represents a read interval matched to a portion of the alignment path
         using path_chunk_t = pair<pair<string::const_iterator, string::const_iterator>, path_t>;
 

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -286,17 +286,29 @@ using namespace std;
         template<class AlnType>
         string path_score_annotations(const unordered_map<pair<path_handle_t, bool>, vector<pair<AlnType, pair<step_handle_t, step_handle_t>>>>& surjections) const;
         
-        // helpers to choose one among supplementary alignments to be the primary
+        // helpers to choose one alignment as primary and classify the alternatives
+        /// Select the highest-scoring surjection as primary.
+        ///
+        /// Non-primary surjections that overlap the primary's query interval by more
+        /// than disjoint_interval_allowable_overlap are retained as secondary.
+        /// Disjoint surjections are retained as supplementary when
+        /// report_supplementary is enabled and are otherwise omitted.
+        ///
+        /// Modifies surjections in place by annotating retained alternatives and
+        /// removing supplementaries that were not requested.
         template<class AlnType>
         void choose_primary_internal(vector<pair<AlnType, pair<step_handle_t, step_handle_t>>>& surjections,
-                                     const function<void(AlnType&)>& annotate_supplementary) const;
+                                     const function<void(AlnType&)>& annotate_supplementary,
+                                     const function<void(AlnType&)>& annotate_secondary) const;
         void choose_primary(vector<pair<Alignment, pair<step_handle_t, step_handle_t>>>& surjections) const {
             function<void(Alignment&)> annotate_supplementary = [](Alignment& aln) { set_annotation<bool>(aln, "supplementary", true); };
-            choose_primary_internal(surjections, annotate_supplementary);
+            function<void(Alignment&)> annotate_secondary = [](Alignment& aln) { aln.set_is_secondary(true); };
+            choose_primary_internal(surjections, annotate_supplementary, annotate_secondary);
         }
         void choose_primary(vector<pair<multipath_alignment_t, pair<step_handle_t, step_handle_t>>>& surjections) const {
             function<void(multipath_alignment_t&)> annotate_supplementary = [](multipath_alignment_t& mp_aln) { mp_aln.set_annotation("supplementary", true); };
-            choose_primary_internal(surjections, annotate_supplementary);
+            function<void(multipath_alignment_t&)> annotate_secondary = [](multipath_alignment_t& mp_aln) { mp_aln.set_annotation("secondary", true); };
+            choose_primary_internal(surjections, annotate_supplementary, annotate_secondary);
         }
         
         vector<tuple<Alignment, size_t, size_t>> generate_hard_clipped_alignments(const Alignment& source) const;
@@ -456,7 +468,8 @@ using namespace std;
 
     template<class AlnType>
     void Surjector::choose_primary_internal(vector<pair<AlnType, pair<step_handle_t, step_handle_t>>>& surjections,
-                                            const function<void(AlnType&)>& annotate_supplementary) const {
+                                            const function<void(AlnType&)>& annotate_supplementary,
+                                            const function<void(AlnType&)>& annotate_secondary) const {
         if (surjections.size() > 1) {
             size_t opt_idx = 0;
             int32_t opt_score = get_score(surjections.front().first);
@@ -467,10 +480,29 @@ using namespace std;
                     opt_idx = i;
                 }
             }
-            
-            for (size_t i = 0; i < surjections.size(); ++i) {
-                if (i != opt_idx) {
+
+            const auto best_interval = aligned_interval(surjections[opt_idx].first);
+
+            // Iterate backward so supplementaries can be removed safely.
+            for (size_t i = surjections.size(); i-- > 0;) {
+                if (i == opt_idx) {
+                    continue;
+                }
+                // Compare query coverage
+                const auto interval = aligned_interval(surjections[i].first);
+                const int64_t query_overlap = max<int64_t>(
+                    0,
+                    min(best_interval.second, interval.second)
+                    - max(best_interval.first, interval.first));
+
+                if (query_overlap > disjoint_interval_allowable_overlap) {
+                    annotate_secondary(surjections[i].first);
+                }
+                else if (report_supplementary) {
                     annotate_supplementary(surjections[i].first);
+                }
+                else {
+                    surjections.erase(surjections.begin() + i);
                 }
             }
         }

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -139,6 +139,9 @@ using namespace std;
         mutable atomic_flag warned_about_subgraph_size = ATOMIC_FLAG_INIT;
         
         bool prune_suspicious_anchors = false;
+        /// Remove anchors contained entirely within mapper-declared read tails.
+        /// Tail coordinates are relative to the stored read sequence.
+        bool prune_tail_region_anchors = false;
         int64_t max_tail_anchor_prune = 4;
         static constexpr int64_t DEFAULT_MAX_SLIDE = 6;
         /// Declare an anchor suspicious if it appears again at any offset up
@@ -243,7 +246,8 @@ using namespace std;
                                           vector<tuple<size_t, size_t, int32_t>>& connections) const;
         
         void prune_and_trim_anchors(const string& sequence, vector<path_chunk_t>& path_chunks,
-                                    vector<pair<step_handle_t, step_handle_t>>& step_ranges) const;
+                                    vector<pair<step_handle_t, step_handle_t>>& step_ranges,
+                                    size_t left_tail_length = 0, size_t right_tail_length = 0) const;
         
         /// Compute the widest end-inclusive interval of path positions that
         /// the realigned sequence could align to, or an interval where start >

--- a/src/unittest/alignment.cpp
+++ b/src/unittest/alignment.cpp
@@ -779,6 +779,23 @@ TEST_CASE("Unaligned sequences survive round-trip to GAF", "[alignment][gaf]") {
     }
 }
 
+TEST_CASE("Tail annotations survive round-trip to GAF", "[alignment][gaf]") {
+    VG graph;
+    Alignment aln;
+    {
+        aln.set_sequence("TACACTTAC");
+        set_annotation<double>(aln, "left_tail_length", 3);
+        set_annotation<double>(aln, "right_tail_length", 2);
+    }
+
+    gafkluge::GafRecord gaf = alignment_to_gaf(graph, aln, nullptr, true, false, false);
+    Alignment roundtrip;
+    gaf_to_alignment(graph, gaf, roundtrip);
+
+    REQUIRE(get_annotation<double>(aln, "left_tail_length") == 3.0);
+    REQUIRE(get_annotation<double>(aln, "right_tail_length") == 2.0);
+}
+
 TEST_CASE("Alignments can be left/right-aligned", "[alignment]") {
 
     auto paths_equivalent = [](const Path& path1, const Path& path2) {


### PR DESCRIPTION
## Changelog Entry

To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

- `vg surject` now supports haplotype-aware surjection with `--diploid-map`, jointly processing a read's graph placements, selecting one overall primary alignment, and reporting a global quality along with haplotype and alignment confidence in the `hp`, `hq`, and `aq` tags.

## Description

This PR adds haplotype-aware diploid surjection for long-read GAM and GAF
input through the new `--diploid-map NAME` option.

`vg surject` processes each input graph alignment independently.
However, `vg giraffe` output can contain a primary graph placement and
one or more secondary graph placements for the same read. Processing these
records independently does not allow all haplotype-path surjections to be compared
at the read level.

With `--diploid-map`, consecutive GAM or GAF records sharing a read name are
processed together. Each graph placement is surjected to all overlapping
paths belonging to the requested reference assembly. The resulting
haplotype-path surjections are annotated individually and then pooled so that
**one overall primary alignment** and one read-level **Global Quality** can be
selected across the complete candidate set.

Specifying `--diploid-map NAME`:

- selects paths belonging to reference assembly `NAME`, similarly to
  `--into-ref`;
- enables multimap surjection so all relevant haplotype-path candidates are
  available;
- groups consecutive input records with the same read name;
- compares haplotype paths within each source graph placement;
- compares the pooled surjections from every graph placement;
- selects one overall primary non-supplementary alignment;
- marks the remaining competing alignments secondary;
- emits the lowercase `hp`, `hq`, and `aq` tags.

### Output tags

The following lowercase tags are added to non-supplementary surjections:

- `hp:Z:pri_hap` or `hp:Z:sec_hap` identifies the preferred and alternative
  haplotype-path surjections for each source graph placement.
- `hq:i:<quality>` reports confidence in the haplotype choice.
- `aq:i:<quality>` preserves the original Giraffe MAPQ before output MAPQ is
  replaced with Global Quality.

Haplotype quality is calculated within each source graph placement. After
all graph placements and haplotype surjections for a read are pooled, the
highest-scoring candidate becomes the overall primary and the remaining
candidates become secondary.

Global Quality measures confidence in that overall primary relative to all
other non-supplementary candidates. It is written to the output MAPQ field,
restricted to 0-60, and capped by `aq` so surjection cannot report greater
confidence than the original graph mapping. Equal top scores use vg's
deterministic Giraffe-style tie-breaking.

## Dependencies

- Depends on vgteam/libvgio#93.
- This PR is currently stacked on the mapper-declared tail pruning and
  disjoint-interval classification changes. The branch will be rebased onto
  `master` after those changes merge.