### PR TITLE
Clarify GBWT usage in `vg map --gbwt-name`

### DIFF
--- a/src/subcommand/map_main.cpp
+++ b/src/subcommand/map_main.cpp
@@ -27,6 +27,7 @@ void help_map(char** argv) {
                                             << "[<graph>" << gcsa::GCSA::EXTENSION << "]" << endl
          << "  -1, --gbwt-name FILE             use this GBWT haplotype index "
                                             << "[<graph>"<< gbwt::GBWT::EXTENSION << "]" << endl
+         << "                                   (optional; turns on hap consistency scores)" << endl
          << "algorithm:" << endl
          << "  -t, --threads N                  number of compute threads to use" << endl
          << "  -k, --min-mem INT                minimum MEM length (if 0 estimate via -e) [0]" << endl


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Explain `vg map --gbwt-name` option (resolves #1429)

## Description

The `--gbwt-name` option (and other things that trigger GBWT usage) all end up with [feeding into](https://github.com/vgteam/vg/blob/3d7b308246cf165f74a8e0ff517c5b25ca15516d/src/subcommand/map_main.cpp#L769-L780) a `haplo_score_provider` which is optionally used in [`apply_haplotype_consistency_scores()`](https://github.com/vgteam/vg/blob/3d7b308246cf165f74a8e0ff517c5b25ca15516d/src/mapper.cpp#L2187) to, well, apply haplotype consistency scores. While GBWT index is not generally required, if it isn't passed then that score check never occurs. This PR makes that clear in the helptext.