### PR TITLE
Diploid map interleaved

### DIFF
--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -41,7 +41,8 @@ void help_surject(char** argv) {
          << "  -x, --xg-name FILE        use this graph or XG index (required)" << endl
          << "  -t, --threads N           number of threads to use" << endl
          << "  -d, --diploid-map NAME    like --into-ref, but also turns on --multimap and" << endl
-         << "                            emits hp/hq/aq tags for haplotype-aware diploid surjection" << endl
+         << "                            emits hp/hq/aq tags for haplotype-aware" << endl
+         << "                            diploid surjection" << endl
          << "  -D, --read-length TYPE    read length preset: {short, long}" << endl
          << "  -p, --into-path NAME      surject into this path or its subpaths (may repeat)" << endl
          << "                            default: reference, then non-alt generic" << endl

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -563,6 +563,111 @@ int main_surject(int argc, char** argv) {
             ALIGNMENT_EMITTER_FLAG_HTS_RAW | (spliced * ALIGNMENT_EMITTER_FLAG_HTS_SPLICED));
 
         if (interleaved) {
+            if (diploid_map) {
+                PairedSurjector paired_surjector(surjector, xgidx);
+
+                auto emit_result = [&](PairedSurjector::result_t&& result) {
+                    for (auto& pair : result.pairs) {
+                        alignment_emitter->emit_pair(std::move(pair.first),
+                                                     std::move(pair.second),
+                                                     max_frag_len);
+                    }
+                    if (!result.singles.empty()) {
+                        alignment_emitter->emit_singles(std::move(result.singles));
+                    }
+                    total_reads_surjected += 2;
+                };
+
+                auto process_fragment = [&](PairedSurjector::fragment_group_t& placements) {
+                    if (placements.empty()) {
+                        return;
+                    }
+                    try {
+                        set_crash_context(placements.front().first.name() + ", "
+                                          + placements.front().second.name());
+                        size_t thread_num = omp_get_thread_num();
+                        if (watchdog) {
+                            watchdog->check_in(thread_num, placements.front().first.name());
+                        }
+
+                        for (auto& placement : placements) {
+                            Alignment& first = placement.first;
+                            Alignment& second = placement.second;
+                            if (first.has_fragment_next()) {
+                                if (first.fragment_next().name() != second.name()
+                                    || !second.has_fragment_prev()
+                                    || second.fragment_prev().name() != first.name()) {
+                                    adjacent_but_not_paired_error(logger, first.name(), second.name());
+                                }
+                            }
+                            else if (second.has_fragment_next()) {
+                                if (second.fragment_next().name() != first.name()
+                                    || !first.has_fragment_prev()
+                                    || first.fragment_prev().name() != second.name()) {
+                                    adjacent_but_not_paired_error(logger, first.name(), second.name());
+                                }
+                            }
+                            else {
+                                adjacent_but_not_paired_error(logger, first.name(), second.name());
+                            }
+
+                            if (validate) {
+                                ensure_alignment_is_for_graph(logger, first, *xgidx);
+                                ensure_alignment_is_for_graph(logger, second, *xgidx);
+                            }
+                            if (input_format == "GAF") {
+                                check_gaf_aln(first);
+                                check_gaf_aln(second);
+                            }
+                            set_metadata(first);
+                            set_metadata(second);
+                        }
+
+                        PairedSurjector::result_t result;
+                        if (paired_surjector.surject(std::move(placements), paths,
+                                                     subpath_global, spliced,
+                                                     max_frag_len, result)) {
+                            emit_result(std::move(result));
+                        }
+
+                        if (watchdog) {
+                            watchdog->check_out(thread_num);
+                        }
+                        clear_crash_context();
+                    }
+                    catch (const std::exception& ex) {
+                        report_exception(ex);
+                    }
+                };
+
+                auto ready_for_parallel = [&]() {
+                    return paired_surjector.ready_for_parallel();
+                };
+
+                if (input_format == "GAM") {
+                    get_input_file(file_name, [&](istream& in) {
+                        vg::io::gam_paired_grouped_for_each_parallel_after_wait(
+                            in, process_fragment, ready_for_parallel);
+                    });
+                }
+                else {
+                    vg::io::gaf_paired_grouped_for_each_parallel_after_wait(
+                        *xgidx, file_name, process_fragment, ready_for_parallel);
+                }
+
+                auto buffered = paired_surjector.finalize_fragment_length_distribution();
+                if (show_progress) {
+                    logger.info() << "Fragment length estimate: "
+                                  << paired_surjector.fragment_length_mean() << " +/- "
+                                  << paired_surjector.fragment_length_stddev() << " from "
+                                  << paired_surjector.fragment_length_sample_size()
+                                  << " fragments" << endl;
+                }
+                for (auto& placements : buffered) {
+                    process_fragment(placements);
+                }
+            }
+            else {
             // GAM input is paired, and for HTS output reads need to know their pair partners' mapping locations.
             // TODO: We don't preserve order relationships (like primary/secondary) beyond the interleaving.
             function<void(Alignment&, Alignment&)> lambda = [&](Alignment& src1, Alignment& src2) {
@@ -700,6 +805,7 @@ int main_surject(int argc, char** argv) {
                     return lambda(src1, src2);
                 };
                 vg::io::gaf_paired_interleaved_for_each_parallel(*xgidx, file_name, gaf_checking_lambda);
+            }
             }
         } else {
             // We can just surject each Alignment by itself.

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -40,6 +40,8 @@ void help_surject(char** argv) {
          << "options:" << endl
          << "  -x, --xg-name FILE        use this graph or XG index (required)" << endl
          << "  -t, --threads N           number of threads to use" << endl
+         << "  -d, --diploid-map NAME    like --into-ref, but also turns on --multimap and" << endl
+         << "                            emits hp/hq/aq tags for haplotype-aware diploid surjection" << endl
          << "  -D, --read-length TYPE    read length preset: {short, long}" << endl
          << "  -p, --into-path NAME      surject into this path or its subpaths (may repeat)" << endl
          << "                            default: reference, then non-alt generic" << endl
@@ -165,6 +167,7 @@ int main_surject(int argc, char** argv) {
     string input_format = "GAM";
     bool spliced = false;
     bool interleaved = false;
+    bool diploid_map = false;
     string sample_name;
     string read_group;
     int32_t max_frag_len = 0;
@@ -208,6 +211,7 @@ int main_surject(int argc, char** argv) {
             {"max-tail-len", required_argument, 0, 'T'},
             {"max-graph-scale", required_argument, 0, 'g'},
             {"interleaved", no_argument, 0, 'i'},
+            {"diploid-map", required_argument, 0, 'd'},
             {"multimap", no_argument, 0, 'M'},
             {"gaf-input", no_argument, 0, 'G'},
             {"gamp-input", no_argument, 0, 'm'},
@@ -239,7 +243,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuBN:R:f:C:t:D:SPjI:a:AE:LHMVw:r",
+        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuBN:R:f:C:t:D:d:SPjI:a:AE:LHMVw:r",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -314,6 +318,12 @@ int main_surject(int argc, char** argv) {
             left_align = true;
             break;
                 
+        case 'd':
+            reference_assembly_names.insert(optarg);
+            diploid_map = true;
+            multimap = true;
+            break;
+
         case 'D':
             read_length = optarg;
             break;
@@ -718,16 +728,88 @@ int main_surject(int argc, char** argv) {
                     report_exception(ex);
                 }
             };
+
+            // For --diploid-map, all graph placements sharing a read name (the
+            // primary placement plus any secondaries already in the input) need
+            // to be surjected and compared together, so that haplotype quality
+            // and the single overall primary are chosen across all of them, not
+            // independently per input record.
+            std::function<void(std::vector<Alignment>&)> set_lambda = [&](std::vector<Alignment>& placements) {
+                try {
+                    if (placements.empty()) {
+                        return;
+                    }
+
+                    set_crash_context(placements.front().name());
+                    size_t thread_num = omp_get_thread_num();
+                    if (watchdog) {
+                        watchdog->check_in(thread_num, placements.front().name());
+                    }
+
+                    vector<Alignment> all_surjected;
+                    all_surjected.reserve(placements.size() * 2);
+
+                    for (auto& placement : placements) {
+                        if (validate) {
+                            ensure_alignment_is_for_graph(logger, placement, *xgidx);
+                        }
+                        set_metadata(placement);
+
+                        // multimap_to_all_paths is forced on for diploid mode, so this
+                        // already returns one surjection per overlapping haplotype path
+                        // for this one graph placement.
+                        vector<Alignment> surjected = surjector.surject(placement, paths, subpath_global, spliced);
+
+                        // Assign hp/hq by comparing this graph placement's
+                        // haplotype-path surjections with each other.
+                        surjector.annotate_hap_tags(placement, surjected);
+
+                        all_surjected.insert(all_surjected.end(),
+                                             std::make_move_iterator(surjected.begin()),
+                                             std::make_move_iterator(surjected.end()));
+                    }
+
+                    // Global Quality and single overall primary, chosen across every
+                    // haplotype-path surjection from every graph placement pooled
+                    // together.
+                    surjector.annotate_global_mapq_and_primary(placements.front(), all_surjected);
+
+                    alignment_emitter->emit_singles(std::move(all_surjected));
+                    total_reads_surjected++;
+
+                    if (watchdog) {
+                        watchdog->check_out(thread_num);
+                    }
+                    clear_crash_context();
+                } catch (const std::exception& ex) {
+                    report_exception(ex);
+                }
+            };
+
             if (input_format == "GAM") {
                 get_input_file(file_name, [&](istream& in) {
-                    vg::io::for_each_parallel<Alignment>(in,lambda);
+                    if (diploid_map) {
+                        vg::io::gam_grouped_for_each_parallel(in, set_lambda);
+                    } else {
+                        vg::io::for_each_parallel<Alignment>(in, lambda);
+                    }
                 });
             } else {
-                auto gaf_checking_lambda = [&](Alignment& src) {
-                    check_gaf_aln(src);
-                    return lambda(src);
-                };
-                vg::io::gaf_unpaired_for_each_parallel(*xgidx, file_name, gaf_checking_lambda);
+                if (diploid_map) {
+                    std::function<void(std::vector<Alignment>&)> gaf_set_lambda = [&](std::vector<Alignment>& placements) {
+                        for (auto& p : placements) {
+                            check_gaf_aln(p);
+                        }
+                        set_lambda(placements);
+                    };
+                    vg::io::gaf_grouped_for_each_parallel(*xgidx, file_name, gaf_set_lambda);
+                } else {
+                    auto gaf_checking_lambda = [&](Alignment& src) {
+                        check_gaf_aln(src);
+                        return lambda(src);
+                    };
+                    vg::io::gaf_unpaired_for_each_parallel(*xgidx, file_name, gaf_checking_lambda);
+                }
             }
         }
     } else if (input_format == "GAMP") {

--- a/src/subcommand/surject_main.cpp
+++ b/src/subcommand/surject_main.cpp
@@ -67,6 +67,8 @@ void help_surject(char** argv) {
          << "  -P, --prune-low-cplx      prune short/low complexity anchors in realignment" << endl
          << "                            (on by default for long reads)" << endl
          << "      --no-prune-low-cplx   disable anchor pruning" << endl
+         << "  -j, --prune-tail-region   prune anchors lying fully inside mapper-declared" << endl
+         << "                            tail regions" << endl
          << "  -I, --max-slide N         look for offset duplicates of anchors up to N bp" << endl
          << "                            away when pruning "
                                      << "(default: " << Surjector::DEFAULT_MAX_SLIDE << ")" << endl
@@ -187,6 +189,7 @@ int main_surject(int argc, char** argv) {
     bool validate = true;
     bool show_progress = false;
     bool left_align = false;
+    bool prune_tail_region = false;
 
     int c;
     optind = 2; // force optind past command positional argument
@@ -218,6 +221,7 @@ int main_surject(int argc, char** argv) {
             {"spliced", no_argument, 0, 'S'},
             {"prune-low-cplx", no_argument, 0, 'P'},
             {"no-prune-low-cplx", no_argument, 0, OPT_NO_PRUNE_LOW_CPLX},
+            {"prune-tail-region", no_argument, 0, 'j'},
             {"max-slide", required_argument, 0, 'I'},
             {"max-anchors", required_argument, 0, 'a'},
             {"qual-adj", no_argument, 0, 'A'},
@@ -235,7 +239,7 @@ int main_surject(int argc, char** argv) {
         };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuBN:R:f:C:t:D:SPI:a:AE:LHMVw:r",
+        c = getopt_long (argc, argv, "h?x:p:F:n:lT:g:iGmcbsuBN:R:f:C:t:D:SPjI:a:AE:LHMVw:r",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -324,6 +328,10 @@ int main_surject(int argc, char** argv) {
 
         case OPT_NO_PRUNE_LOW_CPLX: // --no-prune-low-cplx
             prune_anchors = false;
+            break;
+
+        case 'j':
+            prune_tail_region = true; //remove surject anchors from tails
             break;
 
         case 'I':
@@ -482,6 +490,7 @@ int main_surject(int argc, char** argv) {
                                        default_full_length_bonus); 
     }
     surjector.prune_suspicious_anchors = *prune_anchors;
+    surjector.prune_tail_region_anchors = prune_tail_region;
     surjector.max_slide = max_slide;
     surjector.max_anchors = max_anchors;
     if (spliced) {

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -15,6 +15,7 @@
 #include "reverse_graph.hpp"
 #include "subpath_overlay.hpp"
 #include "identity_overlay.hpp"
+#include "mapper.hpp"
 
 #include "algorithms/extract_connecting_graph.hpp"
 #include "algorithms/prune_to_connecting_graph.hpp"
@@ -295,6 +296,395 @@ using namespace std;
 
             alns[i].set_mapping_quality(global_mapq);
         }
+    }
+
+    double Surjector::score_alignment_pair(const Alignment& source,
+                                           const Alignment& first,
+                                           const Alignment& second,
+                                           int64_t template_length,
+                                           double fragment_mean,
+                                           double fragment_stddev,
+                                           bool use_fragment_length) const {
+        double score = first.score() + second.score();
+        if (use_fragment_length && template_length != numeric_limits<int64_t>::max()
+            && fragment_stddev > 0.0) {
+            double log_base = get_aligner(!source.quality().empty())->scorer->get_log_base();
+            if (log_base != 0.0) {
+                double deviation = template_length - fragment_mean;
+                score += (-deviation * deviation /
+                          (2.0 * fragment_stddev * fragment_stddev)) / log_base;
+                score = max(score, static_cast<double>(min(first.score(), second.score())));
+            }
+        }
+        return score;
+    }
+
+    PairedSurjector::PairedSurjector(Surjector& surjector,
+                                     const PathPositionHandleGraph* graph,
+                                     size_t maximum_sample_size,
+                                     size_t reestimation_frequency,
+                                     double robust_estimation_fraction,
+                                     size_t maximum_buffered_fragments)
+        : surjector(surjector), graph(graph),
+          fragment_length_distribution(make_unique<FragmentLengthDistribution>(
+              maximum_sample_size, reestimation_frequency, robust_estimation_fraction)),
+          maximum_buffered_fragments(maximum_buffered_fragments),
+          minimum_samples_for_estimate(reestimation_frequency) {
+    }
+
+    PairedSurjector::~PairedSurjector() = default;
+
+    bool PairedSurjector::ready_for_parallel() const {
+        return fragment_length_distribution->is_finalized() || learning_abandoned;
+    }
+
+    double PairedSurjector::fragment_length_mean() const {
+        return fragment_length_distribution->mean();
+    }
+
+    double PairedSurjector::fragment_length_stddev() const {
+        return fragment_length_distribution->std_dev();
+    }
+
+    size_t PairedSurjector::fragment_length_sample_size() const {
+        return fragment_length_distribution->curr_sample_size();
+    }
+
+    void PairedSurjector::finalize_learning() {
+        if (ready_for_parallel()) {
+            fragment_scoring_available = fragment_length_distribution->is_finalized();
+            return;
+        }
+        if (fragment_length_distribution->curr_sample_size() >= minimum_samples_for_estimate
+            && isfinite(fragment_length_distribution->mean())
+            && isfinite(fragment_length_distribution->std_dev())
+            && fragment_length_distribution->std_dev() > 0.0) {
+            fragment_length_distribution->force_parameters(
+                fragment_length_distribution->mean(), fragment_length_distribution->std_dev());
+            fragment_scoring_available = true;
+        }
+        else {
+            learning_abandoned = true;
+            fragment_scoring_available = false;
+        }
+    }
+
+    vector<PairedSurjector::fragment_group_t>
+    PairedSurjector::finalize_fragment_length_distribution() {
+        finalize_learning();
+        return std::move(ambiguous_fragment_buffer);
+    }
+
+    int64_t PairedSurjector::compute_template_length(const Alignment& first,
+                                                     const Alignment& second) const {
+        if (first.refpos_size() == 0 || second.refpos_size() == 0) {
+            return numeric_limits<int64_t>::max();
+        }
+        const auto& first_pos = first.refpos(0);
+        const auto& second_pos = second.refpos(0);
+        if (first_pos.name().empty() || first_pos.name() != second_pos.name()
+            || !graph->has_path(first_pos.name())) {
+            return numeric_limits<int64_t>::max();
+        }
+        size_t path_length = graph->get_path_length(graph->get_path_handle(first_pos.name()));
+        int64_t first_offset = first_pos.offset();
+        int64_t second_offset = second_pos.offset();
+        auto first_cigar = cigar_against_path(first, first_pos.is_reverse(),
+                                              first_offset, path_length, 0);
+        auto second_cigar = cigar_against_path(second, second_pos.is_reverse(),
+                                               second_offset, path_length, 0);
+        if (first_cigar.empty() || second_cigar.empty()) {
+            return numeric_limits<int64_t>::max();
+        }
+        auto lengths = compute_template_lengths(first_offset, first_cigar,
+                                                second_offset, second_cigar);
+        return llabs(static_cast<int64_t>(lengths.first));
+    }
+
+    size_t PairedSurjector::choose_best(const Alignment& first_source,
+                                        const Alignment& second_source,
+                                        const vector<double>& scores) const {
+        vector<size_t> order(scores.size());
+        iota(order.begin(), order.end(), 0);
+        LazyRNG rng([&]() { return first_source.sequence() + second_source.sequence(); });
+        sort_shuffling_ties(order.begin(), order.end(),
+                            [&](size_t a, size_t b) { return scores[a] > scores[b]; }, rng);
+        return order.front();
+    }
+
+    bool PairedSurjector::surject(fragment_group_t&& placements,
+                                  const unordered_set<path_handle_t>& paths,
+                                  bool allow_negative_scores,
+                                  bool preserve_deletions,
+                                  uint64_t maximum_fragment_length,
+                                  result_t& result) {
+        result = result_t();
+        if (placements.empty()) {
+            return true;
+        }
+
+        fragment_scoring_available = fragment_length_distribution->is_finalized();
+        vector<placement_t> work;
+        work.reserve(placements.size());
+
+        using path_strand_t = pair<string, bool>;
+        for (auto& source_pair : placements) {
+            placement_t placement;
+            // Keep the input group intact until we know it will not need to be
+            // buffered and replayed after fragment-length learning.
+            placement.source_first = source_pair.first;
+            placement.source_second = source_pair.second;
+            placement.first = surjector.surject(placement.source_first, paths,
+                                                allow_negative_scores, preserve_deletions);
+            placement.second = surjector.surject(placement.source_second, paths,
+                                                 allow_negative_scores, preserve_deletions);
+
+            unordered_map<path_strand_t, vector<size_t>> second_by_path;
+            for (size_t j = 0; j < placement.second.size(); ++j) {
+                if (!is_supplementary(placement.second[j]) && placement.second[j].refpos_size()) {
+                    const auto& pos = placement.second[j].refpos(0);
+                    second_by_path[make_pair(pos.name(), pos.is_reverse())].push_back(j);
+                }
+            }
+            for (size_t i = 0; i < placement.first.size(); ++i) {
+                if (is_supplementary(placement.first[i]) || !placement.first[i].refpos_size()) {
+                    continue;
+                }
+                const auto& pos = placement.first[i].refpos(0);
+                auto found = second_by_path.find(make_pair(pos.name(), !pos.is_reverse()));
+                if (found == second_by_path.end()) {
+                    continue;
+                }
+                for (size_t j : found->second) {
+                    pair_candidate_t candidate;
+                    candidate.first = i;
+                    candidate.second = j;
+                    candidate.template_length = compute_template_length(
+                        placement.first[i], placement.second[j]);
+                    candidate.score = surjector.score_alignment_pair(
+                        placement.source_first, placement.first[i], placement.second[j],
+                        candidate.template_length, fragment_length_distribution->mean(),
+                        fragment_length_distribution->std_dev(), fragment_scoring_available);
+                    placement.candidates.push_back(candidate);
+                }
+            }
+            work.emplace_back(std::move(placement));
+        }
+
+        vector<double> global_scores;
+        vector<pair<size_t, size_t>> global_index;
+        for (size_t p = 0; p < work.size(); ++p) {
+            for (size_t c = 0; c < work[p].candidates.size(); ++c) {
+                global_scores.push_back(work[p].candidates[c].score);
+                global_index.emplace_back(p, c);
+            }
+        }
+
+        if (global_scores.empty()) {
+            // None of the surjected alignments form a compatible pair. Fall
+            // back to emitting the two read ends as singles.
+            //
+            // Pool surjections across all input graph placements before
+            // selecting primaries. Otherwise, every input placement chooses
+            // its own primary, producing multiple primary BAM records for the
+            // same read end.
+            vector<Alignment> first_surjections;
+            vector<Alignment> second_surjections;
+
+            size_t first_count = 0;
+            size_t second_count = 0;
+            for (const auto& placement : work) {
+                first_count += placement.first.size();
+                second_count += placement.second.size();
+            }
+            first_surjections.reserve(first_count);
+            second_surjections.reserve(second_count);
+
+            for (auto& placement : work) {
+                // Haplotype competition remains local to one input graph
+                // placement.
+                surjector.annotate_hap_tags(placement.source_first, placement.first);
+                surjector.annotate_hap_tags(placement.source_second, placement.second);
+                for (auto& aln : placement.first) {
+                    first_surjections.emplace_back(std::move(aln));
+                }
+                for (auto& aln : placement.second) {
+                    second_surjections.emplace_back(std::move(aln));
+                }
+            }
+
+            // Choose exactly one primary across all graph placements for each
+            // read end.
+            surjector.annotate_global_mapq_and_primary(
+                work.front().source_first, first_surjections);
+            surjector.annotate_global_mapq_and_primary(
+                work.front().source_second, second_surjections);
+
+            for (auto& aln : first_surjections) {
+                if (aln.refpos_size()) {
+                    result.singles.emplace_back(std::move(aln));
+                }
+            }
+            for (auto& aln : second_surjections) {
+                if (aln.refpos_size()) {
+                    result.singles.emplace_back(std::move(aln));
+                }
+            }
+            return true;
+        }
+
+        size_t best_global = choose_best(work.front().source_first,
+                                         work.front().source_second, global_scores);
+        size_t best_placement = global_index[best_global].first;
+        size_t best_candidate = global_index[best_global].second;
+        auto& winning_placement = work[best_placement];
+        auto& winning_candidate = winning_placement.candidates[best_candidate];
+
+        if (!ready_for_parallel()) {
+            bool can_train = winning_placement.source_first.mapping_quality() == 60
+                && winning_placement.source_second.mapping_quality() == 60
+                && winning_candidate.template_length != numeric_limits<int64_t>::max()
+                && (maximum_fragment_length == 0
+                    || static_cast<uint64_t>(winning_candidate.template_length) <= maximum_fragment_length);
+            if (can_train) {
+                fragment_length_distribution->register_fragment_length(
+                    winning_candidate.template_length);
+                fragment_scoring_available = fragment_length_distribution->is_finalized();
+            }
+            else {
+                ambiguous_fragment_buffer.emplace_back(std::move(placements));
+                if (ambiguous_fragment_buffer.size() >= maximum_buffered_fragments) {
+                    finalize_learning();
+                }
+                return false;
+            }
+        }
+
+        int32_t global_mapq = surjector.compute_mapping_quality_from_scores(
+            winning_placement.source_first, global_scores, best_global);
+        global_mapq = max<int32_t>(0, min<int32_t>(60, global_mapq));
+        global_mapq = min(global_mapq,
+                          min(winning_placement.source_first.mapping_quality(),
+                              winning_placement.source_second.mapping_quality()));
+
+        for (auto& placement : work) {
+            for (auto& aln : placement.first) {
+                if (!is_supplementary(aln)) {
+                    aln.set_is_secondary(true);
+                    aln.set_mapping_quality(global_mapq);
+                    Surjector::set_sam_tag_annotation(aln, "aq", 'i',
+                        to_string(placement.source_first.mapping_quality()));
+                }
+            }
+            for (auto& aln : placement.second) {
+                if (!is_supplementary(aln)) {
+                    aln.set_is_secondary(true);
+                    aln.set_mapping_quality(global_mapq);
+                    Surjector::set_sam_tag_annotation(aln, "aq", 'i',
+                        to_string(placement.source_second.mapping_quality()));
+                }
+            }
+
+            if (!placement.candidates.empty()) {
+                vector<double> local_scores;
+                for (const auto& candidate : placement.candidates) {
+                    local_scores.push_back(candidate.score);
+                }
+                size_t local_best = choose_best(placement.source_first,
+                                                placement.source_second, local_scores);
+                int32_t hq = surjector.compute_mapping_quality_from_scores(
+                    placement.source_first, local_scores, local_best);
+                hq = max<int32_t>(0, min<int32_t>(60, hq));
+                size_t best_first = placement.candidates[local_best].first;
+                size_t best_second = placement.candidates[local_best].second;
+                for (size_t i = 0; i < placement.first.size(); ++i) {
+                    if (!is_supplementary(placement.first[i])) {
+                        Surjector::set_sam_tag_annotation(placement.first[i], "hp", 'Z',
+                            i == best_first ? "pri_hap" : "sec_hap");
+                        Surjector::set_sam_tag_annotation(placement.first[i], "hq", 'i', to_string(hq));
+                    }
+                }
+                for (size_t i = 0; i < placement.second.size(); ++i) {
+                    if (!is_supplementary(placement.second[i])) {
+                        Surjector::set_sam_tag_annotation(placement.second[i], "hp", 'Z',
+                            i == best_second ? "pri_hap" : "sec_hap");
+                        Surjector::set_sam_tag_annotation(placement.second[i], "hq", 'i', to_string(hq));
+                    }
+                }
+            }
+        }
+
+        winning_placement.first[winning_candidate.first].set_is_secondary(false);
+        winning_placement.second[winning_candidate.second].set_is_secondary(false);
+
+        for (auto& placement : work) {
+            map<string, size_t> best_per_path;
+            for (size_t c = 0; c < placement.candidates.size(); ++c) {
+                const auto& candidate = placement.candidates[c];
+                const string& path = placement.first[candidate.first].refpos(0).name();
+                auto found = best_per_path.find(path);
+                if (found == best_per_path.end()
+                    || candidate.score > placement.candidates[found->second].score
+                    || (&placement == &winning_placement && c == best_candidate)) {
+                    best_per_path[path] = c;
+                }
+            }
+
+            for (auto& aln : placement.first) {
+                if (is_supplementary(aln) && !has_annotation(aln, "mate_info")) {
+                    const Alignment* mate = nullptr;
+                    if (aln.refpos_size()) {
+                        auto found = best_per_path.find(aln.refpos(0).name());
+                        if (found != best_per_path.end()) {
+                            mate = &placement.second[placement.candidates[found->second].second];
+                        }
+                    }
+                    set_annotation(aln, "mate_info",
+                        mate
+                            ? mate_info(mate->refpos(0).name(), mate->refpos(0).offset(),
+                                        mate->refpos(0).is_reverse(), false)
+                            : mate_info("", -1, false, false));
+                }
+            }
+            for (auto& aln : placement.second) {
+                if (is_supplementary(aln) && !has_annotation(aln, "mate_info")) {
+                    const Alignment* mate = nullptr;
+                    if (aln.refpos_size()) {
+                        auto found = best_per_path.find(aln.refpos(0).name());
+                        if (found != best_per_path.end()) {
+                            mate = &placement.first[placement.candidates[found->second].first];
+                        }
+                    }
+                    set_annotation(aln, "mate_info",
+                        mate
+                            ? mate_info(mate->refpos(0).name(), mate->refpos(0).offset(),
+                                        mate->refpos(0).is_reverse(), true)
+                            : mate_info("", -1, false, true));
+                }
+            }
+            vector<bool> paired_first(placement.first.size(), false);
+            vector<bool> paired_second(placement.second.size(), false);
+            for (const auto& path_candidate : best_per_path) {
+                const auto& candidate = placement.candidates[path_candidate.second];
+                if (!paired_first[candidate.first] && !paired_second[candidate.second]) {
+                    paired_first[candidate.first] = true;
+                    paired_second[candidate.second] = true;
+                    result.pairs.emplace_back(std::move(placement.first[candidate.first]),
+                                              std::move(placement.second[candidate.second]));
+                }
+            }
+            for (size_t i = 0; i < placement.first.size(); ++i) {
+                if (!paired_first[i] && placement.first[i].refpos_size()) {
+                    result.singles.emplace_back(std::move(placement.first[i]));
+                }
+            }
+            for (size_t i = 0; i < placement.second.size(); ++i) {
+                if (!paired_second[i] && placement.second[i].refpos_size()) {
+                    result.singles.emplace_back(std::move(placement.second[i]));
+                }
+            }
+        }
+        return true;
     }
 
     vector<Alignment> Surjector::surject(const Alignment& source, const unordered_set<path_handle_t>& paths,

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -23,6 +23,8 @@
 
 #include "bdsg/hash_graph.hpp"
 
+#include <numeric>
+
 // #define debug_spliced_surject
 // #define debug_anchored_surject
 // #define debug_multipath_surject
@@ -115,6 +117,184 @@ using namespace std;
             dp_aligner.reset();
         }
         
+    }
+
+    int32_t Surjector::compute_mapping_quality_from_scores(
+        const Alignment& source,
+        const std::vector<double>& scores,
+        size_t best_idx,
+        bool fast_approximation) const {
+
+        if (scores.empty() || best_idx >= scores.size()) {
+            return 0;
+        }
+        if (scores.size() == 1) {
+            return 60;
+        }
+
+        // compute_first_mapping_quality scores the first candidate, so place
+        // the selected candidate first while preserving the other scores.
+        std::vector<double> reordered;
+        reordered.reserve(scores.size());
+        reordered.push_back(scores[best_idx]);
+
+        for (size_t i = 0; i < scores.size(); ++i) {
+            if (i != best_idx) {
+                reordered.push_back(scores[i]);
+            }
+        }
+
+        const GSSWAligner* aligner = get_aligner(!source.quality().empty());
+        return aligner->mapq_calc->compute_first_mapping_quality(
+            reordered, fast_approximation);
+    }
+
+    void Surjector::set_sam_tag_annotation(Alignment& aln,
+                                            const std::string& tag,
+                                            char type,
+                                            const std::string& value) {
+        std::string old_tags;
+        if (has_annotation(aln, "tags")) {
+            old_tags = get_annotation<std::string>(aln, "tags");
+        }
+
+        const std::string prefix = tag + ":";
+        std::string new_tags;
+
+        size_t begin = 0;
+        while (begin < old_tags.size()) {
+            size_t end = old_tags.find('\t', begin);
+            if (end == std::string::npos) {
+                end = old_tags.size();
+            }
+
+            const std::string token = old_tags.substr(begin, end - begin);
+            if (token.compare(0, prefix.size(), prefix) != 0) {
+                if (!new_tags.empty()) {
+                    new_tags.push_back('\t');
+                }
+                new_tags += token;
+            }
+
+            begin = end + 1;
+        }
+
+        if (!new_tags.empty()) {
+            new_tags.push_back('\t');
+        }
+        new_tags += tag + ":" + type + ":" + value;
+
+        set_annotation<std::string>(aln, "tags", new_tags);
+    }
+
+    void Surjector::annotate_hap_tags(
+        const Alignment& source,
+        std::vector<Alignment>& alns) const {
+
+        if (alns.empty()) {
+            return;
+        }
+
+        std::vector<double> scores;
+        std::vector<size_t> indices;
+        scores.reserve(alns.size());
+        indices.reserve(alns.size());
+
+        // Supplementary segments do not compete for haplotype assignment.
+        for (size_t i = 0; i < alns.size(); ++i) {
+            if (!is_supplementary(alns[i])) {
+                scores.push_back(alns[i].score());
+                indices.push_back(i);
+            }
+        }
+
+        if (indices.empty()) {
+            return;
+        }
+
+        std::vector<size_t> score_order(scores.size());
+        std::iota(score_order.begin(), score_order.end(), 0);
+        LazyRNG rng([&]() { return source.sequence(); });
+        sort_shuffling_ties(score_order.begin(), score_order.end(),
+                            [&](size_t a, size_t b) { return scores[a] > scores[b]; }, rng);
+        const size_t best_k = score_order.front();
+
+        const size_t best_i = indices[best_k];
+        int32_t hq = compute_mapping_quality_from_scores(
+            source, scores, best_k);
+        hq = std::max<int32_t>(0, std::min<int32_t>(60, hq));
+
+        for (size_t i : indices) {
+            set_sam_tag_annotation(
+                alns[i],
+                "hp",
+                'Z',
+                i == best_i ? "pri_hap" : "sec_hap");
+
+            set_sam_tag_annotation(
+                alns[i],
+                "hq",
+                'i',
+                std::to_string(hq));
+        }
+    }
+
+    void Surjector::annotate_global_mapq_and_primary(
+        const Alignment& source,
+        std::vector<Alignment>& alns) const {
+
+        if (alns.empty()) {
+            return;
+        }
+
+        std::vector<double> scores;
+        std::vector<size_t> indices;
+        scores.reserve(alns.size());
+        indices.reserve(alns.size());
+
+        // Supplementary segments do not compete for the overall primary.
+        for (size_t i = 0; i < alns.size(); ++i) {
+            if (!is_supplementary(alns[i])) {
+                scores.push_back(alns[i].score());
+                indices.push_back(i);
+            }
+        }
+
+        if (indices.empty()) {
+            return;
+        }
+
+        std::vector<size_t> score_order(scores.size());
+        std::iota(score_order.begin(), score_order.end(), 0);
+        LazyRNG rng([&]() { return source.sequence(); });
+        sort_shuffling_ties(score_order.begin(), score_order.end(),
+                            [&](size_t a, size_t b) { return scores[a] > scores[b]; }, rng);
+        const size_t best_k = score_order.front();
+
+        const size_t best_i = indices[best_k];
+
+        for (size_t i : indices) {
+            alns[i].set_is_secondary(i != best_i);
+        }
+
+        int32_t global_mapq = compute_mapping_quality_from_scores(
+            source, scores, best_k);
+        global_mapq = std::max<int32_t>(
+            0, std::min<int32_t>(60, global_mapq));
+
+        // The first grouped input record is the original Giraffe primary.
+        const int32_t alignment_quality = source.mapping_quality();
+        global_mapq = std::min(global_mapq, alignment_quality);
+
+        for (size_t i : indices) {
+            set_sam_tag_annotation(
+                alns[i],
+                "aq",
+                'i',
+                std::to_string(alignment_quality));
+
+            alns[i].set_mapping_quality(global_mapq);
+        }
     }
 
     vector<Alignment> Surjector::surject(const Alignment& source, const unordered_set<path_handle_t>& paths,
@@ -5872,5 +6052,3 @@ using namespace std;
         return return_val;
     }
 }
-
-

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -5306,9 +5306,10 @@ using namespace std;
         size_t curr_interval_strict_right_bound = -1;
         for (const auto& chunk_interval : chunk_intervals) {
             
-            // check for sufficient separation to start a new supplementary using the directly attested intervals
+            // Preserve sufficiently separated reference regions as distinct alignment
+            // candidates; supplementary reporting is decided after alignment.
             if (disjoint_path_intervals.empty() ||
-                (report_supplementary && curr_interval_strict_right_bound + max_gap + 1 < get<0>(chunk_interval))) {
+                curr_interval_strict_right_bound + max_gap + 1 < get<0>(chunk_interval)) {
                 // make new interval
                 curr_interval_strict_right_bound = get<1>(chunk_interval);
                 disjoint_path_intervals.emplace_back(get<2>(chunk_interval), get<3>(chunk_interval),

--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -336,11 +336,30 @@ using namespace std;
         }
 #endif
         
-        // we want to remove anchors that can be error-prone: short anchors in the tails and anchors in
-        // low complexity sequences
+        // Read mapper-declared tail lengths. These coordinates are
+        // relative to the stored read sequence and independent of path orientation.
+        // Missing annotations remain zero, making tail-region pruning a no-op.
+        size_t left_tail_length = 0, right_tail_length = 0;
+        if (source_aln) {
+            if (has_annotation(*source_aln, "left_tail_length")) {
+                left_tail_length = static_cast<size_t>(get_annotation<double>(*source_aln, "left_tail_length"));
+            }
+            if (has_annotation(*source_aln, "right_tail_length")) {
+                right_tail_length = static_cast<size_t>(get_annotation<double>(*source_aln, "right_tail_length"));
+            }
+        }
+        else {
+            if (source_mp_aln->has_annotation("left_tail_length")) {
+                left_tail_length = static_cast<size_t>(*((const double*) source_mp_aln->get_annotation("left_tail_length").second));
+            }
+            if (source_mp_aln->has_annotation("right_tail_length")) {
+                right_tail_length = static_cast<size_t>(*((const double*) source_mp_aln->get_annotation("right_tail_length").second));
+            }
+        }
         for (auto it = path_overlapping_anchors.begin(); it != path_overlapping_anchors.end(); ++it) {
             prune_and_trim_anchors(source_aln ? source_aln->sequence() : source_mp_aln->sequence(),
-                                   it->second.first, it->second.second);
+                                   it->second.first, it->second.second,
+                                   left_tail_length, right_tail_length);
         }
         
         // the surjected alignment for each path we overlapped
@@ -4643,10 +4662,11 @@ using namespace std;
     }
 
     void Surjector::prune_and_trim_anchors(const string& sequence, vector<path_chunk_t>& path_chunks,
-                                           vector<pair<step_handle_t, step_handle_t>>& step_ranges) const {
-        
-        if (!prune_suspicious_anchors && max_anchors > path_chunks.size()) {
-            // the setting don't require us to prune anything here
+                                           vector<pair<step_handle_t, step_handle_t>>& step_ranges,
+                                           size_t left_tail_length, size_t right_tail_length) const {
+
+        if (!prune_suspicious_anchors && !prune_tail_region_anchors && max_anchors > path_chunks.size()) {
+            // the settings don't require us to prune anything here
             return;
         }
         
@@ -4670,7 +4690,37 @@ using namespace std;
         }
         
         vector<bool> keep(path_chunks.size(), true);
-        
+
+        // Clamp tail lengths to the read length
+        size_t read_length = sequence.size();
+        left_tail_length = std::min(left_tail_length, read_length);
+        right_tail_length = std::min(right_tail_length, read_length);
+        size_t right_tail_begin = read_length - right_tail_length;
+
+        if (prune_tail_region_anchors) {
+            // Drop anchors whose entire read interval lies inside a mapper-declared tail region.
+            for (int i = 0; i < path_chunks.size(); ++i) {
+                auto& chunk = path_chunks[i];
+                size_t anchor_read_start = chunk.first.first - sequence.begin();
+                size_t anchor_read_end = chunk.first.second - sequence.begin();
+
+                bool fully_in_left_tail = (left_tail_length > 0 && anchor_read_end <= left_tail_length);
+                bool fully_in_right_tail = (right_tail_length > 0 && anchor_read_start >= right_tail_begin);
+
+                if (fully_in_left_tail || fully_in_right_tail) {
+#ifdef debug_anchored_surject
+                    cerr << "anchor " << i << " (read[" << anchor_read_start << ":" << anchor_read_end
+                        << "]) pruned for lying fully inside "
+                        << (fully_in_left_tail ? "left" : "right")
+                        << " tail region"
+                        << " (left_tail_length=" << left_tail_length
+                        << ", right_tail_length=" << right_tail_length << ")" << endl;
+#endif
+                    keep[i] = false;
+                }
+            }
+        }
+
         if (prune_suspicious_anchors) {
 #ifdef debug_anchored_surject
             cerr << "pruning suspicious anchors";
@@ -4682,7 +4732,12 @@ using namespace std;
             for (int i = 0; i < path_chunks.size(); ++i) {
                 auto& chunk = path_chunks[i];
                 // Mark anchors that are themselves suspicious as not to be kept.
-                
+
+                if (!keep[i]) {
+                    // Already pruned by the tail-region check above; skip remaining checks.
+                    continue;
+                }
+
                 // Short tails
                 if ((chunk.first.first == path_chunks.front().first.first || chunk.first.second == path_chunks.back().first.second) // Is at either tail
                     && (anchor_lengths[i] <= max_tail_anchor_prune || chunk.first.second - chunk.first.first <= max_tail_anchor_prune)) { // And is too short

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -90,7 +90,31 @@ using namespace std;
                                               vector<tuple<string, int64_t, bool>>& positions_out,
                                               bool allow_negative_scores = false,
                                               bool preserve_deletions = false) const;
-        
+
+        /// Compute mapping quality for the candidate at best_idx relative to the
+        /// other candidate scores.
+        int32_t compute_mapping_quality_from_scores(const Alignment& source,
+                                                    const std::vector<double>& scores,
+                                                    size_t best_idx,
+                                                    bool fast_approximation = false) const;
+
+        /// Mark the best non-supplementary haplotype surjection with hp:Z:pri_hap,
+        /// mark the others with hp:Z:sec_hap, and record haplotype quality in hq.
+        void annotate_hap_tags(const Alignment& source,
+                               std::vector<Alignment>& alns) const;
+
+        /// Choose one overall primary from all non-supplementary surjections,
+        /// mark the remaining candidates secondary, and compute their Global Quality.
+        /// The source primary's original Giraffe MAPQ is retained in aq.
+        void annotate_global_mapq_and_primary(const Alignment& source,
+                                              std::vector<Alignment>& alns) const;
+
+        /// Set a SAM-style tag, replacing an existing tag with the same name.
+        static void set_sam_tag_annotation(Alignment& aln,
+                                           const std::string& tag,
+                                           char type,
+                                           const std::string& value);
+
         /// a local type that represents a read interval matched to a portion of the alignment path
         using path_chunk_t = pair<pair<string::const_iterator, string::const_iterator>, path_t>;
 

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -286,17 +286,29 @@ using namespace std;
         template<class AlnType>
         string path_score_annotations(const unordered_map<pair<path_handle_t, bool>, vector<pair<AlnType, pair<step_handle_t, step_handle_t>>>>& surjections) const;
         
-        // helpers to choose one among supplementary alignments to be the primary
+        // helpers to choose one alignment as primary and classify the alternatives
+        /// Select the highest-scoring surjection as primary.
+        ///
+        /// Non-primary surjections that overlap the primary's query interval by more
+        /// than disjoint_interval_allowable_overlap are retained as secondary.
+        /// Disjoint surjections are retained as supplementary when
+        /// report_supplementary is enabled and are otherwise omitted.
+        ///
+        /// Modifies surjections in place by annotating retained alternatives and
+        /// removing supplementaries that were not requested.
         template<class AlnType>
         void choose_primary_internal(vector<pair<AlnType, pair<step_handle_t, step_handle_t>>>& surjections,
-                                     const function<void(AlnType&)>& annotate_supplementary) const;
+                                     const function<void(AlnType&)>& annotate_supplementary,
+                                     const function<void(AlnType&)>& annotate_secondary) const;
         void choose_primary(vector<pair<Alignment, pair<step_handle_t, step_handle_t>>>& surjections) const {
             function<void(Alignment&)> annotate_supplementary = [](Alignment& aln) { set_annotation<bool>(aln, "supplementary", true); };
-            choose_primary_internal(surjections, annotate_supplementary);
+            function<void(Alignment&)> annotate_secondary = [](Alignment& aln) { aln.set_is_secondary(true); };
+            choose_primary_internal(surjections, annotate_supplementary, annotate_secondary);
         }
         void choose_primary(vector<pair<multipath_alignment_t, pair<step_handle_t, step_handle_t>>>& surjections) const {
             function<void(multipath_alignment_t&)> annotate_supplementary = [](multipath_alignment_t& mp_aln) { mp_aln.set_annotation("supplementary", true); };
-            choose_primary_internal(surjections, annotate_supplementary);
+            function<void(multipath_alignment_t&)> annotate_secondary = [](multipath_alignment_t& mp_aln) { mp_aln.set_annotation("secondary", true); };
+            choose_primary_internal(surjections, annotate_supplementary, annotate_secondary);
         }
         
         vector<tuple<Alignment, size_t, size_t>> generate_hard_clipped_alignments(const Alignment& source) const;
@@ -456,7 +468,8 @@ using namespace std;
 
     template<class AlnType>
     void Surjector::choose_primary_internal(vector<pair<AlnType, pair<step_handle_t, step_handle_t>>>& surjections,
-                                            const function<void(AlnType&)>& annotate_supplementary) const {
+                                            const function<void(AlnType&)>& annotate_supplementary,
+                                            const function<void(AlnType&)>& annotate_secondary) const {
         if (surjections.size() > 1) {
             size_t opt_idx = 0;
             int32_t opt_score = get_score(surjections.front().first);
@@ -467,10 +480,29 @@ using namespace std;
                     opt_idx = i;
                 }
             }
-            
-            for (size_t i = 0; i < surjections.size(); ++i) {
-                if (i != opt_idx) {
+
+            const auto best_interval = aligned_interval(surjections[opt_idx].first);
+
+            // Iterate backward so supplementaries can be removed safely.
+            for (size_t i = surjections.size(); i-- > 0;) {
+                if (i == opt_idx) {
+                    continue;
+                }
+                // Compare query coverage
+                const auto interval = aligned_interval(surjections[i].first);
+                const int64_t query_overlap = max<int64_t>(
+                    0,
+                    min(best_interval.second, interval.second)
+                    - max(best_interval.first, interval.first));
+
+                if (query_overlap > disjoint_interval_allowable_overlap) {
+                    annotate_secondary(surjections[i].first);
+                }
+                else if (report_supplementary) {
                     annotate_supplementary(surjections[i].first);
+                }
+                else {
+                    surjections.erase(surjections.begin() + i);
                 }
             }
         }

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -26,6 +26,8 @@
 namespace vg {
 
 using namespace std;
+
+class FragmentLengthDistribution;
     
     /**
      * Widget to surject alignments down to linear paths in the graph.
@@ -114,6 +116,16 @@ using namespace std;
                                            const std::string& tag,
                                            char type,
                                            const std::string& value);
+
+        /// Score two surjections together, optionally including a Gaussian
+        /// fragment-length likelihood in the aligner's scoring units.
+        double score_alignment_pair(const Alignment& source,
+                                    const Alignment& first,
+                                    const Alignment& second,
+                                    int64_t template_length,
+                                    double fragment_mean,
+                                    double fragment_stddev,
+                                    bool use_fragment_length) const;
 
         /// a local type that represents a read interval matched to a portion of the alignment path
         using path_chunk_t = pair<pair<string::const_iterator, string::const_iterator>, path_t>;
@@ -460,6 +472,72 @@ using namespace std;
         
         /// the graph we're surjecting onto
         const PathPositionHandleGraph* graph = nullptr;
+    };
+
+    /// Surject and classify all paired graph placements for one fragment while
+    /// learning the fragment-length distribution needed for paired scoring.
+    class PairedSurjector {
+    public:
+        using alignment_pair_t = pair<Alignment, Alignment>;
+        using fragment_group_t = vector<alignment_pair_t>;
+
+        struct result_t {
+            vector<alignment_pair_t> pairs;
+            vector<Alignment> singles;
+        };
+
+        PairedSurjector(Surjector& surjector,
+                        const PathPositionHandleGraph* graph,
+                        size_t maximum_sample_size = 1000,
+                        size_t reestimation_frequency = 100,
+                        double robust_estimation_fraction = 0.95,
+                        size_t maximum_buffered_fragments = 50000);
+        ~PairedSurjector();
+
+        bool surject(fragment_group_t&& placements,
+                     const unordered_set<path_handle_t>& paths,
+                     bool allow_negative_scores,
+                     bool preserve_deletions,
+                     uint64_t maximum_fragment_length,
+                     result_t& result);
+
+        bool ready_for_parallel() const;
+        vector<fragment_group_t> finalize_fragment_length_distribution();
+        double fragment_length_mean() const;
+        double fragment_length_stddev() const;
+        size_t fragment_length_sample_size() const;
+
+    private:
+        struct pair_candidate_t {
+            size_t first = 0;
+            size_t second = 0;
+            int64_t template_length = numeric_limits<int64_t>::max();
+            double score = 0.0;
+        };
+
+        struct placement_t {
+            Alignment source_first;
+            Alignment source_second;
+            vector<Alignment> first;
+            vector<Alignment> second;
+            vector<pair_candidate_t> candidates;
+        };
+
+        int64_t compute_template_length(const Alignment& first,
+                                        const Alignment& second) const;
+        size_t choose_best(const Alignment& first_source,
+                           const Alignment& second_source,
+                           const vector<double>& scores) const;
+        void finalize_learning();
+
+        Surjector& surjector;
+        const PathPositionHandleGraph* graph;
+        unique_ptr<FragmentLengthDistribution> fragment_length_distribution;
+        vector<fragment_group_t> ambiguous_fragment_buffer;
+        size_t maximum_buffered_fragments;
+        size_t minimum_samples_for_estimate;
+        bool fragment_scoring_available = false;
+        bool learning_abandoned = false;
     };
 
     template<class AlnType>

--- a/src/surjector.hpp
+++ b/src/surjector.hpp
@@ -139,6 +139,9 @@ using namespace std;
         mutable atomic_flag warned_about_subgraph_size = ATOMIC_FLAG_INIT;
         
         bool prune_suspicious_anchors = false;
+        /// Remove anchors contained entirely within mapper-declared read tails.
+        /// Tail coordinates are relative to the stored read sequence.
+        bool prune_tail_region_anchors = false;
         int64_t max_tail_anchor_prune = 4;
         static constexpr int64_t DEFAULT_MAX_SLIDE = 6;
         /// Declare an anchor suspicious if it appears again at any offset up
@@ -243,7 +246,8 @@ using namespace std;
                                           vector<tuple<size_t, size_t, int32_t>>& connections) const;
         
         void prune_and_trim_anchors(const string& sequence, vector<path_chunk_t>& path_chunks,
-                                    vector<pair<step_handle_t, step_handle_t>>& step_ranges) const;
+                                    vector<pair<step_handle_t, step_handle_t>>& step_ranges,
+                                    size_t left_tail_length = 0, size_t right_tail_length = 0) const;
         
         /// Compute the widest end-inclusive interval of path positions that
         /// the realigned sequence could align to, or an interval where start >


### PR DESCRIPTION
## Changelog Entry

- `vg surject --diploid-map --interleaved` now evaluates alternative paired graph placements jointly using haplotype alignment scores and the learned fragment-length distribution.

## Description

This PR adds paired short-read support for `vg surject --diploid-map --interleaved`.

Consecutive alternative placements for the same fragment are grouped and surjected to both sample haplotypes. Compatible mate combinations are enumerated and scored using their combined alignment score and, once available, the learned fragment-length distribution.

The highest-scoring candidate pair becomes the overall primary pair. Alternative compatible placements are emitted as secondary pairs, while supplementary or otherwise unpaired surjections are emitted separately with appropriate mate information.

Fragment-length learning initially runs serially using high-confidence pairs. Ambiguous fragments are buffered until the distribution is available, after which processing continues in parallel.

The output uses:

- `hp` for the preferred or alternative haplotype placement;
- `hq` for confidence in the haplotype selection;
- `aq` for the original graph-alignment mapping quality;
- MAPQ (GlobalQ) for confidence in the globally selected paired placement.

This PR depends on:

- the long-read `--diploid-map` vg changes;
- vgteam/libvgio#95.

This is currently a stacked draft PR and will be rebased onto `master` after its dependencies merge.