### PR TITLE
surject: realign anchors containing substitutions

### DIFF
--- a/src/surjector.cpp
+++ b/src/surjector.cpp
@@ -3403,13 +3403,26 @@ using namespace std;
                 }
 #endif
                 auto normal_aligner = get_aligner(!source.quality().empty());
+                bool chunk_has_substitution = false;
+                if (mp_aln_path_chunks->size() == 1) {
+                    const auto& chunk_path = mp_aln_path_chunks->front().second;
+                    for (size_t i = 0; i < chunk_path.mapping_size() && !chunk_has_substitution; ++i) {
+                        for (const auto& edit : chunk_path.mapping(i).edit()) {
+                            chunk_has_substitution = chunk_has_substitution ||
+                                (edit.from_length() != 0 && edit.to_length() != 0 && !edit.sequence().empty());
+                        }
+                    }
+                }
                 // check whether it's necessary to do any alignment in this interval
                 if (mp_aln_path_chunks->size() == 1 &&
+                    !chunk_has_substitution &&
                     mp_aln_path_chunks->front().first.first == mp_aln_source->sequence().begin() &&
                     mp_aln_path_chunks->front().first.second == mp_aln_source->sequence().end()) {
 #ifdef debug_anchored_surject
                     cerr << "chunk constitutes full alignment of this interval, no need for multipath alignment" << endl;
 #endif
+                    surjected_aln.set_sequence(mp_aln_source->sequence());
+                    surjected_aln.set_quality(mp_aln_source->quality());
                     to_proto_path(mp_aln_path_chunks->front().second, *surjected_aln.mutable_path());
                     surjected_aln.set_score(normal_aligner->scorer->score_contiguous_alignment(surjected_aln));
                     // TODO: it should be possible to rely on the ref chunks here rather than using the path scan later


### PR DESCRIPTION
## Changelog Entry

- Surjection now realigns complete anchor chunks containing substitutions
  instead of accepting them through the exact-anchor shortcut.

## Description

When one anchor chunk covered an entire surjection interval, surjection copied
the chunk directly and rescored it without realignment. This shortcut assumed
that the chunk represented an exact match.

Some mapper-produced chunks contain sequence-bearing substitution edits,
including ambiguous `N` bases. Applying the shortcut to these chunks could
produce incorrect alignment scores, including large negative scores.

This change restricts the shortcut to chunks without substitutions. Chunks
containing substitutions follow the existing multipath realignment path.
It also initializes the interval sequence and base qualities before rescoring
a shortcut alignment.
