### PR TITLE
GAF sorting improvements

### DIFF
--- a/src/gaf_sorter.cpp
+++ b/src/gaf_sorter.cpp
@@ -44,17 +44,28 @@ void GAFSorterRecord::set_key(key_type type) {
         std::uint32_t min_id = std::numeric_limits<std::uint32_t>::max();
         std::uint32_t max_id = 0;
         std::string_view path = this->get_field(PATH_FIELD);
-        size_t start = 1;
+        size_t start = 0;
         while (start < path.size()) {
+            bool is_reverse;
+            if (path[start] == '<') {
+                is_reverse = true;
+            } else if (path[start] == '>') {
+                is_reverse = false;
+            } else {
+                this->key = MISSING_KEY;
+                return;
+            }
+            start++;
             std::uint32_t id = 0;
             auto result = std::from_chars(path.data() + start, path.data() + path.size(), id);
             if (result.ec != std::errc()) {
                 this->key = MISSING_KEY;
                 return;
             }
+            id = gbwt::Node::encode(id, is_reverse);
             min_id = std::min(min_id, id);
             max_id = std::max(max_id, id);
-            start = (result.ptr - path.data()) + 1;
+            start = (result.ptr - path.data());
         }
         if (min_id == std::numeric_limits<std::uint32_t>::max()) {
             this->key = MISSING_KEY;

--- a/src/gaf_sorter.cpp
+++ b/src/gaf_sorter.cpp
@@ -1,6 +1,7 @@
 #include "gaf_sorter.hpp"
 
 #include <chrono>
+#include <cmath>
 #include <deque>
 #include <fstream>
 #include <queue>
@@ -428,8 +429,16 @@ bool sort_gaf(const std::string& input_file, const std::string& output_file, con
         std::cerr << "Initial sort finished with " << total_records << " records in " << files.size() << " files" << std::endl;
     }
 
-    // Intermediate merges. If a worker thread fails, we break on join.
+    // Adjust merge width if necessary.
     size_t files_per_merge = std::max(params.files_per_merge, size_t(2));
+    if (params.two_merge_rounds && files.size() > files_per_merge * files_per_merge) {
+        files_per_merge = static_cast<size_t>(std::ceil(std::sqrt(files.size())));
+        if (params.progress) {
+            std::cerr << "Adjusting merge width to " << files_per_merge << std::endl;
+        }
+    }
+
+    // Intermediate merges. If a worker thread fails, we break on join.
     size_t round = 0;
     while (files.size() > files_per_merge) {
         if (params.progress) {

--- a/src/gaf_sorter.hpp
+++ b/src/gaf_sorter.hpp
@@ -7,7 +7,6 @@
  * NOTE: There is an equivalent standalone tool included with GBZ-base.
  *
  * TODO: Asynchronous I/O.
- * TODO: Option for automatic detection of merge width to guarantee <= 2 rounds.
  * TODO: Option for giving approximate batch size in bytes.
  */
 
@@ -237,11 +236,14 @@ struct GAFSorterParameters {
     /// Buffer size for reading and writing records.
     size_t buffer_size = BUFFER_SIZE;
 
+    /// GBWT output file, if any.
+    std::string gbwt_file;
+
     /// Use stable sorting.
     bool stable = false;
 
-    /// GBWT output file, if any.
-    std::string gbwt_file;
+    /// Guarantee <= 2 merge rounds.
+    bool two_merge_rounds = false;
 
     /// Make the GBWT bidirectional.
     bool bidirectional_gbwt = false;

--- a/src/gaf_sorter.hpp
+++ b/src/gaf_sorter.hpp
@@ -48,7 +48,7 @@ struct GAFSorterRecord {
 
     /// Types of keys that can be derived from the value.
     enum key_type {
-        /// (minimum node id, maximum node id) in the path.
+        /// (minimum GBWT node id, maximum GBWT node id) in the path.
         key_node_interval,
         /// Hash of the value for random shuffling.
         key_hash,

--- a/src/subcommand/gamsort_main.cpp
+++ b/src/subcommand/gamsort_main.cpp
@@ -51,6 +51,7 @@ void help_gamsort(char** argv) {
                                         << "[" << GAFSorterParameters::RECORDS_PER_FILE << "]" << std::endl;
     std::cerr << "  -m, --merge-width N     number of files to merge at once "
                                         << "[" << GAFSorterParameters::FILES_PER_MERGE << "]" << std::endl;
+    std::cerr << "      --two-merge-rounds  adjust --merge-width to guarantee <= 2 merge rounds" << std::endl;
     std::cerr << "  -S, --stable            use stable sorting" << std::endl;
     std::cerr << "  -g, --gbwt-output FILE  write a GBWT index of the paths to FILE" << std::endl;
     std::cerr << "  -b, --bidirectional     make the GBWT index bidirectional" << std::endl;
@@ -75,6 +76,8 @@ int main_gamsort(int argc, char **argv) {
     // GAF sorting options.
     GAFSorterParameters gaf_params;
 
+    constexpr int OPT_TWO_MERGE_ROUNDS = 1000;
+
     int c;
     optind = 2; // force optind past command positional argument
     while (true)
@@ -88,6 +91,7 @@ int main_gamsort(int argc, char **argv) {
             { "gaf-input", no_argument, 0, 'G' },
             { "chunk-size", required_argument, 0, 'c' },
             { "merge-width", required_argument, 0, 'm' },
+            { "two-merge-rounds", no_argument, 0, OPT_TWO_MERGE_ROUNDS },
             { "stable", no_argument, 0, 'S' },
             { "gbwt-output", required_argument, 0, 'g' },
             { "bidirectional", no_argument, 0, 'b' },
@@ -133,6 +137,9 @@ int main_gamsort(int argc, char **argv) {
             break;
         case 'm':
             gaf_params.files_per_merge = parse<size_t>(optarg);
+            break;
+        case OPT_TWO_MERGE_ROUNDS:
+            gaf_params.two_merge_rounds = true;
             break;
         case 'S':
             gaf_params.stable = true;

--- a/src/unittest/gaf_sorter.cpp
+++ b/src/unittest/gaf_sorter.cpp
@@ -27,14 +27,10 @@ struct GAFInfo {
     gbwt::vector_type forward_path;
     size_t id;
     std::uint32_t min_node, max_node;
-    std::uint32_t first_node;
-    bool first_is_reverse;
 
     GAFInfo(size_t id, size_t nodes) :
         id(id),
-        min_node(std::numeric_limits<std::uint32_t>::max()), max_node(0),
-        first_node(std::numeric_limits<std::uint32_t>::max()),
-        first_is_reverse(false) {
+        min_node(std::numeric_limits<std::uint32_t>::max()), max_node(0) {
 
         // Name, query length, query start, query end;
         std::string nd = std::to_string(nodes);
@@ -49,13 +45,10 @@ struct GAFInfo {
         for (size_t i = 0; i < nodes; i++) {
             std::uint32_t node = rng() % 1000 + 1;
             bool reverse = rng() % 2;
-            this->forward_path.push_back(gbwt::Node::encode(node, reverse));
-            this->min_node = std::min(this->min_node, node);
-            this->max_node = std::max(this->max_node, node);
-            if (i == 0) {
-                this->first_node = node;
-                this->first_is_reverse = reverse;
-            }
+            std::uint32_t gbwt_node = gbwt::Node::encode(node, reverse);
+            this->forward_path.push_back(gbwt_node);
+            this->min_node = std::min(this->min_node, gbwt_node);
+            this->max_node = std::max(this->max_node, gbwt_node);
             this->line += (reverse ? "<" : ">") + std::to_string(node);
         }
         if (is_reverse) {

--- a/test/t/42_vg_gamsort.t
+++ b/test/t/42_vg_gamsort.t
@@ -74,7 +74,7 @@ grep -v "^@" x.shuffled.gaf | sort > x.shuffled.gaf.lexicographic
 cmp x.gaf.lexicographic x.shuffled.gaf.lexicographic
 is "$?" "0" "Shuffling a GAF preserves read data"
 
-rm -f x.gaf x.gaf.header, x.gaf.no_header x.gaf.lexicographic
+rm -f x.gaf x.gaf.header x.gaf.no_header x.gaf.lexicographic
 rm -f x.sorted.gaf x.sorted.gaf.header x.sorted.gaf.lexicographic
 rm -f x.shuffled.gaf x.shuffled.gaf.lexicographic
 rm -f x.gbwt


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `vg gamsort` sorts GAF by GBWT node id intervals for better compatibility with GAF-base.
 * `vg gamsort` option `--two-merge-rounds` to guarantee at most two rounds of merges when sorting GAF.

## Description

Some small improvements to GAF sorting with `vg gamsort`. Sorting is now done by GBWT (oriented) node id intervals rather than vg (unoriented) node id intervals to meet the expectations of GAF-base. There is also option `--two-merge-rounds` that increases the merge width when necessary to guarantee at most two merge rounds.