### PR TITLE
avoid underflow

### DIFF
--- a/src/minimizer_mapper_from_chains.cpp
+++ b/src/minimizer_mapper_from_chains.cpp
@@ -2249,7 +2249,9 @@ void MinimizerMapper::do_alignment_on_chains(const Alignment& aln, const std::ve
                                      seeds[chains[chain_i].back()],
                                      seeds[chains[chain_j].front()],
                                      seeds[chains[chain_j].back()])) {
-                --chain_count_by_alignment[i];
+                // chain i is basically chain j, so don't count it against chain j
+                crash_unless(chain_count_by_alignment[j] > 0);
+                --chain_count_by_alignment[j];
             }
         }
     }


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Avoid underflowing multiplicities in `vg giraffe` chaining mode (caused erroneous MAPQ 0)

## Description

We had been managing to underflow `chain_count_by_alignment` here such that multiplicities got set as just around the maximum value for a `size_t`. Such high multiplicity guaranteed a MAPQ of 0.

This will not change the alignments output. It _will_ likely "rescue" some MAPQ 0s, including some that represent incorrect alignments, and that will change variant calling. I have not tested the extent of the change.