### PR TITLE
Swap to mirrors for anongit.freedesktop.org submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -126,10 +126,10 @@
 	url = https://github.com/babyplutokurt/GFAz.git
 [submodule "deps/cairo"]
 	path = deps/cairo
-	url = git://anongit.freedesktop.org/git/cairo
+	url = https://gitlab.freedesktop.org/cairo/cairo.git
 [submodule "deps/pixman"]
 	path = deps/pixman
-	url = git://anongit.freedesktop.org/git/pixman
+	url = https://gitlab.freedesktop.org/pixman/pixman.git
 [submodule "deps/elfutils"]
 	path = deps/elfutils
 	url = https://github.com/vgteam/elfutils.git


### PR DESCRIPTION
## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * `cairo` and `pixman` submodules pulled from `https://gitlab.freedesktop.org` instead of `git://anongit.freedesktop.org` since the latter seems to have broken

## Description

Fix the ability to clone/build vg from source (at least on my computer) and thus fix CI tests. Importantly, assuming this works, we'll be able to do a release on Monday