### PR TITLE
Special treatment for GRef references in vg haplptypes

### DIFF
--- a/src/gref.cpp
+++ b/src/gref.cpp
@@ -113,16 +113,18 @@ void GrefCover::compute(const PathHandleGraph* graph,
         // scans in apply() and write_gref_segments() used to paper over -- and they papered
         // over it inconsistently, because one ran before the base copies existed and one after,
         // so the segments table named a path holding entirely different sequence.
-        // Test the copy name, not the path name: a PanSN path read from a GFA with no RS
-        // header carries a phase block (CHM13#0#chr1_1_alt#0), which does not end in _alt even
-        // though the copy made from it does.
+        // Test the fragment base name, not the path name and not the copy name.  The path
+        // name can carry a phase block (CHM13#0#chr1_1_alt#0, from a PanSN GFA with no RS
+        // header) and the copy name can carry a subrange (gref_CHM13#0#chr1_1_alt[100-200]);
+        // neither ends in _alt, so neither sees the collision.  make_gref_base_name() drops
+        // both, leaving exactly the name make_gref_name() hangs the fragments off.
         string ref_name = graph->get_path_name(ref_path_handle);
-        string copy_name = make_gref_copy_name(ref_name);
-        if (is_gref_name(copy_name)) {
+        string base_name = make_gref_base_name(ref_name);
+        if (is_gref_name(base_name)) {
             cerr << "[gref error]: reference path " << ref_name << " would be copied to "
-                 << copy_name << ", which is a gref fragment name (_{N}_alt), so it would"
+                 << base_name << ", which is a gref fragment name (_{N}_alt), so it would"
                  << " collide with the fragments hanging off "
-                 << parse_base_path(copy_name) << ". Rename the contig, or select reference"
+                 << parse_base_path(base_name) << ". Rename the contig, or select reference"
                  << " paths that are not in the gref namespace." << endl;
             exit(1);
         }

--- a/src/recombinator.cpp
+++ b/src/recombinator.cpp
@@ -1,5 +1,6 @@
 #include "recombinator.hpp"
 
+#include "gref.hpp"
 #include "kff.hpp"
 #include "statistics.hpp"
 #include "algorithms/component.hpp"
@@ -33,6 +34,7 @@ constexpr size_t Recombinator::KFF_BLOCK_SIZE;
 constexpr double Recombinator::PRESENT_DISCOUNT;
 constexpr double Recombinator::HET_ADJUSTMENT;
 constexpr double Recombinator::ABSENT_SCORE;
+constexpr size_t Recombinator::MIN_GREF_LENGTH;
 
 //------------------------------------------------------------------------------
 
@@ -491,8 +493,28 @@ Haplotypes HaplotypePartitioner::partition_haplotypes(const Parameters& paramete
 
     // Assign chains to jobs and fill in contig names.
     auto chains_by_job = gbwtgraph::partition_chains(this->distance_index, this->gbz.graph, jobs);
-    // We do not use a path filter, because a GBZ graph should not contain alt paths.
-    auto contig_names = jobs.contig_names(this->gbz.graph);
+    // A component is named after the first reference/generic path found in it, and that name
+    // becomes the contig of every haplotype generated from the chain. Prefer a name from
+    // outside the gref namespace, so that adding a gref cover to a graph does not rename its
+    // chains: a fragment would name the chain `chr1_7_alt`, and a gref copy of a non-PanSN
+    // reference carries the whole name as its locus, so it would give `gref_x` instead of `x`.
+    // Where a component has nothing else, fall back to any gref path that is not a fragment;
+    // for PanSN that is the copy of the reference path, whose locus is the right name anyway.
+    std::function<bool(const path_handle_t&)> not_gref = [&](const path_handle_t& path) -> bool {
+        return !GrefCover::is_gref_derived(this->gbz.graph.get_sample_name(path))
+            && !GrefCover::is_gref_derived(this->gbz.graph.get_locus_name(path));
+    };
+    std::function<bool(const path_handle_t&)> not_gref_fragment = [&](const path_handle_t& path) -> bool {
+        return !is_gref_fragment(this->gbz.graph.get_sample_name(path), this->gbz.graph.get_locus_name(path));
+    };
+    auto contig_names = jobs.contig_names(this->gbz.graph, not_gref);
+    auto gref_names = jobs.contig_names(this->gbz.graph, not_gref_fragment);
+    for (size_t i = 0; i < contig_names.size(); i++) {
+        // contig_names() falls back to "component_i" when the filter rejects everything.
+        if (contig_names[i] == "component_" + std::to_string(i)) {
+            contig_names[i] = gref_names[i];
+        }
+    }
     for (size_t job_id = 0; job_id < result.jobs(); job_id++) {
         for (auto& chain : chains_by_job[job_id]) {
             result.chains[chain.offset].job_id = job_id;
@@ -1537,6 +1559,8 @@ void Recombinator::Statistics::combine(const Statistics& another) {
     this->connections += another.connections;
     this->ref_paths += another.ref_paths;
     this->copied_paths += another.copied_paths;
+    this->gref_fragments += another.gref_fragments;
+    this->gref_fragments_dropped += another.gref_fragments_dropped;
     this->kmers += another.kmers;
     this->score += another.score;
 }
@@ -1556,6 +1580,9 @@ std::ostream& Recombinator::Statistics::print(std::ostream& out) const {
     }
     if (this->copied_paths > 0) {
         out << "; copied " << this->copied_paths << " paths from excluded chains";
+    }
+    if (this->gref_fragments > 0 || this->gref_fragments_dropped > 0) {
+        out << "; clipped gref fragments to " << this->gref_fragments << " pieces (" << this->gref_fragments_dropped << " too short)";
     }
     if (this->kmers > 0) {
         double average_score = this->score / (this->kmers * this->haplotypes);
@@ -1609,7 +1636,7 @@ void Recombinator::Parameters::print(std::ostream& out) const {
         out << "- heuristic sampling (" << this->num_haplotypes << " haplotypes)" << std::endl;
     }
     if (this->include_reference) {
-        out << "- include reference paths" << std::endl;
+        out << "- include reference paths (gref fragments clipped, min length " << this->min_gref_length << ")" << std::endl;
     }
     if (!this->high_coverage_chains.empty()) {
         out << "- " << this->high_coverage_chains.size() << " high-coverage chains ("
@@ -1640,6 +1667,128 @@ void add_path(const gbwt::GBWT& source, gbwt::size_type path_id, gbwt::GBWTBuild
 
     gbwt::vector_type path = source.extract(gbwt::Path::encode(path_id, false));
     builder.insert(path, true);
+}
+
+//------------------------------------------------------------------------------
+
+bool is_gref_fragment(const std::string& sample_name, const std::string& contig_name) {
+    if (sample_name == gbwtgraph::GENERIC_PATH_SAMPLE_NAME || sample_name == PathMetadata::NO_SAMPLE_NAME) {
+        // A generic path stores its whole name as the contig, so the gref
+        // namespace and the fragment suffix are both in there.
+        return GrefCover::is_gref_derived(contig_name) && GrefCover::is_gref_name(contig_name);
+    }
+    return GrefCover::is_gref_derived(sample_name) && GrefCover::is_gref_name(contig_name);
+}
+
+// As above, for a path in the given GBWT index. Assumes that the path has full metadata.
+bool is_gref_fragment(const gbwt::GBWT& index, gbwt::size_type path_id) {
+    gbwt::PathName path_name = index.metadata.path(path_id);
+    return is_gref_fragment(index.metadata.sample(path_name.sample), index.metadata.contig(path_name.contig));
+}
+
+std::vector<PathPiece> clip_path_to_index(
+    const gbwt::vector_type& path, const gbwt::DynamicGBWT& index,
+    const std::function<size_t(gbwt::node_type)>& node_length
+) {
+    std::vector<PathPiece> result;
+
+    // `contains()` only checks that the node is within the alphabet, so a node is in the
+    // index only if its record is also nonempty -- that is the test
+    // `GBWTGraph::determine_real_nodes()` uses to decide which nodes the graph has.
+    // `hasEdge()` validates its source node itself, so it is safe on any node id.
+    auto present = [&](gbwt::node_type node) -> bool {
+        return index.contains(node) && !index.empty(node);
+    };
+
+    PathPiece piece;
+    size_t offset = 0; // Offset (in bp) of the current node from the start of the path.
+    for (size_t i = 0; i < path.size(); i++) {
+        gbwt::node_type node = path[i];
+        bool extends = (piece.nodes > 0 && index.hasEdge(path[i - 1], node));
+        if (!extends && piece.nodes > 0) {
+            result.push_back(piece);
+            piece.nodes = 0;
+        }
+        if (extends || present(node)) {
+            if (piece.nodes == 0) {
+                piece.start = i;
+                piece.bp_offset = offset;
+                piece.bp_length = 0;
+            }
+            piece.nodes++;
+            piece.bp_length += node_length(node);
+        }
+        offset += node_length(node);
+    }
+    if (piece.nodes > 0) {
+        result.push_back(piece);
+    }
+
+    return result;
+}
+
+// Adds the pieces of the given gref fragments that survive in the builder to the
+// builder. Call this after `builder.finish()`, so that the index reflects all
+// other paths in the job; `clip_path_to_index()` then guarantees that no new
+// nodes or edges are added. A piece starting at offset 0 keeps the original path
+// name, while the others become subranges (`gref_CHM13#0#chr1_7_alt[500]`), with
+// offsets relative to the fragment in the full graph even if it had already
+// been clipped.
+//
+// Every fragment is clipped before any of them is inserted. `builder.insert()`
+// flushes the builder once its buffer fills, and a flush hands the index to a
+// construction thread that keeps mutating it until the next flush, so the index
+// must not be read once insertion has started.
+void add_gref_fragments(
+    const gbwtgraph::GBZ& gbz, const std::vector<gbwt::size_type>& path_ids, size_t min_length,
+    gbwt::GBWTBuilder& builder, gbwtgraph::MetadataBuilder& metadata, Recombinator::Statistics& statistics
+) {
+    auto node_length = [&](gbwt::node_type node) -> size_t {
+        return gbz.graph.get_length(gbwtgraph::GBWTGraph::node_to_handle(node));
+    };
+
+    // A surviving piece and the subrange start it will be named with.
+    struct ClippedPiece {
+        gbwt::size_type path_id;
+        gbwt::vector_type nodes;
+        size_t count;
+    };
+    std::vector<ClippedPiece> pieces;
+    for (gbwt::size_type path_id : path_ids) {
+        size_t original_count = gbz.index.metadata.path(path_id).count;
+        gbwt::vector_type path = gbz.index.extract(gbwt::Path::encode(path_id, false));
+        for (const PathPiece& piece : clip_path_to_index(path, builder.index, node_length)) {
+            if (piece.bp_length < min_length) {
+                statistics.gref_fragments_dropped++;
+                continue;
+            }
+            pieces.push_back({
+                path_id,
+                gbwt::vector_type(path.begin() + piece.start, path.begin() + piece.start + piece.nodes),
+                original_count + piece.bp_offset
+            });
+        }
+    }
+
+    for (const ClippedPiece& piece : pieces) {
+        gbwt::PathName path_name = gbz.index.metadata.path(piece.path_id);
+        std::string sample_name = gbz.index.metadata.sample(path_name.sample);
+        std::string contig_name = gbz.index.metadata.contig(path_name.contig);
+        // The metadata must be added in the same order as the paths.
+        if (sample_name == gbwtgraph::GENERIC_PATH_SAMPLE_NAME) {
+            // As add_generic_path(), but with the subrange start as the count.
+            metadata.add_path(
+                PathSense::GENERIC, PathMetadata::NO_SAMPLE_NAME, contig_name,
+                PathMetadata::NO_HAPLOTYPE, PathMetadata::NO_PHASE_BLOCK,
+                subrange_t(piece.count, PathMetadata::NO_END_POSITION)
+            );
+        } else {
+            // Reference samples will be copied later.
+            metadata.add_haplotype(sample_name, contig_name, path_name.phase, piece.count);
+        }
+        builder.insert(piece.nodes, true);
+        statistics.gref_fragments++;
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -1808,14 +1957,21 @@ gbwt::GBWT Recombinator::generate_haplotypes(const std::string& kff_file, const 
         }
     }
 
-    // Figure out GBWT path ids for reference paths in each job.
+    // Figure out GBWT path ids for reference paths in each job. Gref fragments are
+    // kept apart: copying them through would keep every node of the gref cover, so
+    // they are clipped to the sampled graph once the job is otherwise complete.
     std::vector<std::vector<gbwt::size_type>> reference_paths(this->haplotypes.jobs());
+    std::vector<std::vector<gbwt::size_type>> gref_fragment_paths(this->haplotypes.jobs());
     if (parameters.include_reference) {
         for (size_t i = 0; i < this->gbz.graph.named_paths.size(); i++) {
             size_t job_id = this->jobs_for_cached_paths[i];
             gbwt::size_type path_id = this->gbz.graph.named_paths[i].id;
             if (job_id < this->haplotypes.jobs() && excluded_path_ids.find(path_id) == excluded_path_ids.end()) {
-                reference_paths[job_id].push_back(path_id);
+                if (is_gref_fragment(this->gbz.index, path_id)) {
+                    gref_fragment_paths[job_id].push_back(path_id);
+                } else {
+                    reference_paths[job_id].push_back(path_id);
+                }
             }
         }
     }
@@ -1879,6 +2035,12 @@ gbwt::GBWT Recombinator::generate_haplotypes(const std::string& kff_file, const 
             }
         }
         builder.finish();
+        // The topology of the job is now final. Add the pieces of the gref
+        // fragments that fit in it; they cannot add nodes or edges.
+        if (!gref_fragment_paths[job].empty()) {
+            add_gref_fragments(this->gbz, gref_fragment_paths[job], parameters.min_gref_length, builder, metadata, job_statistics);
+            builder.finish();
+        }
         builder.index.addMetadata();
         builder.index.metadata = metadata.get_metadata();
         indexes[job] = builder.index;

--- a/src/recombinator.hpp
+++ b/src/recombinator.hpp
@@ -11,6 +11,7 @@
 #include "hash_map.hpp"
 #include "snarl_distance_index.hpp"
 
+#include <functional>
 #include <iostream>
 
 #include <gbwtgraph/algorithms.h>
@@ -497,6 +498,10 @@ public:
     /// keeping wrong variants out.
     constexpr static double ABSENT_SCORE = 0.8;
 
+    /// Minimum length (in bp) for a piece of a gref fragment to survive in the
+    /// sampled graph. The same floor as `vg paths --min-gref-len`.
+    constexpr static size_t MIN_GREF_LENGTH = 50;
+
     /// The amount of progress information that should be printed to stderr.
     typedef Haplotypes::Verbosity Verbosity;
 
@@ -535,6 +540,12 @@ public:
 
         /// Number of paths copied verbatim from excluded chains.
         size_t copied_paths = 0;
+
+        /// Number of gref fragment pieces that survived in the sampled graph.
+        size_t gref_fragments = 0;
+
+        /// Number of gref fragment pieces dropped for being too short.
+        size_t gref_fragments_dropped = 0;
 
         /// Number of kmers selected.
         size_t kmers = 0;
@@ -594,8 +605,14 @@ public:
         /// Badness threshold for subchains when using diploid sampling.
         double badness_threshold = BADNESS_THRESHOLD;
 
-        /// Include named and reference paths.
+        /// Include named and reference paths. Gref fragments (`gref_CHM13#0#chr1_7_alt`)
+        /// are not copied through, as that would pin the whole gref cover to the
+        /// output; they are clipped to the sampled graph instead. See
+        /// `clip_path_to_index()`.
         bool include_reference = false;
+
+        /// Minimum length (in bp) for a piece of a gref fragment to be kept.
+        size_t min_gref_length = MIN_GREF_LENGTH;
 
         /// Samples whose haplotypes shouldn't be used, even if they score well.
         unordered_set<std::string> banned_samples;
@@ -724,6 +741,48 @@ private:
     Statistics copy_chain(const Haplotypes::TopLevelChain& chain,
         gbwt::GBWTBuilder& builder, gbwtgraph::MetadataBuilder& metadata) const;
 };
+
+//------------------------------------------------------------------------------
+
+/**
+ * Returns true if a path with the given GBWT sample and contig names is a gref
+ * fragment: a path in the gref namespace whose contig has the `_{N}_alt`
+ * fragment suffix (`gref_CHM13#0#chr1_7_alt`). Gref copies of reference paths
+ * (`gref_CHM13#0#chr1`) are not fragments. Generic paths carry their full name
+ * as the contig, which handles gref covers of non-PanSN references (`gref_x_1_alt`).
+ *
+ * The names are the metadata fields, not the composed path name: a fragment that
+ * has already been clipped once renders as `gref_CHM13#0#chr1_7_alt[500]`, and the
+ * subrange must not hide the suffix.
+ */
+bool is_gref_fragment(const std::string& sample_name, const std::string& contig_name);
+
+/// A maximal piece of a path whose nodes and edges all exist in a GBWT index.
+struct PathPiece {
+    /// Offset of the first node in the source path.
+    size_t start = 0;
+
+    /// Number of nodes in the piece.
+    size_t nodes = 0;
+
+    /// Offset (in bp) of the piece from the start of the source path.
+    size_t bp_offset = 0;
+
+    /// Length of the piece in bp.
+    size_t bp_length = 0;
+};
+
+/**
+ * Splits `path` into the maximal pieces whose nodes are all in `index` and whose
+ * consecutive nodes are all joined by an edge in `index`. Every piece can then be
+ * inserted into the index without adding any node or edge to the graph it
+ * encodes. `node_length` gives the length of a GBWT node in bp; offsets are
+ * accumulated over every node of the path, whether it survives or not.
+ */
+std::vector<PathPiece> clip_path_to_index(
+    const gbwt::vector_type& path, const gbwt::DynamicGBWT& index,
+    const std::function<size_t(gbwt::node_type)>& node_length
+);
 
 //------------------------------------------------------------------------------
 

--- a/src/subcommand/haplotypes_main.cpp
+++ b/src/subcommand/haplotypes_main.cpp
@@ -81,6 +81,10 @@ constexpr double badness() {
     return Recombinator::BADNESS_THRESHOLD;
 }
 
+constexpr size_t min_gref_len() {
+    return Recombinator::MIN_GREF_LENGTH;
+}
+
 }; // namespace haplotypes_defaults
 
 //----------------------------------------------------------------------------
@@ -256,8 +260,11 @@ void help_haplotypes(char** argv, bool developer_options) {
     std::cerr << "                               in --diploid-sampling" << std::endl;
     std::cerr << "      --badness F              threshold for badness of a subchain "
                                              << "[" << haplotypes_defaults::badness() << "]" << std::endl;
-    std::cerr << "      --include-reference      include named and reference paths in the output" << std::endl;
+    std::cerr << "      --include-reference      include named and reference paths in the output;" << std::endl;
+    std::cerr << "                               gref fragments are clipped to the sampled graph" << std::endl;
     std::cerr << "      --set-reference NAME     use sample X as a reference sample (may repeat)" << std::endl;
+    std::cerr << "      --min-gref-len N         minimum length of a clipped gref fragment "
+                                             << "[" << haplotypes_defaults::min_gref_len() << "]" << std::endl;
     std::cerr << "      --ban-sample NAME        don't use NAME haplotypes, no matter the score" << std::endl;
     std::cerr << "      --high-cov-contig NAME   sample contig/path NAME with the high-coverage" << std::endl;
     std::cerr << "                               model: frequent kmers are the signal, no diploid" << std::endl;
@@ -317,6 +324,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
     constexpr int OPT_HALF_COVERAGE_NUM_HAPLOTYPES = 1316;
     constexpr int OPT_EXCLUDE_CONTIG = 1317;
     constexpr int OPT_WRAP = 1318;
+    constexpr int OPT_MIN_GREF_LEN = 1319;
     constexpr int OPT_VALIDATE = 1400;
     constexpr int OPT_STATISTICS = 1500;
     constexpr int OPT_DENSITY = 1600;
@@ -345,6 +353,7 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
         { "badness", required_argument, 0, OPT_BADNESS },
         { "include-reference", no_argument, 0, OPT_INCLUDE_REFERENCE },
         { "set-reference", required_argument, 0, OPT_SET_REFERENCE },
+        { "min-gref-len", required_argument, 0, OPT_MIN_GREF_LEN },
         { "ban-sample", required_argument, 0, OPT_BAN_SAMPLE },
         { "high-cov-contig", required_argument, 0, OPT_HIGH_COVERAGE_CONTIG },
         { "high-cov-num-haps", required_argument, 0, OPT_HIGH_COVERAGE_NUM_HAPLOTYPES },
@@ -479,6 +488,12 @@ HaplotypesConfig::HaplotypesConfig(int argc, char** argv, size_t max_threads) {
             break;
         case OPT_SET_REFERENCE:
             this->reference_samples.insert(optarg);
+            break;
+        case OPT_MIN_GREF_LEN:
+            this->recombinator_parameters.min_gref_length = parse<size_t>(optarg);
+            if (this->recombinator_parameters.min_gref_length == 0) {
+                this->logger.error() << "minimum gref fragment length cannot be 0" << std::endl;
+            }
             break;
         case OPT_BAN_SAMPLE:
             this->recombinator_parameters.banned_samples.insert(optarg);

--- a/src/unittest/recombinator.cpp
+++ b/src/unittest/recombinator.cpp
@@ -1,0 +1,193 @@
+/** \file
+ *
+ * Unit tests for recombinator.cpp, specifically for clipping gref fragments to a
+ * sampled graph.
+ */
+
+#include "../recombinator.hpp"
+
+#include "catch.hpp"
+
+#include <set>
+#include <utility>
+#include <vector>
+
+namespace vg {
+
+namespace unittest {
+
+//------------------------------------------------------------------------------
+
+namespace {
+
+// gbwt::vector_type may store nodes in a narrower type than gbwt::node_type.
+typedef gbwt::vector_type::value_type node_t;
+node_t fwd(nid_t id) { return gbwt::Node::encode(id, false); }
+node_t rev(nid_t id) { return gbwt::Node::encode(id, true); }
+
+// Node length is the node id, so offsets are easy to predict.
+size_t id_as_length(gbwt::node_type node) { return gbwt::Node::id(node); }
+
+// Paths 1-2-3, 3-4, 5-6 and 8. Every node from 1 to 8 except 7 is in the index,
+// with 7 inside the alphabet range but unused. Nodes 4 and 5 are both present
+// but there is no edge between them.
+std::vector<gbwt::vector_type> index_paths() {
+    return {
+        { fwd(1), fwd(2), fwd(3) },
+        { fwd(3), fwd(4) },
+        { fwd(5), fwd(6) },
+        { fwd(8) },
+    };
+}
+
+void insert_paths(gbwt::GBWTBuilder& builder, const std::vector<gbwt::vector_type>& paths) {
+    for (const gbwt::vector_type& path : paths) {
+        builder.insert(path, true);
+    }
+}
+
+// All (node, successor) pairs in the index, excluding the endmarker.
+std::set<std::pair<gbwt::node_type, gbwt::node_type>> edges_in(const gbwt::DynamicGBWT& index) {
+    std::set<std::pair<gbwt::node_type, gbwt::node_type>> result;
+    for (gbwt::node_type node = index.firstNode(); node < index.sigma(); node++) {
+        if (index.empty(node)) { continue; }
+        for (gbwt::edge_type edge : index.edges(node)) {
+            if (edge.first != gbwt::ENDMARKER) {
+                result.emplace(node, edge.first);
+            }
+        }
+    }
+    return result;
+}
+
+void check_piece(const PathPiece& piece, size_t start, size_t nodes, size_t bp_offset, size_t bp_length) {
+    REQUIRE(piece.start == start);
+    REQUIRE(piece.nodes == nodes);
+    REQUIRE(piece.bp_offset == bp_offset);
+    REQUIRE(piece.bp_length == bp_length);
+}
+
+} // anonymous namespace
+
+//------------------------------------------------------------------------------
+
+TEST_CASE("Paths are clipped to the nodes and edges of a GBWT index", "[gref][recombinator]") {
+    gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+    gbwt::GBWTBuilder builder(gbwt::bit_length(rev(8)), 1024);
+    insert_paths(builder, index_paths());
+    builder.finish();
+    const gbwt::DynamicGBWT& index = builder.index;
+
+    SECTION("a path that is entirely in the index is one piece") {
+        gbwt::vector_type path { fwd(1), fwd(2), fwd(3) };
+        auto pieces = clip_path_to_index(path, index, id_as_length);
+        REQUIRE(pieces.size() == 1);
+        check_piece(pieces[0], 0, 3, 0, 6);
+    }
+
+    SECTION("the reverse orientation is in the index too") {
+        gbwt::vector_type path { rev(3), rev(2), rev(1) };
+        auto pieces = clip_path_to_index(path, index, id_as_length);
+        REQUIRE(pieces.size() == 1);
+        check_piece(pieces[0], 0, 3, 0, 6);
+    }
+
+    SECTION("a missing node splits the path and still counts toward the offset") {
+        gbwt::vector_type path { fwd(1), fwd(2), fwd(7), fwd(3), fwd(4) };
+        auto pieces = clip_path_to_index(path, index, id_as_length);
+        REQUIRE(pieces.size() == 2);
+        check_piece(pieces[0], 0, 2, 0, 3);
+        check_piece(pieces[1], 3, 2, 10, 7);
+    }
+
+    SECTION("present nodes without an edge between them are split") {
+        gbwt::vector_type path { fwd(3), fwd(4), fwd(5), fwd(6) };
+        auto pieces = clip_path_to_index(path, index, id_as_length);
+        REQUIRE(pieces.size() == 2);
+        check_piece(pieces[0], 0, 2, 0, 7);
+        check_piece(pieces[1], 2, 2, 7, 11);
+    }
+
+    SECTION("a node inside the alphabet range but not in the index is missing") {
+        REQUIRE(index.contains(fwd(7)));
+        gbwt::vector_type path { fwd(7) };
+        REQUIRE(clip_path_to_index(path, index, id_as_length).empty());
+    }
+
+    SECTION("a node outside the alphabet range is missing") {
+        gbwt::vector_type path { fwd(2), fwd(100) };
+        auto pieces = clip_path_to_index(path, index, id_as_length);
+        REQUIRE(pieces.size() == 1);
+        check_piece(pieces[0], 0, 1, 0, 2);
+    }
+
+    SECTION("an empty path has no pieces") {
+        gbwt::vector_type path;
+        REQUIRE(clip_path_to_index(path, index, id_as_length).empty());
+    }
+
+    SECTION("nothing survives in an empty index") {
+        gbwt::DynamicGBWT empty;
+        gbwt::vector_type path { fwd(1), fwd(2) };
+        REQUIRE(clip_path_to_index(path, empty, id_as_length).empty());
+    }
+}
+
+TEST_CASE("A GBWT builder can be finished, extended, and finished again", "[gref][recombinator]") {
+    gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+    gbwt::GBWTBuilder builder(gbwt::bit_length(rev(8)), 1024);
+    std::vector<gbwt::vector_type> paths = index_paths();
+    insert_paths(builder, paths);
+    builder.finish();
+    size_t sequences = builder.index.sequences();
+    auto edges = edges_in(builder.index);
+
+    SECTION("a path over existing nodes and edges does not change the topology") {
+        gbwt::vector_type path { fwd(1), fwd(2), fwd(3), fwd(4) };
+        builder.insert(path, true);
+        builder.finish();
+        REQUIRE(builder.index.sequences() == sequences + 2);
+        REQUIRE(builder.index.bidirectional());
+        REQUIRE(edges_in(builder.index) == edges);
+
+        // Everything is still there, and the index can still be compressed.
+        paths.push_back(path);
+        gbwt::GBWT compressed(builder.index);
+        REQUIRE(compressed.sequences() == sequences + 2);
+        for (size_t i = 0; i < paths.size(); i++) {
+            REQUIRE(compressed.extract(gbwt::Path::encode(i, false)) == paths[i]);
+        }
+    }
+
+    SECTION("a path with a new edge is detected by the test itself") {
+        gbwt::vector_type path { fwd(1), fwd(3) };
+        builder.insert(path, true);
+        builder.finish();
+        auto new_edges = edges_in(builder.index);
+        REQUIRE(new_edges.size() == edges.size() + 2);
+        REQUIRE(new_edges.count(std::make_pair(fwd(1), fwd(3))) == 1);
+        REQUIRE(new_edges.count(std::make_pair(rev(3), rev(1))) == 1);
+    }
+}
+
+TEST_CASE("Gref fragments are recognized from sample and contig names", "[gref][recombinator]") {
+    SECTION("PanSN names") {
+        REQUIRE(is_gref_fragment("gref_CHM13", "chr1_7_alt"));
+        REQUIRE_FALSE(is_gref_fragment("gref_CHM13", "chr1")); // A gref copy of the reference path.
+        REQUIRE_FALSE(is_gref_fragment("GRCh38", "chr1_7_alt")); // A contig that happens to look like a fragment.
+        REQUIRE_FALSE(is_gref_fragment("CHM13", "chr1"));
+    }
+
+    SECTION("generic paths carry their full name as the contig") {
+        REQUIRE(is_gref_fragment(gbwtgraph::GENERIC_PATH_SAMPLE_NAME, "gref_x_1_alt"));
+        REQUIRE(is_gref_fragment(PathMetadata::NO_SAMPLE_NAME, "gref_x_1_alt"));
+        REQUIRE_FALSE(is_gref_fragment(gbwtgraph::GENERIC_PATH_SAMPLE_NAME, "gref_x"));
+        REQUIRE_FALSE(is_gref_fragment(gbwtgraph::GENERIC_PATH_SAMPLE_NAME, "x_1_alt"));
+    }
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace unittest
+
+} // namespace vg

--- a/test/t/11_vg_paths.t
+++ b/test/t/11_vg_paths.t
@@ -7,7 +7,7 @@ PATH=../bin:$PATH # for vg
 
 export LC_ALL="C" # force a consistent sort order 
 
-plan tests 129
+plan tests 131
 
 vg construct -r small/x.fa -v small/x.vcf.gz -a > x.vg
 vg construct -r small/x.fa -v small/x.vcf.gz > x2.vg
@@ -300,6 +300,17 @@ is $? 1 "a reference contig named like a gref fragment is refused"
 is $(grep -c "would be copied to gref_CHM13#0#chr1_1_alt" collision.err) 1 "the error names the colliding gref path"
 
 rm -f collision_test.vg collision.err
+
+# The same collision, but on a subranged reference.  The guard has to test the fragment base
+# name: the copy name keeps the subrange (gref_CHM13#0#chr1_1_alt[100-200]), so it does not
+# end in _alt and the collision used to slip through.
+sed 's|^P\tCHM13#0#chr1_1_alt\t|P\tCHM13#0#chr1_1_alt[100-200]\t|' nesting/gref_name_collision.gfa > collision_subrange.gfa
+vg paths -x collision_subrange.gfa -Q CHM13 --compute-gref --min-gref-len 1 > collision_sub.vg 2> collision_sub.err
+is $? 1 "a subranged reference contig named like a gref fragment is refused"
+
+is $(grep -c "would be copied to gref_CHM13#0#chr1_1_alt" collision_sub.err) 1 "the error names the colliding gref base name, not the subranged copy"
+
+rm -f collision_subrange.gfa collision_sub.vg collision_sub.err
 
 # A PanSN reference read from a GFA without an RS header comes in as haplotype sense, so its
 # name carries a phase block (GRCh38#0#chr1#0) that must not survive into the gref name.

--- a/test/t/54_vg_haplotypes.t
+++ b/test/t/54_vg_haplotypes.t
@@ -5,7 +5,7 @@ BASH_TAP_ROOT=../deps/bash-tap
 
 PATH=../bin:$PATH # for vg
 
-plan tests 80
+plan tests 93
 
 # The test graph consists of two subgraphs of the HPRC Minigraph-Cactus v1.1 graph:
 # - GRCh38#chr6:31498145-31511124 (micb)
@@ -165,6 +165,55 @@ is $(vg gbwt -S -Z diploid3.gbz) 2 "1 generated + 1 reference samples"
 is $(vg gbwt -C -Z diploid3.gbz) 2 "2 contigs"
 is $(vg gbwt -H -Z diploid3.gbz) 3 "2 generated + 1 reference haplotypes"
 
+# Sampling with a gref reference. Build a gref version of the test graph in
+# place: --compute-gref needs a mutable graph, so round-trip through packed
+# format. -l 1 keeps every fragment so the length filter has something to act on.
+vg convert -g -p haplotype-sampling/micb-kir3dl1.gfa > plain.pg
+vg paths -x plain.pg --compute-gref -Q GRCh38 -l 1 > gref.pg
+is $? 0 "computing a gref cover on the test graph"
+vg convert -f gref.pg > gref.gfa
+vg gbwt -G gref.gfa --gbz-format -g gref.gbz -r gref.ri
+vg index -j gref.dist gref.gbz
+vg haplotypes --validate --subchain-length 300 -H gref.hapl gref.gbz
+is $? 0 "generating haplotype information for the gref graph"
+
+# Same GBZ, same haplotype information, same kmers: only the reference sample differs.
+vg haplotypes --validate -i gref.hapl -k haplotype-sampling/HG003.kff --include-reference \
+    --set-reference GRCh38 --min-gref-len 1 -g gref_base.gbz gref.gbz
+is $? 0 "sampling the gref graph with the base reference"
+vg haplotypes --validate -i gref.hapl -k haplotype-sampling/HG003.kff --include-reference \
+    --set-reference gref_GRCh38 --min-gref-len 1 -g gref_ref.gbz gref.gbz
+is $? 0 "sampling the gref graph with the gref reference"
+
+# The gref reference must not change the topology: same nodes and same edges.
+for g in gref_base gref_ref; do
+    vg convert --no-translation -f $g.gbz | awk '$1=="S"{print $2"\t"$3}' | sort > $g.nodes
+    vg convert --no-translation -f $g.gbz | awk '$1=="L"{print $2,$3,$4,$5}' | sort > $g.edges
+done
+cmp gref_base.nodes gref_ref.nodes
+is $? 0 "the gref reference gives the same node set as the base reference"
+cmp gref_base.edges gref_ref.edges
+is $? 0 "the gref reference gives the same edge set as the base reference"
+
+# The gref fragments survive, clipped, and only with the gref reference.
+is $(vg paths -L -x gref_base.gbz | grep -c '_alt') 0 "no gref fragments without the gref reference"
+is $([ $(vg paths -L -x gref_ref.gbz | grep -c '_alt') -gt 0 ] && echo 1 || echo 0) 1 "gref fragments survive with the gref reference"
+is $(vg paths -L -x gref_ref.gbz | grep -c '_alt\[') 4 "4 gref fragments are clipped into subranges"
+is $(vg paths -L -x gref_ref.gbz | grep '_alt' | sed 's/\[[0-9]*\]$//' | sort -u \
+     | comm -23 - <(vg paths -L -x gref.gbz | grep '_alt' | sort -u) | wc -l) 0 "every surviving gref fragment names an input fragment"
+
+# The length filter drops fragments without touching the topology.
+vg haplotypes --validate -i gref.hapl -k haplotype-sampling/HG003.kff --include-reference \
+    --set-reference gref_GRCh38 --min-gref-len 1000000 -g gref_long.gbz gref.gbz
+is $(vg paths -L -x gref_long.gbz | grep -c '_alt') 0 "--min-gref-len drops short gref fragments"
+is "$(vg stats -N gref_long.gbz) $(vg stats -E gref_long.gbz)" "$(vg stats -N gref_base.gbz) $(vg stats -E gref_base.gbz)" "dropping gref fragments keeps the topology"
+
+# Adding a gref cover must not rename the chains, and so must not rename the generated
+# haplotypes.  The gref copy of a non-PanSN reference carries the whole name as its locus
+# (gref_x rather than x), so a chain named after it would silently change the output paths
+# and stop --exclude-contig from matching.
+is "$(vg paths -L -x gref_base.gbz | grep '^recombination' | sort)" "$(vg paths -L -x gref_ref.gbz | grep '^recombination' | sort)" "the gref reference does not rename the generated haplotypes"
+
 # Giraffe integration, guessed output name
 rm -f full.HG003.* default.gam
 vg giraffe --progress -Z full.gbz --haplotype-name full.hapl --kff-name haplotype-sampling/HG003.kff \
@@ -254,6 +303,8 @@ rm -f halfcov.gbz halfcov6.gbz halfcov_pansn.gbz bothcov_log.txt
 rm -f exclude.gbz exclude_pansn.gbz exclude_log.txt
 rm -f wrap.gbz wrap_base.gbz wrap_pansn.gbz wrap_log.txt wrap_exclude_log.txt
 rm -f diploid.gbz diploid2.gbz diploid3.gbz
+rm -f plain.pg gref.pg gref.gfa gref.gbz gref.ri gref.dist gref.hapl
+rm -f gref_base.gbz gref_base.nodes gref_base.edges gref_ref.gbz gref_ref.nodes gref_ref.edges gref_long.gbz
 rm -f full.HG003.* default.gam
 rm -f sampled.003HG.* specified.gam
 rm -f GRCh38.HG003.* HG003_GRCh38.gam


### PR DESCRIPTION
When doing haplotype sampling, you usually want to keep the reference (ex for surjecting / genotyping).  But if you are working with Graph Reference (GRef), there's a problem:  keeping the reference, which covers most of the graph, will prevent haplotype sampling from actually simplifying the graph -- as most nodes and edges will be part of the reference. 

My original mindset was to never haplotype sample on GRef.  Rather use, ex, `CHM13`, then downstream link the sampled gam back to a complete graph with GRef paths etc.  But this doesn't work properly with @benedictpaten's [new vg call](https://github.com/vgteam/vg/pull/4990), which wants a sampled GAM  **and** a sampled graph to work with all at once. 

So this PR changes `vg haplotypes`'s sampling behaviour when faced with a graph reference.   It will now only preserve the base contigs of the graph reference, and clip remove the alt contigs as needed.  

So the end result of setting gref_CHM13 or CHM13 as a reference for haplotype sampling will be topologically identical.  But using gref_CHM13 will keep covering gref (sub) intervals for as much of the sampled graph as possible.   

This is all thanks to Claude/Fable and uses existing naming conventions to determine whether paths are GRef or not...

## Changelog Entry
To be copied to the [draft changelog](https://github.com/vgteam/vg/wiki/Draft-Changelog) by merger:

 * Special haplotype sampling logic added for "gref" references.  Base contigs are fixed, but "alt" contigs can be clipped or lost. 

